### PR TITLE
fix `TeamsLogger` service registration

### DIFF
--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Hosting/Microsoft.Teams.Apps.Extensions/ServiceCollection.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Hosting/Microsoft.Teams.Apps.Extensions/ServiceCollection.cs
@@ -84,12 +84,12 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddTeams(this IServiceCollection collection, Func<IServiceProvider, App> factory)
     {
         collection.AddSingleton(provider => provider.GetRequiredService<Common.Logging.ILogger>());
-        collection.AddSingleton<ILoggerFactory, LoggerFactory>();
-        collection.AddSingleton<ILogger, TeamsLogger>(provider => provider.GetRequiredService<TeamsLogger>());
+        collection.AddSingleton<ILoggerFactory, LoggerFactory>();        
         collection.AddHostedService<TeamsService>();
         collection.AddSingleton(factory);
         collection.AddSingleton(provider => provider.GetRequiredService<App>().Logger);
         collection.AddSingleton(provider => provider.GetRequiredService<App>().Storage);
+        collection.AddSingleton<ILogger, TeamsLogger>(provider => new TeamsLogger(provider.GetRequiredService<App>().Logger));
         collection.AddSingleton<IContext.Accessor>();
         return collection;
     }
@@ -98,11 +98,11 @@ public static class ServiceCollectionExtensions
     {
         collection.AddSingleton(provider => provider.GetRequiredService<Common.Logging.ILogger>());
         collection.AddSingleton<ILoggerFactory, LoggerFactory>();
-        collection.AddSingleton<ILogger, TeamsLogger>(provider => provider.GetRequiredService<TeamsLogger>());
         collection.AddHostedService<TeamsService>();
         collection.AddSingleton(provider => factory(provider).GetAwaiter().GetResult());
         collection.AddSingleton(provider => provider.GetRequiredService<App>().Logger);
         collection.AddSingleton(provider => provider.GetRequiredService<App>().Storage);
+        collection.AddSingleton<ILogger, TeamsLogger>(provider => new TeamsLogger(provider.GetRequiredService<App>().Logger));
         collection.AddSingleton<IContext.Accessor>();
         return collection;
     }

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Hosting/Microsoft.Teams.Apps.Extensions/ServiceCollection.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Hosting/Microsoft.Teams.Apps.Extensions/ServiceCollection.cs
@@ -84,7 +84,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddTeams(this IServiceCollection collection, Func<IServiceProvider, App> factory)
     {
         collection.AddSingleton(provider => provider.GetRequiredService<Common.Logging.ILogger>());
-        collection.AddSingleton<ILoggerFactory, LoggerFactory>();        
+        collection.AddSingleton<ILoggerFactory, LoggerFactory>();
         collection.AddHostedService<TeamsService>();
         collection.AddSingleton(factory);
         collection.AddSingleton(provider => provider.GetRequiredService<App>().Logger);


### PR DESCRIPTION
`TeamsLogger` is not created by default in two of five `ServiceCollection.AddTeams` overloads which it should. This PR fixes that. Otherwise an exception is thrown unless the developer manually registers it with the service collection.