### PR TITLE
add JsonConverters for Cards and fix TargetElements

### DIFF
--- a/Libraries/Microsoft.Teams.Cards/ActionJsonConverter.cs
+++ b/Libraries/Microsoft.Teams.Cards/ActionJsonConverter.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Microsoft.Teams.Cards;
+
+public class ActionJsonConverter : JsonConverter<Microsoft.Teams.Cards.Action>
+{
+    public override Microsoft.Teams.Cards.Action? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var jsonDoc = JsonDocument.ParseValue(ref reader);
+        var jsonObject = jsonDoc.RootElement;
+
+        if (!jsonObject.TryGetProperty("type", out var typeProp))
+            throw new JsonException("Missing 'type' discriminator in Action");
+
+        var typeString = typeProp.GetString();
+
+        return typeString switch
+        {
+            "Action.OpenUrl" => JsonSerializer.Deserialize<OpenUrlAction>(jsonObject.GetRawText(), options),
+            "Action.Submit" => JsonSerializer.Deserialize<SubmitAction>(jsonObject.GetRawText(), options),
+            "Action.ShowCard" => JsonSerializer.Deserialize<ShowCardAction>(jsonObject.GetRawText(), options),
+            "Action.ToggleVisibility" => JsonSerializer.Deserialize<ToggleVisibilityAction>(jsonObject.GetRawText(), options),
+            "Action.Execute" => JsonSerializer.Deserialize<ExecuteAction>(jsonObject.GetRawText(), options),
+            _ => throw new JsonException($"Unknown action type: {typeString}")
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, Microsoft.Teams.Cards.Action value, JsonSerializerOptions options)
+    {
+        var actualType = value.GetType();
+        JsonSerializer.Serialize(writer, value, actualType, options);
+    }
+}

--- a/Libraries/Microsoft.Teams.Cards/CardElementJsonConverter .cs
+++ b/Libraries/Microsoft.Teams.Cards/CardElementJsonConverter .cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Microsoft.Teams.Cards;
+
+public class CardElementJsonConverter : JsonConverter<CardElement>
+{
+    public override CardElement? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var jsonDoc = JsonDocument.ParseValue(ref reader);
+        var jsonObject = jsonDoc.RootElement;
+
+        if (!jsonObject.TryGetProperty("type", out var typeProp))
+            throw new JsonException("Missing 'type' discriminator in CardElement");
+
+        var typeString = typeProp.GetString();
+
+        CardElement? cardElement = typeString switch
+        {
+            "AdaptiveCard" => JsonSerializer.Deserialize<AdaptiveCard>(jsonObject.GetRawText(), options),
+            "Container" => JsonSerializer.Deserialize<Container>(jsonObject.GetRawText(), options), 
+            "ActionSet" => JsonSerializer.Deserialize<ActionSet>(jsonObject.GetRawText(), options),
+            "ColumnSet" => JsonSerializer.Deserialize<ColumnSet>(jsonObject.GetRawText(), options),
+            "Media" => JsonSerializer.Deserialize<Media>(jsonObject.GetRawText(), options),
+            "RichTextBlock" => JsonSerializer.Deserialize<RichTextBlock>(jsonObject.GetRawText(), options),
+            "Table" => JsonSerializer.Deserialize<Table>(jsonObject.GetRawText(), options),
+            "TextBlock" => JsonSerializer.Deserialize<TextBlock>(jsonObject.GetRawText(), options),
+            "FactSet" => JsonSerializer.Deserialize<FactSet>(jsonObject.GetRawText(), options),
+            "ImageSet" => JsonSerializer.Deserialize<ImageSet>(jsonObject.GetRawText(), options),
+            "Image" => JsonSerializer.Deserialize<Image>(jsonObject.GetRawText(), options),
+            "Input.Text" => JsonSerializer.Deserialize<TextInput>(jsonObject.GetRawText(), options),
+            "Input.Date" => JsonSerializer.Deserialize<DateInput>(jsonObject.GetRawText(), options),
+            "Input.Time" => JsonSerializer.Deserialize<TimeInput>(jsonObject.GetRawText(), options),
+            "Input.Number" => JsonSerializer.Deserialize<NumberInput>(jsonObject.GetRawText(), options),
+            "Input.Toggle" => JsonSerializer.Deserialize<ToggleInput>(jsonObject.GetRawText(), options),
+            "Input.ChoiceSet" => JsonSerializer.Deserialize<ChoiceSetInput>(jsonObject.GetRawText(), options),
+            "Input.Rating" => JsonSerializer.Deserialize<RatingInput>(jsonObject.GetRawText(), options),
+            "Rating" => JsonSerializer.Deserialize<Rating>(jsonObject.GetRawText(), options),
+            "CompoundButton" => JsonSerializer.Deserialize<CompoundButton>(jsonObject.GetRawText(), options),
+            "Icon" => JsonSerializer.Deserialize<Icon>(jsonObject.GetRawText(), options),
+            "Carousel" => JsonSerializer.Deserialize<Carousel>(jsonObject.GetRawText(), options),
+            "Badge" => JsonSerializer.Deserialize<Badge>(jsonObject.GetRawText(), options),
+            "Chart.Donut" => JsonSerializer.Deserialize<DonutChart>(jsonObject.GetRawText(), options),
+            "Chart.Pie" => JsonSerializer.Deserialize<PieChart>(jsonObject.GetRawText(), options),
+            "Chart.VerticalBar.Grouped" => JsonSerializer.Deserialize<GroupedVerticalBarChart>(jsonObject.GetRawText(), options),
+            "Chart.VerticalBar" => JsonSerializer.Deserialize<VerticalBarChart>(jsonObject.GetRawText(), options),
+            "Chart.HorizontalBar" => JsonSerializer.Deserialize<HorizontalBarChart>(jsonObject.GetRawText(), options),
+            "Chart.HorizontalBar.Stacked" => JsonSerializer.Deserialize<StackedHorizontalBarChart>(jsonObject.GetRawText(), options),
+            "Chart.Line" => JsonSerializer.Deserialize<LineChart>(jsonObject.GetRawText(), options),
+            "Chart.Gauge" => JsonSerializer.Deserialize<GaugeChart>(jsonObject.GetRawText(), options),
+            "CodeBlock" => JsonSerializer.Deserialize<CodeBlock>(jsonObject.GetRawText(), options),
+            "Component.User" => JsonSerializer.Deserialize<ComUserMicrosoftGraphComponent>(jsonObject.GetRawText(), options),
+            "Component.Users" => JsonSerializer.Deserialize<ComUsersMicrosoftGraphComponent>(jsonObject.GetRawText(), options),
+            "Component.Resource" => JsonSerializer.Deserialize<ComResourceMicrosoftGraphComponent>(jsonObject.GetRawText(), options),
+            "Component.File" => JsonSerializer.Deserialize<ComFileMicrosoftGraphComponent>(jsonObject.GetRawText(), options),
+            "Component.Event" => JsonSerializer.Deserialize<ComEventMicrosoftGraphComponent>(jsonObject.GetRawText(), options),
+            "CarouselPage" => JsonSerializer.Deserialize<CarouselPage>(jsonObject.GetRawText(), options),
+            "TableRow" => JsonSerializer.Deserialize<TableRow>(jsonObject.GetRawText(), options),
+            "TableCell" => JsonSerializer.Deserialize<TableCell>(jsonObject.GetRawText(), options),
+            "TextRun" => JsonSerializer.Deserialize<TextRun>(jsonObject.GetRawText(), options),
+            "Column" => JsonSerializer.Deserialize<Column>(jsonObject.GetRawText(), options),
+            _ => throw new JsonException($"Unknown card element type: {typeString}")
+        };
+
+        return cardElement;
+    }
+
+    public override void Write(Utf8JsonWriter writer, CardElement value, JsonSerializerOptions options)
+    {
+        var type = value.GetType();
+        JsonSerializer.Serialize(writer, value, type, options);
+    }
+
+}

--- a/Libraries/Microsoft.Teams.Cards/Core.cs
+++ b/Libraries/Microsoft.Teams.Cards/Core.cs
@@ -771,8 +771,12 @@ public abstract class SerializableObject
     }
 }
 
+[JsonConverter(typeof(CardElementJsonConverter))]
 public abstract class CardElement : SerializableObject { }
+
+[JsonConverter(typeof(ActionJsonConverter))]
 public abstract class Action : SerializableObject { }
+
 public abstract class ContainerLayout : SerializableObject { }
 
 /// <summary>
@@ -844,7 +848,7 @@ public class AdaptiveCard : CardElement
     /// Defines the container's background image.
     /// </summary>
     [JsonPropertyName("backgroundImage")]
-    public IUnion<string, BackgroundImage>? BackgroundImage { get; set; }
+    public Union<string, BackgroundImage>? BackgroundImage { get; set; }
 
     /// <summary>
     /// Controls how the container's content should be vertically aligned.
@@ -916,7 +920,7 @@ public class AdaptiveCard : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     /// <summary>
     /// The body of the card, comprised of a list of elements displayed according to the layouts property. If the layouts property is not specified, a Layout.Stack is used.
@@ -989,7 +993,7 @@ public class AdaptiveCard : CardElement
         return this;
     }
 
-    public AdaptiveCard WithBackgroundImage(IUnion<string, BackgroundImage> value)
+    public AdaptiveCard WithBackgroundImage(Union<string, BackgroundImage> value)
     {
         this.BackgroundImage = value;
         return this;
@@ -1061,7 +1065,7 @@ public class AdaptiveCard : CardElement
         return this;
     }
 
-    public AdaptiveCard WithFallback(IUnion<CardElement, FallbackElement> value)
+    public AdaptiveCard WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -1178,7 +1182,7 @@ public class ExecuteAction : Action
     /// An alternate action to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<Action, FallbackAction>? Fallback { get; set; }
+    public Union<Action, FallbackAction>? Fallback { get; set; }
 
     public ExecuteAction WithId(string value)
     {
@@ -1252,7 +1256,7 @@ public class ExecuteAction : Action
         return this;
     }
 
-    public ExecuteAction WithFallback(IUnion<Action, FallbackAction> value)
+    public ExecuteAction WithFallback(Union<Action, FallbackAction> value)
     {
         this.Fallback = value;
         return this;
@@ -1532,7 +1536,7 @@ public class SubmitAction : Action
     /// An alternate action to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<Action, FallbackAction>? Fallback { get; set; }
+    public Union<Action, FallbackAction>? Fallback { get; set; }
 
     public SubmitAction WithId(string value)
     {
@@ -1606,7 +1610,7 @@ public class SubmitAction : Action
         return this;
     }
 
-    public SubmitAction WithFallback(IUnion<Action, FallbackAction> value)
+    public SubmitAction WithFallback(Union<Action, FallbackAction> value)
     {
         this.Fallback = value;
         return this;
@@ -1720,7 +1724,7 @@ public class OpenUrlAction : Action
     /// An alternate action to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<Action, FallbackAction>? Fallback { get; set; }
+    public Union<Action, FallbackAction>? Fallback { get; set; }
 
     public OpenUrlAction(string url)
     {
@@ -1781,7 +1785,7 @@ public class OpenUrlAction : Action
         return this;
     }
 
-    public OpenUrlAction WithFallback(IUnion<Action, FallbackAction> value)
+    public OpenUrlAction WithFallback(Union<Action, FallbackAction> value)
     {
         this.Fallback = value;
         return this;
@@ -1853,13 +1857,13 @@ public class ToggleVisibilityAction : Action
     /// The Ids of the elements to toggle the visibility of.
     /// </summary>
     [JsonPropertyName("targetElements")]
-    public IUnion<IList<string>, IList<TargetElement>>? TargetElements { get; set; }
+    public Union<IList<string>, IList<TargetElement>>? TargetElements { get; set; }
 
     /// <summary>
     /// An alternate action to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<Action, FallbackAction>? Fallback { get; set; }
+    public Union<Action, FallbackAction>? Fallback { get; set; }
 
     public ToggleVisibilityAction WithId(string value)
     {
@@ -1909,13 +1913,13 @@ public class ToggleVisibilityAction : Action
         return this;
     }
 
-    public ToggleVisibilityAction WithTargetElements(IUnion<IList<string>, IList<TargetElement>> value)
+    public ToggleVisibilityAction WithTargetElements(Union<IList<string>, IList<TargetElement>> value)
     {
         this.TargetElements = value;
         return this;
     }
 
-    public ToggleVisibilityAction WithFallback(IUnion<Action, FallbackAction> value)
+    public ToggleVisibilityAction WithFallback(Union<Action, FallbackAction> value)
     {
         this.Fallback = value;
         return this;
@@ -2017,7 +2021,7 @@ public class ShowCardAction : Action
     /// An alternate action to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<Action, FallbackAction>? Fallback { get; set; }
+    public Union<Action, FallbackAction>? Fallback { get; set; }
 
     /// <summary>
     /// The card that should be displayed when the action is executed.
@@ -2073,7 +2077,7 @@ public class ShowCardAction : Action
         return this;
     }
 
-    public ShowCardAction WithFallback(IUnion<Action, FallbackAction> value)
+    public ShowCardAction WithFallback(Union<Action, FallbackAction> value)
     {
         this.Fallback = value;
         return this;
@@ -2157,7 +2161,7 @@ public class ResetInputsAction : Action
     /// An alternate action to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<Action, FallbackAction>? Fallback { get; set; }
+    public Union<Action, FallbackAction>? Fallback { get; set; }
 
     public ResetInputsAction WithId(string value)
     {
@@ -2213,7 +2217,7 @@ public class ResetInputsAction : Action
         return this;
     }
 
-    public ResetInputsAction WithFallback(IUnion<Action, FallbackAction> value)
+    public ResetInputsAction WithFallback(Union<Action, FallbackAction> value)
     {
         this.Fallback = value;
         return this;
@@ -2385,7 +2389,7 @@ public class AreaGridLayout : ContainerLayout
     /// The columns in the grid layout, defined as a percentage of the available width or in pixels using the `<number>px` format.
     /// </summary>
     [JsonPropertyName("columns")]
-    public IUnion<IList<float>, IList<string>>? Columns { get; set; }
+    public Union<IList<float>, IList<string>>? Columns { get; set; }
 
     /// <summary>
     /// The areas in the grid layout.
@@ -2411,7 +2415,7 @@ public class AreaGridLayout : ContainerLayout
         return this;
     }
 
-    public AreaGridLayout WithColumns(IUnion<IList<float>, IList<string>> value)
+    public AreaGridLayout WithColumns(Union<IList<float>, IList<string>> value)
     {
         this.Columns = value;
         return this;
@@ -2981,7 +2985,7 @@ public class Container : CardElement
     /// Defines the container's background image.
     /// </summary>
     [JsonPropertyName("backgroundImage")]
-    public IUnion<string, BackgroundImage>? BackgroundImage { get; set; }
+    public Union<string, BackgroundImage>? BackgroundImage { get; set; }
 
     /// <summary>
     /// Controls how the container's content should be vertically aligned.
@@ -3011,7 +3015,7 @@ public class Container : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     /// <summary>
     /// The elements in the container.
@@ -3126,7 +3130,7 @@ public class Container : CardElement
         return this;
     }
 
-    public Container WithBackgroundImage(IUnion<string, BackgroundImage> value)
+    public Container WithBackgroundImage(Union<string, BackgroundImage> value)
     {
         this.BackgroundImage = value;
         return this;
@@ -3156,7 +3160,7 @@ public class Container : CardElement
         return this;
     }
 
-    public Container WithFallback(IUnion<CardElement, FallbackElement> value)
+    public Container WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -3250,7 +3254,7 @@ public class ActionSet : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     /// <summary>
     /// The actions in the set.
@@ -3329,7 +3333,7 @@ public class ActionSet : CardElement
         return this;
     }
 
-    public ActionSet WithFallback(IUnion<CardElement, FallbackElement> value)
+    public ActionSet WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -3459,7 +3463,7 @@ public class ColumnSet : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     /// <summary>
     /// The columns in the set.
@@ -3569,7 +3573,7 @@ public class ColumnSet : CardElement
         return this;
     }
 
-    public ColumnSet WithFallback(IUnion<CardElement, FallbackElement> value)
+    public ColumnSet WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -3681,7 +3685,7 @@ public class Media : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public Media WithId(string value)
     {
@@ -3767,7 +3771,7 @@ public class Media : CardElement
         return this;
     }
 
-    public Media WithFallback(IUnion<CardElement, FallbackElement> value)
+    public Media WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -3927,13 +3931,13 @@ public class RichTextBlock : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     /// <summary>
     /// The inlines making up the rich text block.
     /// </summary>
     [JsonPropertyName("inlines")]
-    public IUnion<IList<TextRun>, IList<string>>? Inlines { get; set; }
+    public Union<IList<TextRun>, IList<string>>? Inlines { get; set; }
 
     public RichTextBlock WithId(string value)
     {
@@ -4001,13 +4005,13 @@ public class RichTextBlock : CardElement
         return this;
     }
 
-    public RichTextBlock WithFallback(IUnion<CardElement, FallbackElement> value)
+    public RichTextBlock WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
     }
 
-    public RichTextBlock WithInlines(IUnion<IList<TextRun>, IList<string>> value)
+    public RichTextBlock WithInlines(Union<IList<TextRun>, IList<string>> value)
     {
         this.Inlines = value;
         return this;
@@ -4149,7 +4153,7 @@ public class Table : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     /// <summary>
     /// The rows of the table.
@@ -4277,7 +4281,7 @@ public class Table : CardElement
         return this;
     }
 
-    public Table WithFallback(IUnion<CardElement, FallbackElement> value)
+    public Table WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -4311,7 +4315,7 @@ public class ColumnDefinition : SerializableObject
     /// The width of the column in the table, expressed as either a percentage of the available width or in pixels, using the `<number>px` format.
     /// </summary>
     [JsonPropertyName("width")]
-    public IUnion<string, float>? Width { get; set; }
+    public Union<string, float>? Width { get; set; }
 
     public ColumnDefinition WithHorizontalCellContentAlignment(HorizontalAlignment value)
     {
@@ -4325,7 +4329,7 @@ public class ColumnDefinition : SerializableObject
         return this;
     }
 
-    public ColumnDefinition WithWidth(IUnion<string, float> value)
+    public ColumnDefinition WithWidth(Union<string, float> value)
     {
         this.Width = value;
         return this;
@@ -4467,7 +4471,7 @@ public class TextBlock : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public TextBlock(string text)
     {
@@ -4594,7 +4598,7 @@ public class TextBlock : CardElement
         return this;
     }
 
-    public TextBlock WithFallback(IUnion<CardElement, FallbackElement> value)
+    public TextBlock WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -4682,7 +4686,7 @@ public class FactSet : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public FactSet(params IList<Fact> facts)
     {
@@ -4755,7 +4759,7 @@ public class FactSet : CardElement
         return this;
     }
 
-    public FactSet WithFallback(IUnion<CardElement, FallbackElement> value)
+    public FactSet WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -4891,7 +4895,7 @@ public class ImageSet : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public ImageSet(params IList<Image> images)
     {
@@ -4976,7 +4980,7 @@ public class ImageSet : CardElement
         return this;
     }
 
-    public ImageSet WithFallback(IUnion<CardElement, FallbackElement> value)
+    public ImageSet WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -5118,7 +5122,7 @@ public class Image : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public Image(string url)
     {
@@ -5245,7 +5249,7 @@ public class Image : CardElement
         return this;
     }
 
-    public Image WithFallback(IUnion<CardElement, FallbackElement> value)
+    public Image WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -5413,7 +5417,7 @@ public class TextInput : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public TextInput WithId(string value)
     {
@@ -5541,7 +5545,7 @@ public class TextInput : CardElement
         return this;
     }
 
-    public TextInput WithFallback(IUnion<CardElement, FallbackElement> value)
+    public TextInput WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -5673,7 +5677,7 @@ public class DateInput : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public DateInput WithId(string value)
     {
@@ -5783,7 +5787,7 @@ public class DateInput : CardElement
         return this;
     }
 
-    public DateInput WithFallback(IUnion<CardElement, FallbackElement> value)
+    public DateInput WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -5915,7 +5919,7 @@ public class TimeInput : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public TimeInput WithId(string value)
     {
@@ -6025,7 +6029,7 @@ public class TimeInput : CardElement
         return this;
     }
 
-    public TimeInput WithFallback(IUnion<CardElement, FallbackElement> value)
+    public TimeInput WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -6157,7 +6161,7 @@ public class NumberInput : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public NumberInput WithId(string value)
     {
@@ -6267,7 +6271,7 @@ public class NumberInput : CardElement
         return this;
     }
 
-    public NumberInput WithFallback(IUnion<CardElement, FallbackElement> value)
+    public NumberInput WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -6405,7 +6409,7 @@ public class ToggleInput : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public ToggleInput(string title)
     {
@@ -6526,7 +6530,7 @@ public class ToggleInput : CardElement
         return this;
     }
 
-    public ToggleInput WithFallback(IUnion<CardElement, FallbackElement> value)
+    public ToggleInput WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -6676,7 +6680,7 @@ public class ChoiceSetInput : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public ChoiceSetInput(params IList<Choice> choices)
     {
@@ -6809,7 +6813,7 @@ public class ChoiceSetInput : CardElement
         return this;
     }
 
-    public ChoiceSetInput WithFallback(IUnion<CardElement, FallbackElement> value)
+    public ChoiceSetInput WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -7037,7 +7041,7 @@ public class RatingInput : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public RatingInput WithId(string value)
     {
@@ -7153,7 +7157,7 @@ public class RatingInput : CardElement
         return this;
     }
 
-    public RatingInput WithFallback(IUnion<CardElement, FallbackElement> value)
+    public RatingInput WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -7277,7 +7281,7 @@ public class Rating : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public Rating WithId(string value)
     {
@@ -7381,7 +7385,7 @@ public class Rating : CardElement
         return this;
     }
 
-    public Rating WithFallback(IUnion<CardElement, FallbackElement> value)
+    public Rating WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -7499,7 +7503,7 @@ public class CompoundButton : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public CompoundButton WithId(string value)
     {
@@ -7597,7 +7601,7 @@ public class CompoundButton : CardElement
         return this;
     }
 
-    public CompoundButton WithFallback(IUnion<CardElement, FallbackElement> value)
+    public CompoundButton WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -7763,7 +7767,7 @@ public class Icon : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public Icon(string name)
     {
@@ -7860,7 +7864,7 @@ public class Icon : CardElement
         return this;
     }
 
-    public Icon WithFallback(IUnion<CardElement, FallbackElement> value)
+    public Icon WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -7960,7 +7964,7 @@ public class Carousel : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     /// <summary>
     /// The pages in the carousel.
@@ -8046,7 +8050,7 @@ public class Carousel : CardElement
         return this;
     }
 
-    public Carousel WithFallback(IUnion<CardElement, FallbackElement> value)
+    public Carousel WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -8188,7 +8192,7 @@ public class Badge : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public Badge WithId(string value)
     {
@@ -8304,7 +8308,7 @@ public class Badge : CardElement
         return this;
     }
 
-    public Badge WithFallback(IUnion<CardElement, FallbackElement> value)
+    public Badge WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -8410,7 +8414,7 @@ public class DonutChart : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public DonutChart WithId(string value)
     {
@@ -8496,7 +8500,7 @@ public class DonutChart : CardElement
         return this;
     }
 
-    public DonutChart WithFallback(IUnion<CardElement, FallbackElement> value)
+    public DonutChart WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -8644,7 +8648,7 @@ public class PieChart : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public PieChart WithId(string value)
     {
@@ -8730,7 +8734,7 @@ public class PieChart : CardElement
         return this;
     }
 
-    public PieChart WithFallback(IUnion<CardElement, FallbackElement> value)
+    public PieChart WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -8866,7 +8870,7 @@ public class GroupedVerticalBarChart : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public GroupedVerticalBarChart WithId(string value)
     {
@@ -8982,7 +8986,7 @@ public class GroupedVerticalBarChart : CardElement
         return this;
     }
 
-    public GroupedVerticalBarChart WithFallback(IUnion<CardElement, FallbackElement> value)
+    public GroupedVerticalBarChart WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -9184,7 +9188,7 @@ public class VerticalBarChart : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public VerticalBarChart WithId(string value)
     {
@@ -9294,7 +9298,7 @@ public class VerticalBarChart : CardElement
         return this;
     }
 
-    public VerticalBarChart WithFallback(IUnion<CardElement, FallbackElement> value)
+    public VerticalBarChart WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -9310,7 +9314,7 @@ public class VerticalBarChartDataValue : SerializableObject
     /// The x axis value of the data point.
     /// </summary>
     [JsonPropertyName("x")]
-    public IUnion<string, float>? X { get; set; }
+    public Union<string, float>? X { get; set; }
 
     /// <summary>
     /// The y axis value of the data point.
@@ -9324,7 +9328,7 @@ public class VerticalBarChartDataValue : SerializableObject
     [JsonPropertyName("color")]
     public ChartColor? Color { get; set; }
 
-    public VerticalBarChartDataValue WithX(IUnion<string, float> value)
+    public VerticalBarChartDataValue WithX(Union<string, float> value)
     {
         this.X = value;
         return this;
@@ -9466,7 +9470,7 @@ public class HorizontalBarChart : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public HorizontalBarChart WithId(string value)
     {
@@ -9576,7 +9580,7 @@ public class HorizontalBarChart : CardElement
         return this;
     }
 
-    public HorizontalBarChart WithFallback(IUnion<CardElement, FallbackElement> value)
+    public HorizontalBarChart WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -9742,7 +9746,7 @@ public class StackedHorizontalBarChart : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public StackedHorizontalBarChart WithId(string value)
     {
@@ -9846,7 +9850,7 @@ public class StackedHorizontalBarChart : CardElement
         return this;
     }
 
-    public StackedHorizontalBarChart WithFallback(IUnion<CardElement, FallbackElement> value)
+    public StackedHorizontalBarChart WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -10042,7 +10046,7 @@ public class LineChart : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public LineChart WithId(string value)
     {
@@ -10146,7 +10150,7 @@ public class LineChart : CardElement
         return this;
     }
 
-    public LineChart WithFallback(IUnion<CardElement, FallbackElement> value)
+    public LineChart WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -10208,7 +10212,7 @@ public class LineChartValue : SerializableObject
     /// Otherwise, if x values are represented as a mix of numbers and strings or if at least one x value isn't in the `YYYY-MM-DD` format, the chart will be rendered as a categorical chart, i.e. x axis values will be displayed as categories.
     /// </summary>
     [JsonPropertyName("x")]
-    public IUnion<float, string>? X { get; set; }
+    public Union<float, string>? X { get; set; }
 
     /// <summary>
     /// The y axis value of the data point.
@@ -10216,7 +10220,7 @@ public class LineChartValue : SerializableObject
     [JsonPropertyName("y")]
     public float? Y { get; set; }
 
-    public LineChartValue WithX(IUnion<float, string> value)
+    public LineChartValue WithX(Union<float, string> value)
     {
         this.X = value;
         return this;
@@ -10370,7 +10374,7 @@ public class GaugeChart : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public GaugeChart WithId(string value)
     {
@@ -10498,7 +10502,7 @@ public class GaugeChart : CardElement
         return this;
     }
 
-    public GaugeChart WithFallback(IUnion<CardElement, FallbackElement> value)
+    public GaugeChart WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -10646,7 +10650,7 @@ public class CodeBlock : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public CodeBlock WithId(string value)
     {
@@ -10732,7 +10736,7 @@ public class CodeBlock : CardElement
         return this;
     }
 
-    public CodeBlock WithFallback(IUnion<CardElement, FallbackElement> value)
+    public CodeBlock WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -10748,7 +10752,7 @@ public class ComUserMicrosoftGraphComponent : CardElement
     /// Must be **Component**.
     /// </summary>
     [JsonPropertyName("type")]
-    public string Type { get; } = "Component";
+    public string Type { get; } = "Component.User";
 
     /// <summary>
     /// A unique identifier for the element or action. Input elements must have an id, otherwise they will not be validated and their values will not be sent to the Bot.
@@ -10832,7 +10836,7 @@ public class ComUserMicrosoftGraphComponent : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public ComUserMicrosoftGraphComponent WithId(string value)
     {
@@ -10906,7 +10910,7 @@ public class ComUserMicrosoftGraphComponent : CardElement
         return this;
     }
 
-    public ComUserMicrosoftGraphComponent WithFallback(IUnion<CardElement, FallbackElement> value)
+    public ComUserMicrosoftGraphComponent WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -10952,7 +10956,7 @@ public class ComUsersMicrosoftGraphComponent : CardElement
     /// Must be **Component**.
     /// </summary>
     [JsonPropertyName("type")]
-    public string Type { get; } = "Component";
+    public string Type { get; } = "Component.Users";
 
     /// <summary>
     /// A unique identifier for the element or action. Input elements must have an id, otherwise they will not be validated and their values will not be sent to the Bot.
@@ -11036,7 +11040,7 @@ public class ComUsersMicrosoftGraphComponent : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public ComUsersMicrosoftGraphComponent WithId(string value)
     {
@@ -11110,7 +11114,7 @@ public class ComUsersMicrosoftGraphComponent : CardElement
         return this;
     }
 
-    public ComUsersMicrosoftGraphComponent WithFallback(IUnion<CardElement, FallbackElement> value)
+    public ComUsersMicrosoftGraphComponent WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -11144,7 +11148,7 @@ public class ComResourceMicrosoftGraphComponent : CardElement
     /// Must be **Component**.
     /// </summary>
     [JsonPropertyName("type")]
-    public string Type { get; } = "Component";
+    public string Type { get; } = "Component.Resource";
 
     /// <summary>
     /// A unique identifier for the element or action. Input elements must have an id, otherwise they will not be validated and their values will not be sent to the Bot.
@@ -11228,7 +11232,7 @@ public class ComResourceMicrosoftGraphComponent : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public ComResourceMicrosoftGraphComponent WithId(string value)
     {
@@ -11302,7 +11306,7 @@ public class ComResourceMicrosoftGraphComponent : CardElement
         return this;
     }
 
-    public ComResourceMicrosoftGraphComponent WithFallback(IUnion<CardElement, FallbackElement> value)
+    public ComResourceMicrosoftGraphComponent WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -11378,7 +11382,7 @@ public class ComFileMicrosoftGraphComponent : CardElement
     /// Must be **Component**.
     /// </summary>
     [JsonPropertyName("type")]
-    public string Type { get; } = "Component";
+    public string Type { get; } = "Component.File";
 
     /// <summary>
     /// A unique identifier for the element or action. Input elements must have an id, otherwise they will not be validated and their values will not be sent to the Bot.
@@ -11462,7 +11466,7 @@ public class ComFileMicrosoftGraphComponent : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public ComFileMicrosoftGraphComponent WithId(string value)
     {
@@ -11536,7 +11540,7 @@ public class ComFileMicrosoftGraphComponent : CardElement
         return this;
     }
 
-    public ComFileMicrosoftGraphComponent WithFallback(IUnion<CardElement, FallbackElement> value)
+    public ComFileMicrosoftGraphComponent WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -11594,7 +11598,7 @@ public class ComEventMicrosoftGraphComponent : CardElement
     /// Must be **Component**.
     /// </summary>
     [JsonPropertyName("type")]
-    public string Type { get; } = "Component";
+    public string Type { get; } = "Component.Event";
 
     /// <summary>
     /// A unique identifier for the element or action. Input elements must have an id, otherwise they will not be validated and their values will not be sent to the Bot.
@@ -11678,7 +11682,7 @@ public class ComEventMicrosoftGraphComponent : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public ComEventMicrosoftGraphComponent WithId(string value)
     {
@@ -11752,7 +11756,7 @@ public class ComEventMicrosoftGraphComponent : CardElement
         return this;
     }
 
-    public ComEventMicrosoftGraphComponent WithFallback(IUnion<CardElement, FallbackElement> value)
+    public ComEventMicrosoftGraphComponent WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -12068,7 +12072,7 @@ public class CarouselPage : CardElement
     /// Defines the container's background image.
     /// </summary>
     [JsonPropertyName("backgroundImage")]
-    public IUnion<string, BackgroundImage>? BackgroundImage { get; set; }
+    public Union<string, BackgroundImage>? BackgroundImage { get; set; }
 
     /// <summary>
     /// Controls how the container's content should be vertically aligned.
@@ -12098,7 +12102,7 @@ public class CarouselPage : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     /// <summary>
     /// The elements in the page.
@@ -12189,7 +12193,7 @@ public class CarouselPage : CardElement
         return this;
     }
 
-    public CarouselPage WithBackgroundImage(IUnion<string, BackgroundImage> value)
+    public CarouselPage WithBackgroundImage(Union<string, BackgroundImage> value)
     {
         this.BackgroundImage = value;
         return this;
@@ -12219,7 +12223,7 @@ public class CarouselPage : CardElement
         return this;
     }
 
-    public CarouselPage WithFallback(IUnion<CardElement, FallbackElement> value)
+    public CarouselPage WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -12343,7 +12347,7 @@ public class TableRow : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     /// <summary>
     /// The cells in the row.
@@ -12447,7 +12451,7 @@ public class TableRow : CardElement
         return this;
     }
 
-    public TableRow WithFallback(IUnion<CardElement, FallbackElement> value)
+    public TableRow WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -12559,7 +12563,7 @@ public class TableCell : CardElement
     /// Defines the container's background image.
     /// </summary>
     [JsonPropertyName("backgroundImage")]
-    public IUnion<string, BackgroundImage>? BackgroundImage { get; set; }
+    public Union<string, BackgroundImage>? BackgroundImage { get; set; }
 
     /// <summary>
     /// Controls how the container's content should be vertically aligned.
@@ -12589,7 +12593,7 @@ public class TableCell : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     /// <summary>
     /// The items (elements) in the cell.
@@ -12686,7 +12690,7 @@ public class TableCell : CardElement
         return this;
     }
 
-    public TableCell WithBackgroundImage(IUnion<string, BackgroundImage> value)
+    public TableCell WithBackgroundImage(Union<string, BackgroundImage> value)
     {
         this.BackgroundImage = value;
         return this;
@@ -12716,7 +12720,7 @@ public class TableCell : CardElement
         return this;
     }
 
-    public TableCell WithFallback(IUnion<CardElement, FallbackElement> value)
+    public TableCell WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -12840,7 +12844,7 @@ public class TextRun : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     public TextRun(string text)
     {
@@ -12943,7 +12947,7 @@ public class TextRun : CardElement
         return this;
     }
 
-    public TextRun WithFallback(IUnion<CardElement, FallbackElement> value)
+    public TextRun WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;
@@ -13067,7 +13071,7 @@ public class Column : CardElement
     /// Defines the container's background image.
     /// </summary>
     [JsonPropertyName("backgroundImage")]
-    public IUnion<string, BackgroundImage>? BackgroundImage { get; set; }
+    public Union<string, BackgroundImage>? BackgroundImage { get; set; }
 
     /// <summary>
     /// Controls how the container's content should be vertically aligned.
@@ -13091,7 +13095,7 @@ public class Column : CardElement
     /// The width of the column. If expressed as a number, represents the relative weight of the column in the set. If expressed as a string, `auto` will automatically adjust the column's width according to its content, `stretch` will make the column use the remaining horizontal space (shared with other columns with width set to `stretch`) and using the `<number>px` format will give the column an explicit width in pixels.
     /// </summary>
     [JsonPropertyName("width")]
-    public IUnion<string, float>? Width { get; set; }
+    public Union<string, float>? Width { get; set; }
 
     /// <summary>
     /// The area of a Layout.AreaGrid layout in which an element should be displayed.
@@ -13103,7 +13107,7 @@ public class Column : CardElement
     /// An alternate element to render if the type of this one is unsupported or if the host application doesn't support all the capabilities specified in the requires property.
     /// </summary>
     [JsonPropertyName("fallback")]
-    public IUnion<CardElement, FallbackElement>? Fallback { get; set; }
+    public Union<CardElement, FallbackElement>? Fallback { get; set; }
 
     /// <summary>
     /// The elements in the column.
@@ -13218,7 +13222,7 @@ public class Column : CardElement
         return this;
     }
 
-    public Column WithBackgroundImage(IUnion<string, BackgroundImage> value)
+    public Column WithBackgroundImage(Union<string, BackgroundImage> value)
     {
         this.BackgroundImage = value;
         return this;
@@ -13242,7 +13246,7 @@ public class Column : CardElement
         return this;
     }
 
-    public Column WithWidth(IUnion<string, float> value)
+    public Column WithWidth(Union<string, float> value)
     {
         this.Width = value;
         return this;
@@ -13254,7 +13258,7 @@ public class Column : CardElement
         return this;
     }
 
-    public Column WithFallback(IUnion<CardElement, FallbackElement> value)
+    public Column WithFallback(Union<CardElement, FallbackElement> value)
     {
         this.Fallback = value;
         return this;

--- a/Microsoft.Teams.sln
+++ b/Microsoft.Teams.sln
@@ -59,6 +59,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Teams.Plugins.Asp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.BotBuilder", "Samples\Samples.BotBuilder\Samples.BotBuilder.csproj", "{6A21694E-6F76-463E-AF50-C258A0C94BF4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Teams.Cards.Tests", "Tests\Microsoft.Teams.Cards.Tests\Microsoft.Teams.Cards.Tests.csproj", "{EB37AF27-E3F5-452B-B639-B0806B73138D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -333,6 +335,18 @@ Global
 		{6A21694E-6F76-463E-AF50-C258A0C94BF4}.Release|x64.Build.0 = Release|Any CPU
 		{6A21694E-6F76-463E-AF50-C258A0C94BF4}.Release|x86.ActiveCfg = Release|Any CPU
 		{6A21694E-6F76-463E-AF50-C258A0C94BF4}.Release|x86.Build.0 = Release|Any CPU
+		{EB37AF27-E3F5-452B-B639-B0806B73138D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB37AF27-E3F5-452B-B639-B0806B73138D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB37AF27-E3F5-452B-B639-B0806B73138D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EB37AF27-E3F5-452B-B639-B0806B73138D}.Debug|x64.Build.0 = Debug|Any CPU
+		{EB37AF27-E3F5-452B-B639-B0806B73138D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EB37AF27-E3F5-452B-B639-B0806B73138D}.Debug|x86.Build.0 = Debug|Any CPU
+		{EB37AF27-E3F5-452B-B639-B0806B73138D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB37AF27-E3F5-452B-B639-B0806B73138D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB37AF27-E3F5-452B-B639-B0806B73138D}.Release|x64.ActiveCfg = Release|Any CPU
+		{EB37AF27-E3F5-452B-B639-B0806B73138D}.Release|x64.Build.0 = Release|Any CPU
+		{EB37AF27-E3F5-452B-B639-B0806B73138D}.Release|x86.ActiveCfg = Release|Any CPU
+		{EB37AF27-E3F5-452B-B639-B0806B73138D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -363,5 +377,6 @@ Global
 		{6542E318-AF5B-4D63-B5BA-242AA48085B9} = {809F86A1-1C4C-B159-0CD4-DF9D33D876CE}
 		{E7277625-CD7C-42C0-84C1-EE39D8CCF909} = {F2D7E877-38D6-8C91-7D90-99648DD298BA}
 		{6A21694E-6F76-463E-AF50-C258A0C94BF4} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
+		{EB37AF27-E3F5-452B-B639-B0806B73138D} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/Tests/Microsoft.Teams.Cards.Tests/Actions.cs
+++ b/Tests/Microsoft.Teams.Cards.Tests/Actions.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Teams.Cards.Tests
+{
+    public class Actions
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            IndentSize = 2,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public AdaptiveCard SetupAdaptiveCardWithActions()
+        {
+            var body = new List<CardElement>
+            {
+                new TextInput()
+                    .WithId("fullName")
+                    .WithLabel("Full Name")
+                    .WithPlaceholder("Enter your full name")
+                    .WithIsRequired(true)
+                    .WithErrorMessage("Please enter your name"),
+
+                new TextInput()
+                    .WithId("email")
+                    .WithLabel("Email Address")
+                    .WithPlaceholder("Enter your email")
+                    .WithStyle(InputTextStyle.Email)
+                    .WithIsRequired(true)
+                    .WithErrorMessage("Please enter your email"),
+
+                new NumberInput()
+                    .WithId("age")
+                    .WithLabel("Age")
+                    .WithPlaceholder("Enter your age")
+                    .WithMin(18)
+                    .WithMax(120)
+                    .WithValue(25),
+
+                new ChoiceSetInput()
+                    .WithId("department")
+                    .WithLabel("Department")
+                    .WithStyle(StyleEnum.Expanded)
+                    .WithChoices(new List<Choice>
+                    {
+                        new Choice().WithTitle("Engineering").WithValue("eng"),
+                        new Choice().WithTitle("Marketing").WithValue("marketing"),
+                        new Choice().WithTitle("Sales").WithValue("sales"),
+                        new Choice().WithTitle("Support").WithValue("support"),
+                    }),
+
+                new ToggleInput("Subscribe to newsletter")
+                    .WithId("newsletter")
+                    .WithValueOn("yes")
+                    .WithValueOff("no")
+                    .WithValue("true"),
+
+                new RatingInput()
+                    .WithId("satisfaction")
+                    .WithLabel("Satisfaction Rating"),
+
+                new DateInput()
+                    .WithId("eventDate")
+                    .WithLabel("Event Date")
+                    .WithPlaceholder("Select a date")
+                    .WithIsRequired(true)
+                    .WithErrorMessage("Please select a date"),
+
+                new TimeInput()
+                    .WithId("eventTime")
+                    .WithLabel("Event Time")
+                    .WithPlaceholder("Select a time")
+                    .WithIsRequired(true)
+                    .WithErrorMessage("Please select a time"),
+
+                new ActionSet(
+                new SubmitAction()
+                    .WithId("submit-all")
+                    .WithTitle("Submit Form")
+                    .WithStyle(ActionStyle.Positive)
+                    .WithData(new SubmitActionData
+                    {
+                        NonSchemaProperties = new Dictionary<string, object?> { ["action"] = "submit" }
+                    }),
+
+                new OpenUrlAction("https://example.com")
+                    .WithId("visit-website")
+                    .WithTitle("Visit Website")
+                    .WithIconUrl("globe,regular"),
+
+                new ExecuteAction()
+                    .WithId("validate")
+                    .WithTitle("Validate")
+                    .WithVerb("validate")
+                    .WithData(new SubmitActionData
+                    {
+                        NonSchemaProperties = new Dictionary<string, object?> { ["action"] = "validate" }
+                    }),
+
+                new ToggleVisibilityAction()
+                    .WithId("toggle-advanced")
+                    .WithTitle("Toggle Advanced")
+                    .WithTargetElements(new List<TargetElement>
+                    {
+                        new TargetElement().WithElementId("advanced-section").WithIsVisible(true)
+                    })
+                )
+            };
+
+            var card = new AdaptiveCard().WithVersion(Cards.Version.Version1_5).WithId("actions-card")
+            .WithSchema("https://adaptivecards.io/schemas/adaptive-card.json")
+            .WithBody(body);
+            return card;
+        }
+
+
+        [Fact]
+        public void Actions_JsonSerialize()
+        {
+            var card = SetupAdaptiveCardWithActions();
+            var expectedJson = File.ReadAllText(@"../../../Json/Actions.json");
+
+            var json = JsonSerializer.Serialize<CardElement>(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void Actions_JsonSerialize_Derived_FromClass()
+        {
+            AdaptiveCard card = SetupAdaptiveCardWithActions();
+            var expectedJson = File.ReadAllText(@"../../../Json/Actions.json");
+
+            var json = JsonSerializer.Serialize(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void Actions_JsonSerialize_Derived_FromBaseClass()
+        {
+            CardElement card = SetupAdaptiveCardWithActions();
+            var expectedJson = File.ReadAllText(@"../../../Json/Actions.json");
+
+            var json = JsonSerializer.Serialize(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void Actions_JsonDeserialize()
+        {
+            var json = File.ReadAllText(@"../../../Json/Actions.json");
+            var card = JsonSerializer.Deserialize<AdaptiveCard>(json, JsonOptions);
+            var expected = SetupAdaptiveCardWithActions();
+
+            Assert.NotNull(card);
+            Assert.Equal(expected.ToString(), card!.ToString());
+            Assert.NotNull(card.Body);
+
+            Assert.Contains(card.Body, e => e is TextInput);
+            Assert.Contains(card.Body, e => e is NumberInput );
+            Assert.Contains(card.Body, e => e is ChoiceSetInput);
+            Assert.Contains(card.Body, e => e is ToggleInput);
+            Assert.Contains(card.Body, e => e is RatingInput);
+            Assert.Contains(card.Body, e => e is DateInput);
+            Assert.Contains(card.Body, e => e is TimeInput);
+
+            var actionSet = card.Body.OfType<ActionSet>().FirstOrDefault();
+            Assert.NotNull(actionSet);
+            Assert.NotNull(actionSet.Actions);
+            Assert.Contains(actionSet.Actions, a => a is SubmitAction);
+            Assert.Contains(actionSet.Actions, a => a is OpenUrlAction);
+            Assert.Contains(actionSet.Actions, a => a is ExecuteAction);
+            Assert.Contains(actionSet.Actions, a => a is ToggleVisibilityAction);
+        }
+
+        [Fact]
+        public void Actions_RoundTripSerialization()
+        {
+            var originalJson = File.ReadAllText(@"../../../Json/Actions.json");
+
+            var card = JsonSerializer.Deserialize<AdaptiveCard>(originalJson, JsonOptions);
+
+            var serializedJson = JsonSerializer.Serialize<CardElement>(card!, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(originalJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(serializedJson, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+    }
+}

--- a/Tests/Microsoft.Teams.Cards.Tests/Advanced.cs
+++ b/Tests/Microsoft.Teams.Cards.Tests/Advanced.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+using Microsoft.Teams.Common;
+
+namespace Microsoft.Teams.Cards.Tests
+{
+    public class AdaptiveCardAdvancedTests
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            IndentSize = 2,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public AdaptiveCard SetupAdaptiveCardWithAdvanced()
+        {
+            var body = new List<CardElement>
+            {
+                new RichTextBlock()
+                    .WithInlines(new Union<IList<TextRun>, IList<string>>(new List<TextRun>
+                    {
+                        new TextRun("This text includes ")
+                            .WithWeight(TextWeight.Default),
+                        new TextRun("bold")
+                            .WithWeight(TextWeight.Bolder),
+                        new TextRun(", ")
+                            .WithWeight(TextWeight.Default),
+                        new TextRun("italic")
+                            .WithItalic(true),
+                        new TextRun(", and ")
+                            .WithWeight(TextWeight.Default),
+                        new TextRun("colored")
+                            .WithColor(TextColor.Good),
+                        new TextRun(" text.")
+                            .WithWeight(TextWeight.Default)
+                    })),
+
+                new Badge()
+                    .WithIcon("star")
+                    .WithStyle(BadgeStyle.Good)
+                    .WithTooltip("Top Performer"),
+
+                new CompoundButton()
+                    .WithTitle("Learn More")
+                    .WithDescription("Click to read more about adaptive cards")
+                    .WithIcon(new IconInfo()
+                        .WithName("info")),
+
+                new Carousel()
+                    .WithPages(new List<CarouselPage>
+                    {
+                        new CarouselPage()
+                            .WithItems(new List<CardElement>
+                            {
+                                new TextBlock("Welcome to page 1")
+                                    .WithSize(TextSize.Large)
+                                    .WithWeight(TextWeight.Bolder)
+                            }),
+                        new CarouselPage()
+                            .WithItems(new List<CardElement>
+                            {
+                                new TextBlock("This is page 2")
+                                    .WithSize(TextSize.Large)
+                                    .WithWeight(TextWeight.Bolder)
+                            })
+                    }),
+
+                new Rating()
+                    .WithValue(4.5f)
+            };
+
+            var card = new AdaptiveCard().WithVersion(Version.Version1_5).WithId("advancedCard")
+                .WithSchema("https://adaptivecards.io/schemas/adaptive-card.json")
+                .WithBody(body);
+            return card;
+        }
+
+        [Fact]
+        public void Advanced_JsonSerialize()
+        {
+            var card = SetupAdaptiveCardWithAdvanced();
+            var expectedJson = File.ReadAllText(@"../../../Json/Advanced.json");
+
+            var json = JsonSerializer.Serialize<CardElement>(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void Advanced_JsonSerialize_Derived_FromClass()
+        {
+            AdaptiveCard card = SetupAdaptiveCardWithAdvanced();
+            var expectedJson = File.ReadAllText(@"../../../Json/Advanced.json");
+
+            var json = JsonSerializer.Serialize(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void Advanced_JsonSerialize_Derived_FromBaseClass()
+        {
+            CardElement card = SetupAdaptiveCardWithAdvanced();
+            var expectedJson = File.ReadAllText(@"../../../Json/Advanced.json");
+
+            var json = JsonSerializer.Serialize(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void Advanced_JsonDeserialize()
+        {
+            var json = File.ReadAllText(@"../../../Json/Advanced.json");
+            var card = JsonSerializer.Deserialize<AdaptiveCard>(json, JsonOptions);
+            var expected = SetupAdaptiveCardWithAdvanced();
+
+            Assert.NotNull(card);
+            Assert.Equal(expected.ToString(), card!.ToString());
+            Assert.NotNull(card.Body);
+
+            Assert.Contains(card.Body, e => e is RichTextBlock);
+            Assert.Contains(card.Body, e => e is Badge);
+            Assert.Contains(card.Body, e => e is CompoundButton);
+            Assert.Contains(card.Body, e => e is Carousel);
+            Assert.Contains(card.Body, e => e is Rating);
+
+            var richTextBlock = card.Body.OfType<RichTextBlock>().FirstOrDefault();
+            Assert.NotNull(richTextBlock);
+            Assert.NotNull(richTextBlock.Inlines);
+
+            var carousel = card.Body.OfType<Carousel>().FirstOrDefault();
+            Assert.NotNull(carousel);
+            Assert.NotNull(carousel.Pages);
+
+            var rating = card.Body.OfType<Rating>().FirstOrDefault();
+            Assert.NotNull(rating);
+        }
+
+        [Fact]
+        public void Advanced_RoundTripSerialization()
+        {
+            var originalJson = File.ReadAllText(@"../../../Json/Advanced.json");
+
+            var card = JsonSerializer.Deserialize<AdaptiveCard>(originalJson, JsonOptions);
+
+            var serializedJson = JsonSerializer.Serialize<CardElement>(card!, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(originalJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(serializedJson, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized); 
+        }
+    }
+}

--- a/Tests/Microsoft.Teams.Cards.Tests/Charts.cs
+++ b/Tests/Microsoft.Teams.Cards.Tests/Charts.cs
@@ -1,0 +1,226 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+using Microsoft.Teams.Common;
+
+namespace Microsoft.Teams.Cards.Tests
+{
+    public class Charts
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true, 
+            IndentSize = 2,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public AdaptiveCard SetupAdaptiveCardWithCharts()
+        {
+            var container = new Container()
+                .WithItems(new List<CardElement>
+                {
+                    new TextBlock("Charts Section")
+                        .WithWeight(TextWeight.Bolder)
+                        .WithColor(TextColor.Attention)
+                        .WithSize(TextSize.Medium),
+
+                    new DonutChart()
+                        .WithTitle("Sales Distribution")
+                        .WithData(new List<DonutChartData>
+                        {
+                            new DonutChartData().WithLegend("Q1").WithValue(25).WithColor(ChartColor.CategoricalBlue),
+                            new DonutChartData().WithLegend("Q2").WithValue(30).WithColor(ChartColor.CategoricalGreen),
+                            new DonutChartData().WithLegend("Q3").WithValue(25).WithColor(ChartColor.CategoricalPurple),
+                            new DonutChartData().WithLegend("Q4").WithValue(20).WithColor(ChartColor.CategoricalTeal),
+                        }),
+
+                    new GaugeChart()
+                        .WithTitle("Performance Score")
+                        .WithValue(85)
+                        .WithMin(0)
+                        .WithMax(100)
+                        .WithValueFormat(GaugeChartValueFormat.Percentage)
+                        .WithSegments(new List<GaugeChartLegend>
+                        {
+                            new GaugeChartLegend().WithSize(60).WithLegend("Poor").WithColor(ChartColor.Attention),
+                            new GaugeChartLegend().WithSize(30).WithLegend("Good").WithColor(ChartColor.Warning),
+                            new GaugeChartLegend().WithSize(10).WithLegend("Excellent").WithColor(ChartColor.Good),
+                        }),
+
+                    new PieChart()
+                        .WithTitle("Market Share")
+                        .WithData(new List<DonutChartData>
+                        {
+                            new DonutChartData().WithLegend("Product A").WithValue(40).WithColor(ChartColor.Good),
+                            new DonutChartData().WithLegend("Product B").WithValue(30).WithColor(ChartColor.Attention),
+                            new DonutChartData().WithLegend("Product C").WithValue(30).WithColor(ChartColor.Warning),
+                        }),
+
+                    new GroupedVerticalBarChart()
+                        .WithTitle("Departmental Revenue")
+                        .WithData(new List<GroupedVerticalBarChartData>
+                        {
+                            new GroupedVerticalBarChartData()
+                                .WithLegend("Engineering")
+                                .WithValues(new List<BarChartDataValue>
+                                {
+                                    new BarChartDataValue().WithX("Q1").WithY(120),
+                                    new BarChartDataValue().WithX("Q2").WithY(135),
+                                }),
+                            new GroupedVerticalBarChartData()
+                                .WithLegend("Marketing")
+                                .WithValues(new List<BarChartDataValue>
+                                {
+                                    new BarChartDataValue().WithX("Q1").WithY(110),
+                                    new BarChartDataValue().WithX("Q2").WithY(140),
+                                })
+                        }),
+
+                    new StackedHorizontalBarChart()
+                        .WithTitle("Customer Segments")
+                        .WithData(new List<StackedHorizontalBarChartData>
+                        {
+                            new StackedHorizontalBarChartData()
+                                .WithTitle("SMBs")
+                                .WithData(new List<StackedHorizontalBarChartDataPoint>
+                                {
+                                    new StackedHorizontalBarChartDataPoint().WithLegend("SMBs").WithValue(60).WithColor(ChartColor.Good),
+                                }),
+                            new StackedHorizontalBarChartData()
+                                .WithTitle("Enterprises")
+                                .WithData(new List<StackedHorizontalBarChartDataPoint>
+                                {
+                                    new StackedHorizontalBarChartDataPoint().WithLegend("Enterprises").WithValue(40).WithColor(ChartColor.Warning),
+                                })
+                        }),
+
+                    new LineChart()
+                        .WithTitle("Monthly Sales Trend")
+                        .WithData(new List<LineChartData>
+                        {
+                            new LineChartData()
+                                .WithLegend("2023")
+                                .WithValues(new List<LineChartValue>
+                                {
+                                    new LineChartValue().WithX(new Union<float, string>("Jan")).WithY(100),
+                                    new LineChartValue().WithX(new Union<float, string>("Feb")).WithY(120),
+                                    new LineChartValue().WithX(new Union<float, string>("Mar")).WithY(110),
+                                    new LineChartValue().WithX(new Union<float, string>("Apr")).WithY(130)
+                                }),
+                            new LineChartData()
+                                .WithLegend("2024")
+                                .WithValues(new List<LineChartValue>
+                                {
+                                    new LineChartValue().WithX(new Union<float, string>("Jan")).WithY(110),
+                                    new LineChartValue().WithX(new Union<float, string>("Feb")).WithY(125),
+                                    new LineChartValue().WithX(new Union<float, string>("Mar")).WithY(115),
+                                    new LineChartValue().WithX(new Union<float, string>("Apr")).WithY(140)
+                                })
+                        }),
+
+                    new VerticalBarChart()
+                        .WithTitle("Product Sales")
+                        .WithData(new List<VerticalBarChartDataValue>
+                        {
+                            new VerticalBarChartDataValue().WithX(new Union<string, float>("Product A")).WithY(85).WithColor(ChartColor.CategoricalBlue),
+                            new VerticalBarChartDataValue().WithX(new Union<string, float>("Product B")).WithY(92).WithColor(ChartColor.CategoricalGreen),
+                            new VerticalBarChartDataValue().WithX(new Union<string, float>("Product C")).WithY(78).WithColor(ChartColor.CategoricalPurple)
+                        }),
+                    
+                    new HorizontalBarChart()
+                        .WithTitle("Customer Satisfaction")
+                        .WithData(new List<HorizontalBarChartDataValue>
+                        {
+                            new HorizontalBarChartDataValue().WithX("Service").WithY(88),
+                            new HorizontalBarChartDataValue().WithX("Quality").WithY(95),
+                            new HorizontalBarChartDataValue().WithX("Value").WithY(82)
+                        })
+                });
+
+            var body = new List<CardElement> { container };
+        
+            var card = new AdaptiveCard().WithVersion(Version.Version1_5).WithId("chartsCard")
+                .WithSchema("https://adaptivecards.io/schemas/adaptive-card.json")
+                .WithBody(body);
+            return card;
+        }
+
+        [Fact]
+        public void Charts_JsonSerialize()
+        {
+            var card = SetupAdaptiveCardWithCharts();
+            var expectedJson = File.ReadAllText(@"../../../Json/Charts.json");
+
+            var json = JsonSerializer.Serialize<CardElement>(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void Charts_JsonSerialize_Derived_FromClass()
+        {
+            AdaptiveCard card = SetupAdaptiveCardWithCharts();
+            var expectedJson = File.ReadAllText(@"../../../Json/Charts.json");
+
+            var json = JsonSerializer.Serialize(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void Charts_JsonSerialize_Derived_FromBaseClass()
+        {
+            CardElement card = SetupAdaptiveCardWithCharts();
+            var expectedJson = File.ReadAllText(@"../../../Json/Charts.json");
+
+            var json = JsonSerializer.Serialize(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void Charts_JsonDeserialize()
+        {
+            var json = File.ReadAllText(@"../../../Json/Charts.json");
+            var card = JsonSerializer.Deserialize<AdaptiveCard>(json, JsonOptions);
+            var expected = SetupAdaptiveCardWithCharts();
+
+            Assert.NotNull(card);
+            Assert.Equal(expected.ToString(), card!.ToString());
+            Assert.NotNull(card.Body);
+
+            var container = card.Body.OfType<Container>().FirstOrDefault();
+            Assert.NotNull(container);
+            Assert.NotNull(container.Items);
+
+            Assert.Contains(container.Items, e => e is DonutChart);
+            Assert.Contains(container.Items, e => e is GaugeChart);
+            Assert.Contains(container.Items, e => e is PieChart);
+            Assert.Contains(container.Items, e => e is GroupedVerticalBarChart);
+            Assert.Contains(container.Items, e => e is StackedHorizontalBarChart);
+            Assert.Contains(container.Items, e => e is LineChart);
+            Assert.Contains(container.Items, e => e is VerticalBarChart);
+            Assert.Contains(container.Items, e => e is HorizontalBarChart);
+        }
+
+        [Fact]
+        public void Charts_RoundTripSerialization()
+        {
+            var originalJson = File.ReadAllText(@"../../../Json/Charts.json");
+
+            var card = JsonSerializer.Deserialize<AdaptiveCard>(originalJson, JsonOptions);
+
+            var serializedJson = JsonSerializer.Serialize<CardElement>(card!, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(originalJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(serializedJson, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+    }
+}

--- a/Tests/Microsoft.Teams.Cards.Tests/Data.cs
+++ b/Tests/Microsoft.Teams.Cards.Tests/Data.cs
@@ -1,0 +1,208 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+using Microsoft.Teams.Common;
+
+namespace Microsoft.Teams.Cards.Tests
+{
+    public class AdaptiveCardDataTests
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            IndentSize = 2,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public AdaptiveCard SetupAdaptiveCardWithData()
+        {
+            var body = new List<CardElement>
+            {
+                new FactSet()
+                    .WithFacts(new List<Fact>
+                    {
+                        new Fact("Name", "John Doe"),
+                        new Fact("Department", "Engineering"),
+                        new Fact("Start Date", "2023-01-15"),
+                        new Fact("Location", "Seattle, WA"),
+                        new Fact("Employee ID", "EMP001")
+                    }),
+
+                new Table()
+                    .WithColumns(new List<ColumnDefinition>
+                    {
+                        new ColumnDefinition().WithWidth(new Union<string, float>(1.0f)),
+                        new ColumnDefinition().WithWidth(new Union<string, float>(1.0f)),
+                        new ColumnDefinition().WithWidth(new Union<string, float>(1.0f))
+                    })
+                    .WithRows(new List<TableRow>
+                    {
+                        new TableRow()
+                            .WithCells(new List<TableCell>
+                            {
+                                new TableCell().WithItems(new List<CardElement>
+                                {
+                                    new TextBlock("Product").WithWeight(TextWeight.Bolder)
+                                }),
+                                new TableCell().WithItems(new List<CardElement>
+                                {
+                                    new TextBlock("Description").WithWeight(TextWeight.Bolder)
+                                }),
+                                new TableCell().WithItems(new List<CardElement>
+                                {
+                                    new TextBlock("Price").WithWeight(TextWeight.Bolder)
+                                })
+                            }),
+                        new TableRow()
+                            .WithCells(new List<TableCell>
+                            {
+                                new TableCell().WithItems(new List<CardElement>
+                                {
+                                    new TextBlock("Widget A")
+                                }),
+                                new TableCell().WithItems(new List<CardElement>
+                                {
+                                    new TextBlock("High-quality widget for everyday use")
+                                }),
+                                new TableCell().WithItems(new List<CardElement>
+                                {
+                                    new TextBlock("$29.99")
+                                })
+                            }),
+                        new TableRow()
+                            .WithCells(new List<TableCell>
+                            {
+                                new TableCell().WithItems(new List<CardElement>
+                                {
+                                    new TextBlock("Widget B")
+                                }),
+                                new TableCell().WithItems(new List<CardElement>
+                                {
+                                    new TextBlock("Premium widget with advanced features")
+                                }),
+                                new TableCell().WithItems(new List<CardElement>
+                                {
+                                    new TextBlock("$49.99")
+                                })
+                            })
+                    }),
+
+                new ColumnSet()
+                    .WithColumns(new List<Column>
+                    {
+                        new Column()
+                            .WithWidth(new Union<string, float>("auto"))
+                            .WithItems(new List<CardElement>
+                            {
+                                new TextBlock("Left Column")
+                                    .WithWeight(TextWeight.Bolder)
+                                    .WithHorizontalAlignment(HorizontalAlignment.Center),
+                                new TextBlock("Content in the left column with some sample text.")
+                                    .WithWrap(true)
+                            }),
+                        new Column()
+                            .WithWidth(new Union<string, float>("stretch"))
+                            .WithItems(new List<CardElement>
+                            {
+                                new TextBlock("Right Column")
+                                    .WithWeight(TextWeight.Bolder)
+                                    .WithHorizontalAlignment(HorizontalAlignment.Center),
+                                new TextBlock("Content in the right column with different information.")
+                                    .WithWrap(true)
+                            })
+                    }),
+
+                new CodeBlock()
+                    .WithCodeSnippet("function echo(a) {\n    return a;\n}")
+                    .WithLanguage(CodeLanguage.JavaScript)
+            };
+
+            var card = new AdaptiveCard().WithVersion(Version.Version1_5).WithId("dataCard")
+                .WithSchema("https://adaptivecards.io/schemas/adaptive-card.json")
+                .WithBody(body);
+            return card;
+        }
+
+        [Fact]
+        public void Data_JsonSerialize()
+        {
+            var card = SetupAdaptiveCardWithData();
+            var expectedJson = File.ReadAllText(@"../../../Json/Data.json");
+
+            var json = JsonSerializer.Serialize<CardElement>(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void Data_JsonSerialize_Derived_FromClass()
+        {
+            AdaptiveCard card = SetupAdaptiveCardWithData();
+            var expectedJson = File.ReadAllText(@"../../../Json/Data.json");
+
+            var json = JsonSerializer.Serialize(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void Data_JsonSerialize_Derived_FromBaseClass()
+        {
+            CardElement card = SetupAdaptiveCardWithData();
+            var expectedJson = File.ReadAllText(@"../../../Json/Data.json");
+
+            var json = JsonSerializer.Serialize(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void Data_JsonDeserialize()
+        {
+            var json = File.ReadAllText(@"../../../Json/Data.json");
+            var card = JsonSerializer.Deserialize<AdaptiveCard>(json, JsonOptions);
+            var expected = SetupAdaptiveCardWithData();
+
+            Assert.NotNull(card);
+            Assert.Equal(expected.ToString(), card!.ToString());
+            Assert.NotNull(card.Body);
+
+            Assert.Contains(card.Body, e => e is FactSet);
+            Assert.Contains(card.Body, e => e is Table);
+            Assert.Contains(card.Body, e => e is ColumnSet);
+            Assert.Contains(card.Body, e => e is CodeBlock);
+
+            var factSet = card.Body.OfType<FactSet>().FirstOrDefault();
+            Assert.NotNull(factSet);
+            Assert.NotNull(factSet.Facts);
+
+            var table = card.Body.OfType<Table>().FirstOrDefault();
+            Assert.NotNull(table);
+            Assert.NotNull(table.Rows);
+
+            var columnSet = card.Body.OfType<ColumnSet>().FirstOrDefault();
+            Assert.NotNull(columnSet);
+            Assert.NotNull(columnSet.Columns);
+        }
+
+        [Fact]
+        public void Data_RoundTripSerialization()
+        {
+            var originalJson = File.ReadAllText(@"../../../Json/Data.json");
+
+            var card = JsonSerializer.Deserialize<AdaptiveCard>(originalJson, JsonOptions);
+
+            var serializedJson = JsonSerializer.Serialize<CardElement>(card!, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(originalJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(serializedJson, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+    }
+}

--- a/Tests/Microsoft.Teams.Cards.Tests/GraphComponents.cs
+++ b/Tests/Microsoft.Teams.Cards.Tests/GraphComponents.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Teams.Cards.Tests
+{
+    public class AdaptiveCardComponentsTests
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            IndentSize = 2,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public AdaptiveCard SetupAdaptiveCardWithGraphComponents()
+        {
+            var body = new List<CardElement>
+            {
+                new TextBlock("Microsoft Graph Components")
+                    .WithWeight(TextWeight.Bolder)
+                    .WithSize(TextSize.Large)
+                    .WithColor(TextColor.Accent),
+
+                new ComUserMicrosoftGraphComponent()
+                    .WithId("userComponent")
+                    .WithProperties(new PersonaProperties()
+                        .WithUserPrincipalName("user@contoso.com")),
+
+                new ComUsersMicrosoftGraphComponent()
+                    .WithId("usersComponent")
+                    .WithProperties(new PersonaSetProperties()
+                        .WithUsers(new List<PersonaProperties>
+                        {
+                            new PersonaProperties().WithUserPrincipalName("user1@contoso.com"),
+                            new PersonaProperties().WithUserPrincipalName("user2@contoso.com")
+                        })),
+
+                new ComResourceMicrosoftGraphComponent()
+                    .WithId("resourceComponent")
+                    .WithProperties(new ResourceProperties()
+                        .WithId("resource-id-123")
+                        .WithResourceReference(new Dictionary<string, string> { ["type"] = "channel" })),
+
+                new ComFileMicrosoftGraphComponent()
+                    .WithId("fileComponent")
+                    .WithProperties(new FileProperties()
+                        .WithName("file-id-456")),
+
+                new ComEventMicrosoftGraphComponent()
+                    .WithId("eventComponent")
+                    .WithProperties(new CalendarEventProperties()
+                        .WithId("event-id-789"))
+            };
+
+            var card = new AdaptiveCard().WithVersion(Version.Version1_5).WithId("graphComponentsCard")
+                .WithSchema("https://adaptivecards.io/schemas/adaptive-card.json")
+                .WithBody(body);
+            return card;
+        }
+
+        [Fact]
+        public void GraphComponents_JsonSerialize()
+        {
+            var card = SetupAdaptiveCardWithGraphComponents();
+            var expectedJson = File.ReadAllText(@"../../../Json/GraphComponents.json");
+
+            var json = JsonSerializer.Serialize<CardElement>(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void GraphComponents_JsonSerialize_Derived_FromClass()
+        {
+            AdaptiveCard card = SetupAdaptiveCardWithGraphComponents();
+            var expectedJson = File.ReadAllText(@"../../../Json/GraphComponents.json");
+
+            var json = JsonSerializer.Serialize(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void GraphComponents_JsonSerialize_Derived_FromBaseClass()
+        {
+            CardElement card = SetupAdaptiveCardWithGraphComponents();
+            var expectedJson = File.ReadAllText(@"../../../Json/GraphComponents.json");
+
+            var json = JsonSerializer.Serialize(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void AdaptiveCardWithComponents_JsonDeserialize()
+        {
+            var json = File.ReadAllText(@"../../../Json/GraphComponents.json");
+            var card = JsonSerializer.Deserialize<AdaptiveCard>(json, JsonOptions);
+            var expected = SetupAdaptiveCardWithGraphComponents();
+
+            Assert.NotNull(card);
+            Assert.Equal(expected.ToString(), card!.ToString());
+            Assert.NotNull(card.Body);
+
+            Assert.Contains(card.Body, e => e is TextBlock);
+            Assert.Contains(card.Body, e => e is ComUserMicrosoftGraphComponent);
+            Assert.Contains(card.Body, e => e is ComUsersMicrosoftGraphComponent);
+            Assert.Contains(card.Body, e => e is ComResourceMicrosoftGraphComponent);
+            Assert.Contains(card.Body, e => e is ComFileMicrosoftGraphComponent);
+            Assert.Contains(card.Body, e => e is ComEventMicrosoftGraphComponent);
+        }
+
+        [Fact]
+        public void Components_RoundTripSerialization()
+        {
+            var originalJson = File.ReadAllText(@"../../../Json/GraphComponents.json");
+
+            var card = JsonSerializer.Deserialize<AdaptiveCard>(originalJson, JsonOptions);
+
+            var serializedJson = JsonSerializer.Serialize<CardElement>(card!, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(originalJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(serializedJson, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+    }
+}

--- a/Tests/Microsoft.Teams.Cards.Tests/Json/Actions.json
+++ b/Tests/Microsoft.Teams.Cards.Tests/Json/Actions.json
@@ -1,0 +1,128 @@
+{
+  "type": "AdaptiveCard",
+  "id": "actions-card",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Input.Text",
+      "id": "fullName",
+      "label": "Full Name",
+      "isRequired": true,
+      "errorMessage": "Please enter your name",
+      "placeholder": "Enter your full name"
+    },
+    {
+      "type": "Input.Text",
+      "id": "email",
+      "label": "Email Address",
+      "isRequired": true,
+      "errorMessage": "Please enter your email",
+      "placeholder": "Enter your email",
+      "style": "Email"
+    },
+    {
+      "type": "Input.Number",
+      "id": "age",
+      "label": "Age",
+      "value": 25,
+      "placeholder": "Enter your age",
+      "min": 18,
+      "max": 120
+    },
+    {
+      "type": "Input.ChoiceSet",
+      "id": "department",
+      "label": "Department",
+      "choices": [
+        {
+          "title": "Engineering",
+          "value": "eng"
+        },
+        {
+          "title": "Marketing",
+          "value": "marketing"
+        },
+        {
+          "title": "Sales",
+          "value": "sales"
+        },
+        {
+          "title": "Support",
+          "value": "support"
+        }
+      ],
+      "style": "expanded"
+    },
+    {
+      "type": "Input.Toggle",
+      "id": "newsletter",
+      "value": "true",
+      "title": "Subscribe to newsletter",
+      "valueOn": "yes",
+      "valueOff": "no"
+    },
+    {
+      "type": "Input.Rating",
+      "id": "satisfaction",
+      "label": "Satisfaction Rating"
+    },
+    {
+      "type": "Input.Date",
+      "id": "eventDate",
+      "label": "Event Date",
+      "isRequired": true,
+      "errorMessage": "Please select a date",
+      "placeholder": "Select a date"
+    },
+    {
+      "type": "Input.Time",
+      "id": "eventTime",
+      "label": "Event Time",
+      "isRequired": true,
+      "errorMessage": "Please select a time",
+      "placeholder": "Select a time"
+    },
+    {
+      "type": "ActionSet",
+      "actions": [
+        {
+          "type": "Action.Submit",
+          "id": "submit-all",
+          "title": "Submit Form",
+          "style": "positive",
+          "data": {
+            "action": "submit"
+          }
+        },
+        {
+          "type": "Action.OpenUrl",
+          "id": "visit-website",
+          "title": "Visit Website",
+          "iconUrl": "globe,regular",
+          "url": "https://example.com"
+        },
+        {
+          "type": "Action.Execute",
+          "id": "validate",
+          "title": "Validate",
+          "data": {
+            "action": "validate"
+          },
+          "verb": "validate"
+        },
+        {
+          "type": "Action.ToggleVisibility",
+          "id": "toggle-advanced",
+          "title": "Toggle Advanced",
+          "targetElements": [
+            {
+              "elementId": "advanced-section",
+              "isVisible": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Microsoft.Teams.Cards.Tests/Json/Advanced.json
+++ b/Tests/Microsoft.Teams.Cards.Tests/Json/Advanced.json
@@ -1,0 +1,93 @@
+{
+  "type": "AdaptiveCard",
+  "id": "advancedCard",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "RichTextBlock",
+      "inlines": [
+        {
+          "type": "TextRun",
+          "text": "This text includes ",
+          "weight": "Default"
+        },
+        {
+          "type": "TextRun",
+          "text": "bold",
+          "weight": "Bolder"
+        },
+        {
+          "type": "TextRun",
+          "text": ", ",
+          "weight": "Default"
+        },
+        {
+          "type": "TextRun",
+          "text": "italic",
+          "italic": true
+        },
+        {
+          "type": "TextRun",
+          "text": ", and ",
+          "weight": "Default"
+        },
+        {
+          "type": "TextRun",
+          "text": "colored",
+          "color": "Good"
+        },
+        {
+          "type": "TextRun",
+          "text": " text.",
+          "weight": "Default"
+        }
+      ]
+    },
+    {
+      "type": "Badge",
+      "icon": "star",
+      "style": "Good",
+      "tooltip": "Top Performer"
+    },
+    {
+      "type": "CompoundButton",
+      "icon": {
+        "name": "info"
+      },
+      "title": "Learn More",
+      "description": "Click to read more about adaptive cards"
+    },
+    {
+      "type": "Carousel",
+      "pages": [
+        {
+          "type": "CarouselPage",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "Welcome to page 1",
+              "size": "Large",
+              "weight": "Bolder"
+            }
+          ]
+        },
+        {
+          "type": "CarouselPage",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "This is page 2",
+              "size": "Large",
+              "weight": "Bolder"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Rating",
+      "value": 4.5
+    }
+  ]
+}

--- a/Tests/Microsoft.Teams.Cards.Tests/Json/Charts.json
+++ b/Tests/Microsoft.Teams.Cards.Tests/Json/Charts.json
@@ -1,0 +1,237 @@
+{
+  "type": "AdaptiveCard",
+  "id": "chartsCard",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "Charts Section",
+          "size": "Medium",
+          "weight": "Bolder",
+          "color": "Attention"
+        },
+        {
+          "type": "Chart.Donut",
+          "title": "Sales Distribution",
+          "data": [
+            {
+              "legend": "Q1",
+              "value": 25,
+              "color": "categoricalBlue"
+            },
+            {
+              "legend": "Q2",
+              "value": 30,
+              "color": "categoricalGreen"
+            },
+            {
+              "legend": "Q3",
+              "value": 25,
+              "color": "categoricalPurple"
+            },
+            {
+              "legend": "Q4",
+              "value": 20,
+              "color": "categoricalTeal"
+            }
+          ]
+        },
+        {
+          "type": "Chart.Gauge",
+          "title": "Performance Score",
+          "min": 0,
+          "max": 100,
+          "segments": [
+            {
+              "size": 60,
+              "legend": "Poor",
+              "color": "attention"
+            },
+            {
+              "size": 30,
+              "legend": "Good",
+              "color": "warning"
+            },
+            {
+              "size": 10,
+              "legend": "Excellent",
+              "color": "good"
+            }
+          ],
+          "value": 85,
+          "valueFormat": "Percentage"
+        },
+        {
+          "type": "Chart.Pie",
+          "title": "Market Share",
+          "data": [
+            {
+              "legend": "Product A",
+              "value": 40,
+              "color": "good"
+            },
+            {
+              "legend": "Product B",
+              "value": 30,
+              "color": "attention"
+            },
+            {
+              "legend": "Product C",
+              "value": 30,
+              "color": "warning"
+            }
+          ]
+        },
+        {
+          "type": "Chart.VerticalBar.Grouped",
+          "title": "Departmental Revenue",
+          "data": [
+            {
+              "legend": "Engineering",
+              "values": [
+                {
+                  "x": "Q1",
+                  "y": 120
+                },
+                {
+                  "x": "Q2",
+                  "y": 135
+                }
+              ]
+            },
+            {
+              "legend": "Marketing",
+              "values": [
+                {
+                  "x": "Q1",
+                  "y": 110
+                },
+                {
+                  "x": "Q2",
+                  "y": 140
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Chart.HorizontalBar.Stacked",
+          "title": "Customer Segments",
+          "data": [
+            {
+              "title": "SMBs",
+              "data": [
+                {
+                  "legend": "SMBs",
+                  "value": 60,
+                  "color": "good"
+                }
+              ]
+            },
+            {
+              "title": "Enterprises",
+              "data": [
+                {
+                  "legend": "Enterprises",
+                  "value": 40,
+                  "color": "warning"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Chart.Line",
+          "title": "Monthly Sales Trend",
+          "data": [
+            {
+              "legend": "2023",
+              "values": [
+                {
+                  "x": "Jan",
+                  "y": 100
+                },
+                {
+                  "x": "Feb",
+                  "y": 120
+                },
+                {
+                  "x": "Mar",
+                  "y": 110
+                },
+                {
+                  "x": "Apr",
+                  "y": 130
+                }
+              ]
+            },
+            {
+              "legend": "2024",
+              "values": [
+                {
+                  "x": "Jan",
+                  "y": 110
+                },
+                {
+                  "x": "Feb",
+                  "y": 125
+                },
+                {
+                  "x": "Mar",
+                  "y": 115
+                },
+                {
+                  "x": "Apr",
+                  "y": 140
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Chart.VerticalBar",
+          "title": "Product Sales",
+          "data": [
+            {
+              "x": "Product A",
+              "y": 85,
+              "color": "categoricalBlue"
+            },
+            {
+              "x": "Product B",
+              "y": 92,
+              "color": "categoricalGreen"
+            },
+            {
+              "x": "Product C",
+              "y": 78,
+              "color": "categoricalPurple"
+            }
+          ]
+        },
+        {
+          "type": "Chart.HorizontalBar",
+          "title": "Customer Satisfaction",
+          "data": [
+            {
+              "x": "Service",
+              "y": 88
+            },
+            {
+              "x": "Quality",
+              "y": 95
+            },
+            {
+              "x": "Value",
+              "y": 82
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Microsoft.Teams.Cards.Tests/Json/Data.json
+++ b/Tests/Microsoft.Teams.Cards.Tests/Json/Data.json
@@ -1,0 +1,192 @@
+{
+  "type": "AdaptiveCard",
+  "id": "dataCard",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "FactSet",
+      "facts": [
+        {
+          "title": "Name",
+          "value": "John Doe"
+        },
+        {
+          "title": "Department",
+          "value": "Engineering"
+        },
+        {
+          "title": "Start Date",
+          "value": "2023-01-15"
+        },
+        {
+          "title": "Location",
+          "value": "Seattle, WA"
+        },
+        {
+          "title": "Employee ID",
+          "value": "EMP001"
+        }
+      ]
+    },
+    {
+      "type": "Table",
+      "columns": [
+        {
+          "width": 1
+        },
+        {
+          "width": 1
+        },
+        {
+          "width": 1
+        }
+      ],
+      "rows": [
+        {
+          "type": "TableRow",
+          "cells": [
+            {
+              "type": "TableCell",
+              "items": [
+                { 
+                  "type": "TextBlock",
+                  "text": "Product",
+                  "weight": "Bolder"
+                }
+              ]
+            },
+            {
+              "type": "TableCell",
+              "items": [
+                { 
+                  "type": "TextBlock",
+                  "text": "Description",
+                  "weight": "Bolder"
+                }
+              ]
+            },
+            {
+              "type": "TableCell",
+              "items": [
+                { 
+                  "type":"TextBlock",
+                  "text": "Price",
+                  "weight": "Bolder" 
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TableRow",
+          "cells": [
+            {
+              "type": "TableCell",
+              "items": [
+                { 
+                  "type": "TextBlock",
+                  "text": "Widget A"
+                }
+              ]
+            },
+            {
+              "type": "TableCell",
+              "items": [
+                { 
+                  "type": "TextBlock",
+                  "text": "High-quality widget for everyday use"
+                }
+              ]
+            },
+            {
+              "type": "TableCell",
+              "items": [
+                { 
+                  "type": "TextBlock",
+                  "text": "$29.99"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TableRow",
+          "cells": [
+            {
+              "type": "TableCell",
+              "items": [
+                { 
+                  "type": "TextBlock",
+                  "text": "Widget B"
+                }
+              ]
+            },
+            {
+              "type": "TableCell",
+              "items": [
+                { 
+                  "type": "TextBlock",
+                  "text": "Premium widget with advanced features"
+                }
+              ]
+            },
+            {
+              "type": "TableCell",
+              "items": [
+                { 
+                  "type": "TextBlock",
+                  "text": "$49.99"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "TextBlock",
+              "horizontalAlignment": "Center",
+              "text": "Left Column",
+              "weight": "Bolder"
+            },
+            {
+              "type": "TextBlock",
+              "text": "Content in the left column with some sample text.",
+              "wrap": true
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "stretch",
+          "items": [
+            {
+              "type": "TextBlock",
+              "horizontalAlignment": "Center",
+              "text": "Right Column",
+              "weight": "Bolder"
+            },
+            {
+              "type": "TextBlock",
+              "text": "Content in the right column with different information.",
+              "wrap": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "CodeBlock",
+      "codeSnippet": "function echo(a) {\n    return a;\n}",
+      "language": "JavaScript"
+    }
+  ]
+}

--- a/Tests/Microsoft.Teams.Cards.Tests/Json/GraphComponents.json
+++ b/Tests/Microsoft.Teams.Cards.Tests/Json/GraphComponents.json
@@ -1,0 +1,65 @@
+{
+  "type": "AdaptiveCard",
+  "id": "graphComponentsCard",
+  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "Microsoft Graph Components",
+      "size": "Large",
+      "weight": "Bolder",
+      "color": "Accent"
+    },
+    {
+      "type": "Component.User",
+      "id": "userComponent",
+      "name": "graph.microsoft.com/user",
+      "properties": {
+        "userPrincipalName": "user@contoso.com"
+      }
+    },
+    {
+      "type": "Component.Users",
+      "id": "usersComponent",
+      "name": "graph.microsoft.com/users",
+      "properties": {
+        "users": [
+          {
+            "userPrincipalName": "user1@contoso.com"
+          },
+          {
+            "userPrincipalName": "user2@contoso.com"
+          }
+        ]
+      }
+    },
+    {
+      "type": "Component.Resource",
+      "id": "resourceComponent",
+      "name": "graph.microsoft.com/resource",
+      "properties": {
+        "id": "resource-id-123",
+        "resourceReference": {
+          "type": "channel"
+        }
+      }
+    },
+    {
+      "type": "Component.File",
+      "id": "fileComponent",
+      "name": "graph.microsoft.com/file",
+      "properties": {
+        "name": "file-id-456"
+      }
+    },
+    {
+      "type": "Component.Event",
+      "id": "eventComponent",
+      "name": "graph.microsoft.com/event",
+      "properties": {
+        "id": "event-id-789"
+      }
+    }
+  ]
+}

--- a/Tests/Microsoft.Teams.Cards.Tests/Json/Media.json
+++ b/Tests/Microsoft.Teams.Cards.Tests/Json/Media.json
@@ -1,0 +1,49 @@
+{
+  "type": "AdaptiveCard",
+  "id": "mediaCard",
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Image",
+      "horizontalAlignment": "Center",
+      "url": "https://picsum.photos/400/200",
+      "altText": "Sample landscape image",
+      "style": "RoundedCorners",
+      "size": "Large"
+    },
+    {
+      "type": "Media",
+      "sources": [
+        {
+          "mimeType": "video/mp4",
+          "url": "https://adaptivecardsblob.blob.core.windows.net/assets/AdaptiveCardsOverviewVideo.mp4"
+        }
+      ],
+      "poster": "https://adaptivecards.io/content/poster-video.png"
+    },
+    {
+      "type": "ImageSet",
+      "images": [
+        {
+          "type": "Image",
+          "url": "https://picsum.photos/100/100?random=1",
+          "altText": "Random image 1",
+          "size": "Medium"
+        },
+        {
+          "type": "Image",
+          "url": "https://picsum.photos/100/100?random=2",
+          "altText": "Random image 2",
+          "size": "Medium"
+        },
+        {
+          "type": "Image",
+          "url": "https://picsum.photos/100/100?random=3",
+          "altText": "Random image 3",
+          "size": "Medium"
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Microsoft.Teams.Cards.Tests/Media.cs
+++ b/Tests/Microsoft.Teams.Cards.Tests/Media.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Teams.Cards.Tests
+{
+    public class AdaptiveCardMediaTests
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            IndentSize = 2,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public AdaptiveCard SetupAdaptiveCardWithMedia()
+        {
+            var body = new List<CardElement>
+            {
+                new Image("https://picsum.photos/400/200")
+                    .WithAltText("Sample landscape image")
+                    .WithStyle(ImageStyle.RoundedCorners)
+                    .WithSize(Size.Large)
+                    .WithHorizontalAlignment(HorizontalAlignment.Center),
+
+                new Media()
+                    .WithPoster("https://adaptivecards.io/content/poster-video.png")
+                    .WithSources(new List<MediaSource>
+                    {
+                        new MediaSource()
+                            .WithMimeType("video/mp4")
+                            .WithUrl("https://adaptivecardsblob.blob.core.windows.net/assets/AdaptiveCardsOverviewVideo.mp4")
+                    }),
+
+                new ImageSet()
+                    .WithImages(new List<Image>
+                    {
+                        new Image("https://picsum.photos/100/100?random=1")
+                            .WithAltText("Random image 1")
+                            .WithSize(Size.Medium),
+                        new Image("https://picsum.photos/100/100?random=2")
+                            .WithAltText("Random image 2")
+                            .WithSize(Size.Medium),
+                        new Image("https://picsum.photos/100/100?random=3")
+                            .WithAltText("Random image 3")
+                            .WithSize(Size.Medium)
+                    })
+            };
+
+            var card = new AdaptiveCard().WithVersion(Version.Version1_5).WithId("mediaCard")
+                .WithSchema("http://adaptivecards.io/schemas/adaptive-card.json")
+                .WithBody(body);
+            return card;
+        }
+
+        [Fact]
+        public void AdaptiveCardWithMedia_JsonSerialize()
+        {
+            var card = SetupAdaptiveCardWithMedia();
+            var expectedJson = File.ReadAllText(@"../../../Json/Media.json");
+
+            var json = JsonSerializer.Serialize<CardElement>(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void AdaptiveCardWithMedia_Serialize_Derived_FromClass()
+        {
+            AdaptiveCard card = SetupAdaptiveCardWithMedia();
+            var expectedJson = File.ReadAllText(@"../../../Json/Media.json");
+
+            var json = JsonSerializer.Serialize(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void AdaptiveCardWithMedia_Serialize_Derived_FromBaseClass()
+        {
+            CardElement card = SetupAdaptiveCardWithMedia();
+            var expectedJson = File.ReadAllText(@"../../../Json/Media.json");
+
+            var json = JsonSerializer.Serialize(card, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(expectedJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(json, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+
+        [Fact]
+        public void AdaptiveCardWithMedia_JsonDeserialize()
+        {
+            var json = File.ReadAllText(@"../../../Json/Media.json");
+            var card = JsonSerializer.Deserialize<AdaptiveCard>(json, JsonOptions);
+            var expected = SetupAdaptiveCardWithMedia();
+
+            Assert.NotNull(card);
+            Assert.Equal(expected.ToString(), card!.ToString());
+            Assert.NotNull(card.Body);
+
+            Assert.Contains(card.Body, e => e is Image);
+            Assert.Contains(card.Body, e => e is Media);
+            Assert.Contains(card.Body, e => e is ImageSet);
+
+            var imageSet = card.Body.OfType<ImageSet>().FirstOrDefault();
+            Assert.NotNull(imageSet);
+            Assert.NotNull(imageSet.Images);
+        }
+
+        [Fact]
+        public void AdaptiveCardWithMedia_RoundTripSerialization()
+        {
+            var originalJson = File.ReadAllText(@"../../../Json/Media.json");
+
+            var card = JsonSerializer.Deserialize<AdaptiveCard>(originalJson, JsonOptions);
+
+            var serializedJson = JsonSerializer.Serialize<CardElement>(card!, JsonOptions);
+
+            string expectedNormalized = Regex.Replace(originalJson, @"\s+", "");
+            string actualNormalized = Regex.Replace(serializedJson, @"\s+", "");
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+    }
+}

--- a/Tests/Microsoft.Teams.Cards.Tests/Microsoft.Teams.Cards.Tests.csproj
+++ b/Tests/Microsoft.Teams.Cards.Tests/Microsoft.Teams.Cards.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Libraries\Microsoft.Teams.Cards\Microsoft.Teams.Cards.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Replaced `Iunion` with `Union` as `Iunion` wasn't serializing correctly with `[JsonConverter(typeof(UnionJsonConverterFactory))]` . The converter expects `Union<T1, T2>` for proper (de)serialization.