### PR TITLE
fix: `stream.Close()` short-circuited before queue is flushed

### DIFF
--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.Stream.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.Stream.cs
@@ -59,7 +59,7 @@ public partial class AspNetCorePlugin
 
         public async Task<MessageActivity?> Close()
         {
-            if (_index == 1) return null;
+            if (_index == 1 && _queue.Count == 0) return null;
             if (_result is not null) return _result;
             while (_id is null || _queue.Count > 0)
             {


### PR DESCRIPTION
After all the activity handlers are processed the app will automatically call `context.Stream.Close()` which gracefully closes the stream. However it will only do that if at least one chunk has been sent otherwise it will early return (`_index == 1`). Now it is very much possible that the `_queue` is filled up but has not been flushed (i.e sent to the user) yet. That's because `Emit` does not wait on the `Flush` call - and it shouldn't. 

So you end up in a situation where the queue is filled with chunks ready to be sent, but because nothing is sent yet, the `Close()` call is terminated earlier instead of flushing the queue and then gracefully closing the stream.

Here the fix:

_Check if the queue is empty before returning early!_