### PR TITLE
fix: http client parsing error body as json when it isn't

### DIFF
--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.Stream.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.Stream.cs
@@ -127,12 +127,14 @@ public partial class AspNetCorePlugin
 
                 if (i == 0) return;
 
+                // Send informative updates
                 if (informativeUpdates.Count > 0) {
                     while (informativeUpdates.TryDequeue(out var typing)) {
                         await SendActivity(typing);
                     }
                 }
 
+                // Send text chunk
                 var toSend = new TypingActivity(_text);
                 await SendActivity(toSend);
 


### PR DESCRIPTION
A post request to SMBA's streaming endpoint returned `"\"API  calls quota exceeded\""` (Yes, with the escaped quotes) which the `HttpClient` expects to be a valid json string. And since it isn't,  a `JsonException` is thrown - which propagates up the call stack and results in a 500 response sent back from the app server.

fix:
_if the error content string isn't a valid json, simply return the string in the `HttpException`_.
  
## Debug session

<img width="1340" alt="Screenshot 2025-06-04 at 4 55 59 AM" src="https://github.com/user-attachments/assets/7e52d8d0-bef6-45a4-8539-7315e5d5eb66" />
