### PR TITLE
[Apps] Token Expiration Refresh & System Routes

### DIFF
--- a/Libraries/Microsoft.Teams.Api/Auth/JsonWebToken.cs
+++ b/Libraries/Microsoft.Teams.Api/Auth/JsonWebToken.cs
@@ -50,6 +50,12 @@ public class JsonWebToken : IToken
         get => From.IsBot ? $"urn:botframework:aadappid:{AppId}" : "urn:botframework:azure";
     }
 
+    [JsonPropertyName("expiration")]
+    public DateTime? Expiration
+    {
+        get => Token.ValidTo;
+    }
+
     public JwtSecurityToken Token { get; }
     private readonly string _tokenAsString;
 
@@ -67,5 +73,6 @@ public class JsonWebToken : IToken
         _tokenAsString = response.Token;
     }
 
+    public bool IsExpired() => Token.ValidTo <= DateTime.UtcNow.AddMilliseconds(1000 * 60 * 5);
     public override string ToString() => _tokenAsString;
 }

--- a/Libraries/Microsoft.Teams.Api/Auth/JsonWebToken.cs
+++ b/Libraries/Microsoft.Teams.Api/Auth/JsonWebToken.cs
@@ -56,6 +56,23 @@ public class JsonWebToken : IToken
         get => Token.ValidTo;
     }
 
+    [JsonIgnore]
+    public bool IsExpired
+    {
+        get => Token.ValidTo <= DateTime.UtcNow.AddMilliseconds(1000 * 60 * 5);
+    }
+
+    [JsonPropertyName("scopes")]
+    public IEnumerable<string> Scopes
+    {
+        get
+        {
+            var claim = Token.Claims.FirstOrDefault(c => c.Type == "scope" || c.Type == "scp");
+            if (claim is null) return [];
+            return claim.Value.Split(' ');
+        }
+    }
+
     public JwtSecurityToken Token { get; }
     private readonly string _tokenAsString;
 
@@ -73,6 +90,5 @@ public class JsonWebToken : IToken
         _tokenAsString = response.Token;
     }
 
-    public bool IsExpired() => Token.ValidTo <= DateTime.UtcNow.AddMilliseconds(1000 * 60 * 5);
     public override string ToString() => _tokenAsString;
 }

--- a/Libraries/Microsoft.Teams.Api/Auth/Token.cs
+++ b/Libraries/Microsoft.Teams.Api/Auth/Token.cs
@@ -49,7 +49,12 @@ public interface IToken
     /// check if the token is expired
     /// </summary>
     /// <returns>true if expired, otherwise false</returns>
-    public bool IsExpired();
+    public bool IsExpired { get; }
+
+    /// <summary>
+    /// a list of the tokens scopes
+    /// </summary>
+    public IEnumerable<string> Scopes { get; }
 
     /// <summary>
     /// convert the token to its string representation

--- a/Libraries/Microsoft.Teams.Api/Auth/Token.cs
+++ b/Libraries/Microsoft.Teams.Api/Auth/Token.cs
@@ -5,14 +5,55 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Teams.Api.Auth;
 
+/// <summary>
+/// any authorized token
+/// </summary>
 public interface IToken
 {
+    /// <summary>
+    /// the app id
+    /// </summary>
     public string? AppId { get; }
+
+    /// <summary>
+    /// the app display name
+    /// </summary>
     public string? AppDisplayName { get; }
+
+    /// <summary>
+    /// the tenant id
+    /// </summary>
     public string? TenantId { get; }
+
+    /// <summary>
+    /// the service url to send responses to
+    /// </summary>
     public string ServiceUrl { get; }
+
+    /// <summary>
+    /// where the activity originated from
+    /// </summary>
     public CallerType From { get; }
+
+    /// <summary>
+    /// the id of the acitivity sender
+    /// </summary>
     public string FromId { get; }
+
+    /// <summary>
+    /// the timestamp when this token expires
+    /// </summary>
+    public DateTime? Expiration { get; }
+
+    /// <summary>
+    /// check if the token is expired
+    /// </summary>
+    /// <returns>true if expired, otherwise false</returns>
+    public bool IsExpired();
+
+    /// <summary>
+    /// convert the token to its string representation
+    /// </summary>
     public string ToString();
 }
 

--- a/Libraries/Microsoft.Teams.Api/Clients/ConversationClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/ConversationClient.cs
@@ -1,4 +1,4 @@
-﻿﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;

--- a/Libraries/Microsoft.Teams.Apps.Testing/Plugins/TestPlugin.cs
+++ b/Libraries/Microsoft.Teams.Apps.Testing/Plugins/TestPlugin.cs
@@ -1,4 +1,4 @@
-﻿﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.Teams.Api;

--- a/Libraries/Microsoft.Teams.Apps/Activities/Activity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Activity.cs
@@ -40,6 +40,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = type,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async (context) =>
             {
                 await handler(context);
@@ -56,6 +57,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = type,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = handler,
             Selector = (activity) => activity.Type.Equals(type),
         });
@@ -68,6 +70,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = "activity",
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async (context) =>
             {
                 await handler(context.ToActivityType<TActivity>());
@@ -84,6 +87,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = "activity",
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = (context) => handler(context.ToActivityType<TActivity>()),
             Selector = (activity) => activity.GetType() == typeof(TActivity),
         });
@@ -96,6 +100,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = "activity",
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Selector = select,
             Handler = async (context) =>
             {
@@ -112,6 +117,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = "activity",
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Selector = select,
             Handler = handler
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Activity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Activity.cs
@@ -67,6 +67,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = "activity",
             Handler = async (context) =>
             {
                 await handler(context.ToActivityType<TActivity>());
@@ -82,6 +83,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = "activity",
             Handler = (context) => handler(context.ToActivityType<TActivity>()),
             Selector = (activity) => activity.GetType() == typeof(TActivity),
         });
@@ -93,6 +95,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = "activity",
             Selector = select,
             Handler = async (context) =>
             {
@@ -108,6 +111,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = "activity",
             Selector = select,
             Handler = handler
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Activity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Activity.cs
@@ -39,6 +39,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = type,
             Handler = async (context) =>
             {
                 await handler(context);
@@ -54,6 +55,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = type,
             Handler = handler,
             Selector = (activity) => activity.Type.Equals(type),
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/CommandActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/CommandActivity.cs
@@ -19,6 +19,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.Command,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<CommandActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/CommandActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/CommandActivity.cs
@@ -18,6 +18,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.Command,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<CommandActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/CommandResultActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/CommandResultActivity.cs
@@ -18,6 +18,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.CommandResult,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<CommandResultActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/CommandResultActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/CommandResultActivity.cs
@@ -19,6 +19,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.CommandResult,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<CommandResultActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelCreatedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelCreatedActivity.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class ChannelCreatedAttribute() : UpdateAttribute
+    public class ChannelCreatedAttribute() : UpdateAttribute(ConversationUpdateActivity.EventType.ChannelCreated)
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelCreatedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelCreatedActivity.cs
@@ -29,6 +29,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelCreated]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelCreatedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelCreatedActivity.cs
@@ -30,6 +30,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelCreated]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelDeletedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelDeletedActivity.cs
@@ -29,6 +29,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelDeleted]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelDeletedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelDeletedActivity.cs
@@ -30,6 +30,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelDeleted]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelDeletedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelDeletedActivity.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class ChannelDeletedAttribute() : UpdateAttribute
+    public class ChannelDeletedAttribute() : UpdateAttribute(ConversationUpdateActivity.EventType.ChannelDeleted)
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelMemberAddedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelMemberAddedActivity.cs
@@ -27,6 +27,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelMemberAdded]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelMemberAddedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelMemberAddedActivity.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class ChannelMemberAddedAttribute() : UpdateAttribute
+    public class ChannelMemberAddedAttribute() : UpdateAttribute(ConversationUpdateActivity.EventType.ChannelMemberAdded)
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelMemberAddedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelMemberAddedActivity.cs
@@ -26,6 +26,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelMemberAdded]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelMemberRemovedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelMemberRemovedActivity.cs
@@ -27,6 +27,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelMemberRemoved]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelMemberRemovedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelMemberRemovedActivity.cs
@@ -26,6 +26,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelMemberRemoved]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelMemberRemovedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelMemberRemovedActivity.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class ChannelMemberRemovedAttribute() : UpdateAttribute
+    public class ChannelMemberRemovedAttribute() : UpdateAttribute(ConversationUpdateActivity.EventType.ChannelMemberRemoved)
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelRenamedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelRenamedActivity.cs
@@ -29,6 +29,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelRenamed]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelRenamedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelRenamedActivity.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class ChannelRenamedAttribute() : UpdateAttribute
+    public class ChannelRenamedAttribute() : UpdateAttribute(ConversationUpdateActivity.EventType.ChannelRenamed)
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelRenamedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelRenamedActivity.cs
@@ -30,6 +30,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelRenamed]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelRestoredActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelRestoredActivity.cs
@@ -29,6 +29,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelRestored]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelRestoredActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelRestoredActivity.cs
@@ -30,6 +30,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelRestored]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelRestoredActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelRestoredActivity.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class ChannelRestoredAttribute() : UpdateAttribute
+    public class ChannelRestoredAttribute() : UpdateAttribute(ConversationUpdateActivity.EventType.ChannelRestored)
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelSharedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelSharedActivity.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class ChannelSharedAttribute() : UpdateAttribute
+    public class ChannelSharedAttribute() : UpdateAttribute(ConversationUpdateActivity.EventType.ChannelShared)
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelSharedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelSharedActivity.cs
@@ -27,6 +27,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelShared]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelSharedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelSharedActivity.cs
@@ -26,6 +26,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelShared]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelUnsharedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelUnsharedActivity.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class ChannelUnSharedAttribute() : UpdateAttribute
+    public class ChannelUnSharedAttribute() : UpdateAttribute(ConversationUpdateActivity.EventType.ChannelUnShared)
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelUnsharedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelUnsharedActivity.cs
@@ -27,6 +27,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelUnShared]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelUnsharedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ChannelUnsharedActivity.cs
@@ -26,6 +26,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelUnShared]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ConversationEndActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ConversationEndActivity.cs
@@ -21,6 +21,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.EndOfConversation,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<EndOfConversationActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ConversationEndActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ConversationEndActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.EndOfConversation,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<EndOfConversationActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ConversationUpdateActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ConversationUpdateActivity.cs
@@ -32,6 +32,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.ConversationUpdate,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ConversationUpdateActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ConversationUpdateActivity.cs
@@ -9,8 +9,18 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class UpdateAttribute() : ActivityAttribute(ActivityType.ConversationUpdate, typeof(ConversationUpdateActivity))
+    public class UpdateAttribute : ActivityAttribute
     {
+        public UpdateAttribute() : base(ActivityType.ConversationUpdate, typeof(ConversationUpdateActivity))
+        {
+
+        }
+
+        public UpdateAttribute(ConversationUpdateActivity.EventType eventType) : base(string.Join("/", [ActivityType.ConversationUpdate, eventType]), typeof(ConversationUpdateActivity))
+        {
+
+        }
+
         public override object Coerce(IContext<IActivity> context) => context.ToActivityType<ConversationUpdateActivity>();
     }
 }

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ConversationUpdateActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ConversationUpdateActivity.cs
@@ -21,6 +21,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.ConversationUpdate,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/MembersAddedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/MembersAddedActivity.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class MembersAddedAttribute() : UpdateAttribute
+    public class MembersAddedAttribute() : UpdateAttribute()
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/MembersAddedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/MembersAddedActivity.cs
@@ -29,6 +29,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelMemberAdded]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/MembersAddedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/MembersAddedActivity.cs
@@ -30,6 +30,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelMemberAdded]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/MembersRemovedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/MembersRemovedActivity.cs
@@ -30,6 +30,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelMemberRemoved]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/MembersRemovedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/MembersRemovedActivity.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class MembersRemovedAttribute() : UpdateAttribute
+    public class MembersRemovedAttribute() : UpdateAttribute()
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/MembersRemovedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/MembersRemovedActivity.cs
@@ -29,6 +29,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.ChannelMemberRemoved]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamArchivedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamArchivedActivity.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class TeamArchivedAttribute() : UpdateAttribute
+    public class TeamArchivedAttribute() : UpdateAttribute(ConversationUpdateActivity.EventType.TeamArchived)
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamArchivedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamArchivedActivity.cs
@@ -30,6 +30,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.TeamArchived]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamArchivedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamArchivedActivity.cs
@@ -29,6 +29,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.TeamArchived]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamDeletedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamDeletedActivity.cs
@@ -32,6 +32,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.TeamDeleted]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());
@@ -56,6 +57,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.TeamHardDeleted]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamDeletedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamDeletedActivity.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class TeamDeletedAttribute(bool hard = false) : UpdateAttribute
+    public class TeamDeletedAttribute(bool hard = false) : UpdateAttribute(hard ? ConversationUpdateActivity.EventType.TeamHardDeleted : ConversationUpdateActivity.EventType.TeamDeleted)
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamDeletedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamDeletedActivity.cs
@@ -55,6 +55,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.TeamHardDeleted]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamDeletedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamDeletedActivity.cs
@@ -31,6 +31,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.TeamDeleted]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamRenamedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamRenamedActivity.cs
@@ -30,6 +30,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.TeamRenamed]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamRenamedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamRenamedActivity.cs
@@ -29,6 +29,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.TeamRenamed]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamRenamedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamRenamedActivity.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class TeamRenamedAttribute() : UpdateAttribute
+    public class TeamRenamedAttribute() : UpdateAttribute(ConversationUpdateActivity.EventType.TeamRenamed)
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamRestoredActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamRestoredActivity.cs
@@ -30,6 +30,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.TeamRestored]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamRestoredActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamRestoredActivity.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class TeamRestoredAttribute() : UpdateAttribute
+    public class TeamRestoredAttribute() : UpdateAttribute(ConversationUpdateActivity.EventType.TeamRestored)
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamRestoredActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamRestoredActivity.cs
@@ -29,6 +29,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.TeamRestored]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamUnArchivedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamUnArchivedActivity.cs
@@ -29,6 +29,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.TeamUnarchived]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamUnArchivedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamUnArchivedActivity.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Teams.Apps.Activities;
 public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class TeamUnArchivedAttribute() : UpdateAttribute
+    public class TeamUnArchivedAttribute() : UpdateAttribute(ConversationUpdateActivity.EventType.TeamUnarchived)
     {
         public override bool Select(IActivity activity)
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamUnArchivedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/TeamUnArchivedActivity.cs
@@ -30,6 +30,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.ConversationUpdate, ConversationUpdateActivity.EventType.TeamUnarchived]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ConversationUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/EventActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/EventActivity.cs
@@ -18,6 +18,7 @@ public static partial class AppEventActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.Event,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<EventActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/EventActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/EventActivity.cs
@@ -2,13 +2,24 @@
 // Licensed under the MIT License.
 
 using Microsoft.Teams.Api.Activities;
+using Microsoft.Teams.Api.Activities.Events;
 using Microsoft.Teams.Apps.Routing;
 
 namespace Microsoft.Teams.Apps.Activities.Events;
 
 [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-public class EventAttribute() : ActivityAttribute(ActivityType.Event, typeof(EventActivity))
+public class EventAttribute : ActivityAttribute
 {
+    public EventAttribute() : base(ActivityType.Event, typeof(EventActivity))
+    {
+
+    }
+
+    public EventAttribute(Name name) : base(string.Join("/", [ActivityType.Event, name]), typeof(EventActivity))
+    {
+
+    }
+
     public override object Coerce(IContext<IActivity> context) => context.ToActivityType<EventActivity>();
 }
 

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/EventActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/EventActivity.cs
@@ -30,6 +30,7 @@ public static partial class AppEventActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.Event,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<EventActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingEndActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingEndActivity.cs
@@ -31,6 +31,7 @@ public static partial class AppEventActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Event, Name.MeetingEnd]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MeetingEndActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingEndActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingEndActivity.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Teams.Apps.Activities.Events;
 public static partial class Event
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class MeetingEndAttribute() : EventAttribute
+    public class MeetingEndAttribute() : EventAttribute(Api.Activities.Events.Name.MeetingEnd)
     {
         public override object Coerce(IContext<IActivity> context) => context.ToActivityType<MeetingEndActivity>();
         public override bool Select(IActivity activity)

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingEndActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingEndActivity.cs
@@ -32,6 +32,7 @@ public static partial class AppEventActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Event, Name.MeetingEnd]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MeetingEndActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingJoinActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingJoinActivity.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Teams.Apps.Activities.Events;
 public static partial class Event
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class MeetingJoinAttribute() : EventAttribute
+    public class MeetingJoinAttribute() : EventAttribute(Api.Activities.Events.Name.MeetingParticipantJoin)
     {
         public override object Coerce(IContext<IActivity> context) => context.ToActivityType<MeetingParticipantJoinActivity>();
         public override bool Select(IActivity activity)

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingJoinActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingJoinActivity.cs
@@ -31,6 +31,7 @@ public static partial class AppEventActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Event, Name.MeetingParticipantJoin]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MeetingParticipantJoinActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingJoinActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingJoinActivity.cs
@@ -32,6 +32,7 @@ public static partial class AppEventActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Event, Name.MeetingParticipantJoin]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MeetingParticipantJoinActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingLeaveActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingLeaveActivity.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Teams.Apps.Activities.Events;
 public static partial class Event
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class MeetingLeaveAttribute() : EventAttribute
+    public class MeetingLeaveAttribute() : EventAttribute(Api.Activities.Events.Name.MeetingParticipantLeave)
     {
         public override object Coerce(IContext<IActivity> context) => context.ToActivityType<MeetingParticipantLeaveActivity>();
         public override bool Select(IActivity activity)

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingLeaveActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingLeaveActivity.cs
@@ -31,6 +31,7 @@ public static partial class AppEventActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Event, Name.MeetingParticipantLeave]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MeetingParticipantLeaveActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingLeaveActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingLeaveActivity.cs
@@ -32,6 +32,7 @@ public static partial class AppEventActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Event, Name.MeetingParticipantLeave]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MeetingParticipantLeaveActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingStartActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingStartActivity.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Teams.Apps.Activities.Events;
 public static partial class Event
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class MeetingStartAttribute() : EventAttribute
+    public class MeetingStartAttribute() : EventAttribute(Api.Activities.Events.Name.MeetingStart)
     {
         public override object Coerce(IContext<IActivity> context) => context.ToActivityType<MeetingStartActivity>();
         public override bool Select(IActivity activity)

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingStartActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingStartActivity.cs
@@ -31,6 +31,7 @@ public static partial class AppEventActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Event, Name.MeetingStart]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MeetingStartActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingStartActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/MeetingStartActivity.cs
@@ -32,6 +32,7 @@ public static partial class AppEventActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Event, Name.MeetingStart]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MeetingStartActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/ReadReceiptActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/ReadReceiptActivity.cs
@@ -32,6 +32,7 @@ public static partial class AppEventActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Event, Name.ReadReceipt]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ReadReceiptActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/ReadReceiptActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/ReadReceiptActivity.cs
@@ -31,6 +31,7 @@ public static partial class AppEventActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Event, Name.ReadReceipt]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ReadReceiptActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Events/ReadReceiptActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Events/ReadReceiptActivity.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Teams.Apps.Activities.Events;
 public static partial class Event
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class ReadReceiptAttribute() : EventAttribute
+    public class ReadReceiptAttribute() : EventAttribute(Api.Activities.Events.Name.ReadReceipt)
     {
         public override object Coerce(IContext<IActivity> context) => context.ToActivityType<ReadReceiptActivity>();
         public override bool Select(IActivity activity)

--- a/Libraries/Microsoft.Teams.Apps/Activities/Installs/InstallActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Installs/InstallActivity.cs
@@ -26,6 +26,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.InstallUpdate, InstallUpdateAction.Add]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<InstallUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Installs/InstallActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Installs/InstallActivity.cs
@@ -7,7 +7,7 @@ using Microsoft.Teams.Apps.Routing;
 namespace Microsoft.Teams.Apps.Activities;
 
 [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-public class InstallAttribute() : InstallUpdateAttribute
+public class InstallAttribute() : InstallUpdateAttribute(InstallUpdateAction.Add)
 {
     public override bool Select(IActivity activity)
     {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Installs/InstallActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Installs/InstallActivity.cs
@@ -27,6 +27,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.InstallUpdate, InstallUpdateAction.Add]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<InstallUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Installs/InstallUpdateActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Installs/InstallUpdateActivity.cs
@@ -7,8 +7,18 @@ using Microsoft.Teams.Apps.Routing;
 namespace Microsoft.Teams.Apps.Activities;
 
 [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-public class InstallUpdateAttribute() : ActivityAttribute(ActivityType.InstallUpdate, typeof(InstallUpdateActivity))
+public class InstallUpdateAttribute : ActivityAttribute
 {
+    public InstallUpdateAttribute() : base(ActivityType.InstallUpdate, typeof(InstallUpdateActivity))
+    {
+
+    }
+
+    public InstallUpdateAttribute(InstallUpdateAction action) : base(string.Join("/", [ActivityType.InstallUpdate, action]), typeof(InstallUpdateActivity))
+    {
+
+    }
+
     public override object Coerce(IContext<IActivity> context) => context.ToActivityType<InstallUpdateActivity>();
 }
 

--- a/Libraries/Microsoft.Teams.Apps/Activities/Installs/InstallUpdateActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Installs/InstallUpdateActivity.cs
@@ -29,6 +29,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.InstallUpdate,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<InstallUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Installs/InstallUpdateActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Installs/InstallUpdateActivity.cs
@@ -18,6 +18,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.InstallUpdate,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<InstallUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Installs/UnInstallActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Installs/UnInstallActivity.cs
@@ -7,7 +7,7 @@ using Microsoft.Teams.Apps.Routing;
 namespace Microsoft.Teams.Apps.Activities;
 
 [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-public class UnInstallAttribute() : InstallUpdateAttribute
+public class UnInstallAttribute() : InstallUpdateAttribute(InstallUpdateAction.Remove)
 {
     public override bool Select(IActivity activity)
     {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Installs/UnInstallActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Installs/UnInstallActivity.cs
@@ -26,6 +26,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.InstallUpdate, InstallUpdateAction.Remove]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<InstallUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Installs/UnInstallActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Installs/UnInstallActivity.cs
@@ -27,6 +27,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.InstallUpdate, InstallUpdateAction.Remove]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<InstallUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/AdaptiveCards/ActionActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/AdaptiveCards/ActionActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.AdaptiveCards.Action]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<AdaptiveCards.ActionActivity>());
@@ -38,6 +39,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.AdaptiveCards.Action]),
             Handler = async context => await handler(context.ToActivityType<AdaptiveCards.ActionActivity>()),
             Selector = activity => activity is AdaptiveCards.ActionActivity
         });
@@ -49,6 +51,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.AdaptiveCards.Action]),
             Handler = async context => await handler(context.ToActivityType<AdaptiveCards.ActionActivity>()),
             Selector = activity => activity is AdaptiveCards.ActionActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/AdaptiveCards/ActionActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/AdaptiveCards/ActionActivity.cs
@@ -24,6 +24,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.AdaptiveCards.Action]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<AdaptiveCards.ActionActivity>());
@@ -40,6 +41,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.AdaptiveCards.Action]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<AdaptiveCards.ActionActivity>()),
             Selector = activity => activity is AdaptiveCards.ActionActivity
         });
@@ -52,6 +54,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.AdaptiveCards.Action]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<AdaptiveCards.ActionActivity>()),
             Selector = activity => activity is AdaptiveCards.ActionActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Configs/FetchActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Configs/FetchActivity.cs
@@ -24,6 +24,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Configs.Fetch]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Configs.FetchActivity>());
@@ -40,6 +41,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Configs.Fetch]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<Configs.FetchActivity>()),
             Selector = activity => activity is Configs.FetchActivity
         });
@@ -52,6 +54,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Configs.Fetch]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<Configs.FetchActivity>()),
             Selector = activity => activity is Configs.FetchActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Configs/FetchActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Configs/FetchActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Configs.Fetch]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Configs.FetchActivity>());
@@ -38,6 +39,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Configs.Fetch]),
             Handler = async context => await handler(context.ToActivityType<Configs.FetchActivity>()),
             Selector = activity => activity is Configs.FetchActivity
         });
@@ -49,6 +51,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Configs.Fetch]),
             Handler = async context => await handler(context.ToActivityType<Configs.FetchActivity>()),
             Selector = activity => activity is Configs.FetchActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Configs/SubmitActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Configs/SubmitActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Configs.Submit]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Configs.SubmitActivity>());
@@ -38,6 +39,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Configs.Submit]),
             Handler = async context => await handler(context.ToActivityType<Configs.SubmitActivity>()),
             Selector = activity => activity is Configs.SubmitActivity
         });
@@ -49,6 +51,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Configs.Submit]),
             Handler = async context => await handler(context.ToActivityType<Configs.SubmitActivity>()),
             Selector = activity => activity is Configs.SubmitActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Configs/SubmitActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Configs/SubmitActivity.cs
@@ -24,6 +24,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Configs.Submit]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Configs.SubmitActivity>());
@@ -40,6 +41,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Configs.Submit]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<Configs.SubmitActivity>()),
             Selector = activity => activity is Configs.SubmitActivity
         });
@@ -52,6 +54,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Configs.Submit]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<Configs.SubmitActivity>()),
             Selector = activity => activity is Configs.SubmitActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/ExecuteActionActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/ExecuteActionActivity.cs
@@ -19,6 +19,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.ExecuteAction]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ExecuteActionActivity>());
@@ -34,6 +35,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.ExecuteAction]),
             Handler = context => handler(context.ToActivityType<ExecuteActionActivity>()),
             Selector = activity => activity is ExecuteActionActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/ExecuteActionActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/ExecuteActionActivity.cs
@@ -20,6 +20,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.ExecuteAction]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<ExecuteActionActivity>());
@@ -36,6 +37,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.ExecuteAction]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = context => handler(context.ToActivityType<ExecuteActionActivity>()),
             Selector = activity => activity is ExecuteActionActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/FileConsentActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/FileConsentActivity.cs
@@ -19,6 +19,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.FileConsent]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<FileConsentActivity>());
@@ -34,6 +35,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.FileConsent]),
             Handler = context => handler(context.ToActivityType<FileConsentActivity>()),
             Selector = activity => activity is FileConsentActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/FileConsentActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/FileConsentActivity.cs
@@ -20,6 +20,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.FileConsent]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<FileConsentActivity>());
@@ -36,6 +37,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.FileConsent]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = context => handler(context.ToActivityType<FileConsentActivity>()),
             Selector = activity => activity is FileConsentActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/HandoffActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/HandoffActivity.cs
@@ -19,6 +19,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Handoff]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<HandoffActivity>());
@@ -34,6 +35,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Handoff]),
             Handler = context => handler(context.ToActivityType<HandoffActivity>()),
             Selector = activity => activity is HandoffActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/HandoffActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/HandoffActivity.cs
@@ -20,6 +20,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Handoff]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<HandoffActivity>());
@@ -36,6 +37,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Handoff]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = context => handler(context.ToActivityType<HandoffActivity>()),
             Selector = activity => activity is HandoffActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/InvokeActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/InvokeActivity.cs
@@ -30,6 +30,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.Invoke,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<InvokeActivity>());
@@ -45,6 +46,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.Invoke,
             Handler = context => handler(context.ToActivityType<InvokeActivity>()),
             Selector = activity => activity is InvokeActivity
         });
@@ -56,6 +58,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.Invoke,
             Handler = async context => await handler(context.ToActivityType<InvokeActivity>()),
             Selector = activity => activity is InvokeActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/InvokeActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/InvokeActivity.cs
@@ -36,6 +36,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.Invoke,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<InvokeActivity>());
@@ -52,6 +53,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.Invoke,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = context => handler(context.ToActivityType<InvokeActivity>()),
             Selector = activity => activity is InvokeActivity
         });
@@ -64,6 +66,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.Invoke,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<InvokeActivity>()),
             Selector = activity => activity is InvokeActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/InvokeActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/InvokeActivity.cs
@@ -8,9 +8,14 @@ using Microsoft.Teams.Apps.Routing;
 namespace Microsoft.Teams.Apps.Activities.Invokes;
 
 [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-public class InvokeAttribute(string? name = null, Type? type = null) : ActivityAttribute(ActivityType.Invoke, type ?? typeof(InvokeActivity))
+public class InvokeAttribute : ActivityAttribute
 {
-    public readonly Name? InvokeName = name is not null ? new(name) : null;
+    public Name? InvokeName { get; }
+
+    public InvokeAttribute(string? name = null, Type? type = null) : base(name is null ? ActivityType.Invoke : string.Join("/", [ActivityType.Invoke, name]), type ?? typeof(InvokeActivity))
+    {
+        InvokeName = name is not null ? new(name) : null;
+    }
 
     public override object Coerce(IContext<IActivity> context) => context.ToActivityType<InvokeActivity>();
     public override bool Select(IActivity activity)

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/AnonQueryLinkActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/AnonQueryLinkActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.AnonQueryLink]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.AnonQueryLinkActivity>());
@@ -39,6 +40,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.AnonQueryLink]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.AnonQueryLinkActivity>()),
             Selector = activity => activity is MessageExtensions.AnonQueryLinkActivity
         });
@@ -51,6 +53,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.AnonQueryLink]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.AnonQueryLinkActivity>()),
             Selector = activity => activity is MessageExtensions.AnonQueryLinkActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/AnonQueryLinkActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/AnonQueryLinkActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.AnonQueryLink]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.AnonQueryLinkActivity>());
@@ -37,6 +38,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.AnonQueryLink]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.AnonQueryLinkActivity>()),
             Selector = activity => activity is MessageExtensions.AnonQueryLinkActivity
         });
@@ -48,6 +50,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.AnonQueryLink]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.AnonQueryLinkActivity>()),
             Selector = activity => activity is MessageExtensions.AnonQueryLinkActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/CardButtonClickedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/CardButtonClickedActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.CardButtonClicked]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.CardButtonClickedActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/CardButtonClickedActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/CardButtonClickedActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.CardButtonClicked]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.CardButtonClickedActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/FetchTaskActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/FetchTaskActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.FetchTask]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.FetchTaskActivity>());
@@ -39,6 +40,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.FetchTask]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.FetchTaskActivity>()),
             Selector = activity => activity is MessageExtensions.FetchTaskActivity
         });
@@ -51,6 +53,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.FetchTask]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.FetchTaskActivity>()),
             Selector = activity => activity is MessageExtensions.FetchTaskActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/FetchTaskActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/FetchTaskActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.FetchTask]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.FetchTaskActivity>());
@@ -37,6 +38,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.FetchTask]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.FetchTaskActivity>()),
             Selector = activity => activity is MessageExtensions.FetchTaskActivity
         });
@@ -48,6 +50,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.FetchTask]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.FetchTaskActivity>()),
             Selector = activity => activity is MessageExtensions.FetchTaskActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QueryActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QueryActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.Query]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.QueryActivity>());
@@ -37,6 +38,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.Query]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.QueryActivity>()),
             Selector = activity => activity is MessageExtensions.QueryActivity
         });
@@ -48,6 +50,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.Query]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.QueryActivity>()),
             Selector = activity => activity is MessageExtensions.QueryActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QueryActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QueryActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.Query]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.QueryActivity>());
@@ -39,6 +40,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.Query]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.QueryActivity>()),
             Selector = activity => activity is MessageExtensions.QueryActivity
         });
@@ -51,6 +53,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.Query]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.QueryActivity>()),
             Selector = activity => activity is MessageExtensions.QueryActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QueryLinkActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QueryLinkActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QueryLink]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.QueryLinkActivity>());
@@ -37,6 +38,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QueryLink]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.QueryLinkActivity>()),
             Selector = activity => activity is MessageExtensions.QueryLinkActivity
         });
@@ -48,6 +50,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QueryLink]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.QueryLinkActivity>()),
             Selector = activity => activity is MessageExtensions.QueryLinkActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QueryLinkActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QueryLinkActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QueryLink]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.QueryLinkActivity>());
@@ -39,6 +40,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QueryLink]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.QueryLinkActivity>()),
             Selector = activity => activity is MessageExtensions.QueryLinkActivity
         });
@@ -51,6 +53,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QueryLink]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.QueryLinkActivity>()),
             Selector = activity => activity is MessageExtensions.QueryLinkActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QuerySettingsUrlActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QuerySettingsUrlActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QuerySettingsUrl]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.QuerySettingsUrlActivity>());
@@ -37,6 +38,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QuerySettingsUrl]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.QuerySettingsUrlActivity>()),
             Selector = activity => activity is MessageExtensions.QuerySettingsUrlActivity
         });
@@ -48,6 +50,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QuerySettingsUrl]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.QuerySettingsUrlActivity>()),
             Selector = activity => activity is MessageExtensions.QuerySettingsUrlActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QuerySettingsUrlActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QuerySettingsUrlActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QuerySettingsUrl]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.QuerySettingsUrlActivity>());
@@ -39,6 +40,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QuerySettingsUrl]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.QuerySettingsUrlActivity>()),
             Selector = activity => activity is MessageExtensions.QuerySettingsUrlActivity
         });
@@ -51,6 +53,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QuerySettingsUrl]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.QuerySettingsUrlActivity>()),
             Selector = activity => activity is MessageExtensions.QuerySettingsUrlActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/SelectItemActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/SelectItemActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.SelectItem]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.SelectItemActivity>());
@@ -39,6 +40,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.SelectItem]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.SelectItemActivity>()),
             Selector = activity => activity is MessageExtensions.SelectItemActivity
         });
@@ -51,6 +53,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.SelectItem]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.SelectItemActivity>()),
             Selector = activity => activity is MessageExtensions.SelectItemActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/SelectItemActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/SelectItemActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.SelectItem]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.SelectItemActivity>());
@@ -37,6 +38,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.SelectItem]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.SelectItemActivity>()),
             Selector = activity => activity is MessageExtensions.SelectItemActivity
         });
@@ -48,6 +50,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.SelectItem]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.SelectItemActivity>()),
             Selector = activity => activity is MessageExtensions.SelectItemActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/SettingsActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/SettingsActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.Setting]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.SettingActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/SettingsActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/SettingsActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.Setting]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.SettingActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/SubmitActionActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/SubmitActionActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.SubmitAction]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.SubmitActionActivity>());
@@ -37,6 +38,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.SubmitAction]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.SubmitActionActivity>()),
             Selector = activity => activity is MessageExtensions.SubmitActionActivity
         });
@@ -48,6 +50,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.SubmitAction]),
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.SubmitActionActivity>()),
             Selector = activity => activity is MessageExtensions.SubmitActionActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/SubmitActionActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/SubmitActionActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.SubmitAction]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageExtensions.SubmitActionActivity>());
@@ -39,6 +40,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.SubmitAction]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.SubmitActionActivity>()),
             Selector = activity => activity is MessageExtensions.SubmitActionActivity
         });
@@ -51,6 +53,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.SubmitAction]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<MessageExtensions.SubmitActionActivity>()),
             Selector = activity => activity is MessageExtensions.SubmitActionActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Messages/SubmitActionActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Messages/SubmitActionActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Messages.SubmitAction]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Messages.SubmitActionActivity>());
@@ -37,6 +38,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Messages.SubmitAction]),
             Handler = context => handler(context.ToActivityType<Messages.SubmitActionActivity>()),
             Selector = activity => activity is Messages.SubmitActionActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Messages/SubmitActionActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Messages/SubmitActionActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Messages.SubmitAction]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Messages.SubmitActionActivity>());
@@ -39,6 +40,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Messages.SubmitAction]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = context => handler(context.ToActivityType<Messages.SubmitActionActivity>()),
             Selector = activity => activity is Messages.SubmitActionActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Search/AnswerSearchActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Search/AnswerSearchActivity.cs
@@ -28,6 +28,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Search, SearchType.SearchAnswer]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<SearchActivity>());
@@ -51,6 +52,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Search, SearchType.SearchAnswer]),
             Handler = async context => await handler(context.ToActivityType<SearchActivity>()),
             Selector = activity =>
             {
@@ -70,6 +72,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Search, SearchType.SearchAnswer]),
             Handler = async context => await handler(context.ToActivityType<SearchActivity>()),
             Selector = activity =>
             {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Search/AnswerSearchActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Search/AnswerSearchActivity.cs
@@ -29,6 +29,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Search, SearchType.SearchAnswer]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<SearchActivity>());
@@ -53,6 +54,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Search, SearchType.SearchAnswer]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<SearchActivity>()),
             Selector = activity =>
             {
@@ -73,6 +75,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Search, SearchType.SearchAnswer]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<SearchActivity>()),
             Selector = activity =>
             {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Search/SearchActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Search/SearchActivity.cs
@@ -17,6 +17,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Search]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<SearchActivity>());
@@ -32,6 +33,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Search]),
             Handler = async context => await handler(context.ToActivityType<SearchActivity>()),
             Selector = activity => activity is SearchActivity
         });
@@ -43,6 +45,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Search]),
             Handler = async context => await handler(context.ToActivityType<SearchActivity>()),
             Selector = activity => activity is SearchActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Search/SearchActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Search/SearchActivity.cs
@@ -18,6 +18,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Search]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<SearchActivity>());
@@ -34,6 +35,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Search]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<SearchActivity>()),
             Selector = activity => activity is SearchActivity
         });
@@ -46,6 +48,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Search]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<SearchActivity>()),
             Selector = activity => activity is SearchActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Search/TypeaheadSearchActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Search/TypeaheadSearchActivity.cs
@@ -29,6 +29,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Search, SearchType.Typeahead]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<SearchActivity>());
@@ -53,6 +54,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Search, SearchType.Typeahead]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<SearchActivity>()),
             Selector = activity =>
             {
@@ -73,6 +75,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Search, SearchType.Typeahead]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<SearchActivity>()),
             Selector = activity =>
             {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Search/TypeaheadSearchActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Search/TypeaheadSearchActivity.cs
@@ -28,6 +28,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Search, SearchType.Typeahead]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<SearchActivity>());
@@ -51,6 +52,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Search, SearchType.Typeahead]),
             Handler = async context => await handler(context.ToActivityType<SearchActivity>()),
             Selector = activity =>
             {
@@ -70,6 +72,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Search, SearchType.Typeahead]),
             Handler = async context => await handler(context.ToActivityType<SearchActivity>()),
             Selector = activity =>
             {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/SignIn/TokenExchangeActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/SignIn/TokenExchangeActivity.cs
@@ -19,6 +19,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.TokenExchange]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<SignIn.TokenExchangeActivity>());
@@ -34,6 +35,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.TokenExchange]),
             Handler = async context => await handler(context.ToActivityType<SignIn.TokenExchangeActivity>()),
             Selector = activity => activity is SignIn.TokenExchangeActivity
         });
@@ -45,6 +47,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.TokenExchange]),
             Handler = async context => await handler(context.ToActivityType<SignIn.TokenExchangeActivity>()),
             Selector = activity => activity is SignIn.TokenExchangeActivity
         });
@@ -56,6 +59,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.TokenExchange]),
             Handler = async context => await handler(context.ToActivityType<SignIn.TokenExchangeActivity>()),
             Selector = activity => activity is SignIn.TokenExchangeActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/SignIn/TokenExchangeActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/SignIn/TokenExchangeActivity.cs
@@ -20,6 +20,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.TokenExchange]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<SignIn.TokenExchangeActivity>());
@@ -36,6 +37,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.TokenExchange]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<SignIn.TokenExchangeActivity>()),
             Selector = activity => activity is SignIn.TokenExchangeActivity
         });
@@ -48,6 +50,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.TokenExchange]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<SignIn.TokenExchangeActivity>()),
             Selector = activity => activity is SignIn.TokenExchangeActivity
         });
@@ -60,6 +63,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.TokenExchange]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<SignIn.TokenExchangeActivity>()),
             Selector = activity => activity is SignIn.TokenExchangeActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/SignIn/VerifyStateAcitivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/SignIn/VerifyStateAcitivity.cs
@@ -19,6 +19,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.VerifyState]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<SignIn.VerifyStateActivity>());
@@ -34,6 +35,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.VerifyState]),
             Handler = context => handler(context.ToActivityType<SignIn.VerifyStateActivity>()),
             Selector = activity => activity is SignIn.VerifyStateActivity
         });
@@ -45,6 +47,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.VerifyState]),
             Handler = async context => await handler(context.ToActivityType<SignIn.VerifyStateActivity>()),
             Selector = activity => activity is SignIn.VerifyStateActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/SignIn/VerifyStateAcitivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/SignIn/VerifyStateAcitivity.cs
@@ -20,6 +20,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.VerifyState]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<SignIn.VerifyStateActivity>());
@@ -36,6 +37,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.VerifyState]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = context => handler(context.ToActivityType<SignIn.VerifyStateActivity>()),
             Selector = activity => activity is SignIn.VerifyStateActivity
         });
@@ -48,6 +50,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.SignIn.VerifyState]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<SignIn.VerifyStateActivity>()),
             Selector = activity => activity is SignIn.VerifyStateActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tabs/FetchActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tabs/FetchActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Tabs.Fetch]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Tabs.FetchActivity>());
@@ -39,6 +40,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Tabs.Fetch]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<Tabs.FetchActivity>()),
             Selector = activity => activity is Tabs.FetchActivity
         });
@@ -51,6 +53,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Tabs.Fetch]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<Tabs.FetchActivity>()),
             Selector = activity => activity is Tabs.FetchActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tabs/FetchActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tabs/FetchActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Tabs.Fetch]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Tabs.FetchActivity>());
@@ -37,6 +38,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Tabs.Fetch]),
             Handler = async context => await handler(context.ToActivityType<Tabs.FetchActivity>()),
             Selector = activity => activity is Tabs.FetchActivity
         });
@@ -48,6 +50,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Tabs.Fetch]),
             Handler = async context => await handler(context.ToActivityType<Tabs.FetchActivity>()),
             Selector = activity => activity is Tabs.FetchActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tabs/SubmitActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tabs/SubmitActivity.cs
@@ -23,6 +23,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Tabs.Submit]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Tabs.SubmitActivity>());
@@ -39,6 +40,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Tabs.Submit]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<Tabs.SubmitActivity>()),
             Selector = activity => activity is Tabs.SubmitActivity
         });
@@ -51,6 +53,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Tabs.Submit]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<Tabs.SubmitActivity>()),
             Selector = activity => activity is Tabs.SubmitActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tabs/SubmitActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tabs/SubmitActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Tabs.Submit]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Tabs.SubmitActivity>());
@@ -37,6 +38,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Tabs.Submit]),
             Handler = async context => await handler(context.ToActivityType<Tabs.SubmitActivity>()),
             Selector = activity => activity is Tabs.SubmitActivity
         });
@@ -48,6 +50,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Tabs.Submit]),
             Handler = async context => await handler(context.ToActivityType<Tabs.SubmitActivity>()),
             Selector = activity => activity is Tabs.SubmitActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tasks/FetchActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tasks/FetchActivity.cs
@@ -19,6 +19,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Tasks.Fetch]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Tasks.FetchActivity>());
@@ -34,6 +35,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Tasks.Fetch]),
             Handler = async context => await handler(context.ToActivityType<Tasks.FetchActivity>()),
             Selector = activity => activity is Tasks.FetchActivity
         });
@@ -45,6 +47,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Tasks.Fetch]),
             Handler = async context => await handler(context.ToActivityType<Tasks.FetchActivity>()),
             Selector = activity => activity is Tasks.FetchActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tasks/FetchActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tasks/FetchActivity.cs
@@ -20,6 +20,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Tasks.Fetch]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Tasks.FetchActivity>());
@@ -36,6 +37,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Tasks.Fetch]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<Tasks.FetchActivity>()),
             Selector = activity => activity is Tasks.FetchActivity
         });
@@ -48,6 +50,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Tasks.Fetch]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<Tasks.FetchActivity>()),
             Selector = activity => activity is Tasks.FetchActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tasks/SubmitActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tasks/SubmitActivity.cs
@@ -20,6 +20,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Tasks.Submit]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Tasks.SubmitActivity>());
@@ -36,6 +37,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Tasks.Submit]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<Tasks.SubmitActivity>()),
             Selector = activity => activity is Tasks.SubmitActivity
         });
@@ -48,6 +50,7 @@ public static partial class AppInvokeActivityExtensions
         app.Router.Register(new Route()
         {
             Name = string.Join("/", [ActivityType.Invoke, Name.Tasks.Submit]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context => await handler(context.ToActivityType<Tasks.SubmitActivity>()),
             Selector = activity => activity is Tasks.SubmitActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tasks/SubmitActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Tasks/SubmitActivity.cs
@@ -19,6 +19,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Tasks.Submit]),
             Handler = async context =>
             {
                 await handler(context.ToActivityType<Tasks.SubmitActivity>());
@@ -34,6 +35,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Tasks.Submit]),
             Handler = async context => await handler(context.ToActivityType<Tasks.SubmitActivity>()),
             Selector = activity => activity is Tasks.SubmitActivity
         });
@@ -45,6 +47,7 @@ public static partial class AppInvokeActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Tasks.Submit]),
             Handler = async context => await handler(context.ToActivityType<Tasks.SubmitActivity>()),
             Selector = activity => activity is Tasks.SubmitActivity
         });

--- a/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageActivity.cs
@@ -41,6 +41,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.Message,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageActivity>());
@@ -57,6 +58,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.Message,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageActivity>());
@@ -81,6 +83,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.Message,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageActivity.cs
@@ -40,6 +40,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.Message,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageActivity>());
@@ -55,6 +56,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.Message,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageActivity>());
@@ -78,6 +80,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.Message,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageDeleteActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageDeleteActivity.cs
@@ -21,6 +21,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.MessageDelete,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageDeleteActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageDeleteActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageDeleteActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.MessageDelete,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageDeleteActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageReactionActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageReactionActivity.cs
@@ -50,6 +50,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.MessageReaction,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageReactionActivity>());
@@ -66,6 +67,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.MessageReaction,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageReactionActivity>());
@@ -90,6 +92,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.MessageReaction,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageReactionActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageReactionActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageReactionActivity.cs
@@ -49,6 +49,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.MessageReaction,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageReactionActivity>());
@@ -64,6 +65,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.MessageReaction,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageReactionActivity>());
@@ -87,6 +89,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.MessageReaction,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageReactionActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageUpdateActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageUpdateActivity.cs
@@ -21,6 +21,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.MessageUpdate,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageUpdateActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Messages/MessageUpdateActivity.cs
@@ -22,6 +22,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.MessageUpdate,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<MessageUpdateActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/TypingActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/TypingActivity.cs
@@ -18,6 +18,7 @@ public static partial class AppActivityExtensions
     {
         app.Router.Register(new Route()
         {
+            Name = ActivityType.Typing,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<TypingActivity>());

--- a/Libraries/Microsoft.Teams.Apps/Activities/TypingActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/TypingActivity.cs
@@ -19,6 +19,7 @@ public static partial class AppActivityExtensions
         app.Router.Register(new Route()
         {
             Name = ActivityType.Typing,
+            Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
                 await handler(context.ToActivityType<TypingActivity>());

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -150,7 +150,7 @@ public partial class App
     /// send an activity to the conversation
     /// </summary>
     /// <param name="activity">activity activity to send</param>
-    public async Task<T> Send<T>(string conversationId, T activity, ConversationType? conversationType, string? serviceUrl = null, CancellationToken cancellationToken = default) where T : IActivity
+    public async Task<T> Send<T>(string conversationId, T activity, ConversationType? conversationType = null, string? serviceUrl = null, CancellationToken cancellationToken = default) where T : IActivity
     {
         if (Id is null)
         {
@@ -197,7 +197,7 @@ public partial class App
     /// send a message activity to the conversation
     /// </summary>
     /// <param name="text">the text to send</param>
-    public async Task<MessageActivity> Send(string conversationId, string text, ConversationType? conversationType, string? serviceUrl = null, CancellationToken cancellationToken = default)
+    public async Task<MessageActivity> Send(string conversationId, string text, ConversationType? conversationType = null, string? serviceUrl = null, CancellationToken cancellationToken = default)
     {
         return await Send(conversationId, new MessageActivity(text), conversationType, serviceUrl, cancellationToken);
     }
@@ -206,7 +206,7 @@ public partial class App
     /// send a message activity with a card attachment
     /// </summary>
     /// <param name="card">the card to send as an attachment</param>
-    public async Task<MessageActivity> Send(string conversationId, Cards.AdaptiveCard card, ConversationType? conversationType, string? serviceUrl = null, CancellationToken cancellationToken = default)
+    public async Task<MessageActivity> Send(string conversationId, Cards.AdaptiveCard card, ConversationType? conversationType = null, string? serviceUrl = null, CancellationToken cancellationToken = default)
     {
         return await Send(conversationId, new MessageActivity().AddAttachment(card), conversationType, serviceUrl, cancellationToken);
     }

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -248,6 +248,7 @@ public partial class App
     /// <param name="cancellationToken">the cancellation token</param>
     private async Task<Response> Process(ISenderPlugin sender, ActivityEvent @event, CancellationToken cancellationToken = default)
     {
+        var start = DateTime.UtcNow;
         var routes = Router.Select(@event.Activity);
         JsonWebToken? userToken = null;
 
@@ -352,6 +353,9 @@ public partial class App
             var response = res is Response value
                 ? value
                 : new Response(System.Net.HttpStatusCode.OK, res);
+
+            response.Meta.Routes = i + 1;
+            response.Meta.Elapse = (DateTime.UtcNow - start).Milliseconds;
 
             await Events.Emit(
                 sender,

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -30,6 +30,7 @@ public partial class App
     /// </summary>
     public string? Name => BotToken?.AppDisplayName ?? GraphToken?.AppDisplayName;
 
+    public Status? Status { get; internal set; }
     public ILogger Logger { get; }
     public IStorage<string, object> Storage { get; }
     public ApiClient Api { get; }
@@ -85,6 +86,8 @@ public partial class App
         {
             return OnActivityEvent((ISenderPlugin)plugin, (ActivityEvent)@event, token);
         });
+
+        Status = Apps.Status.Ready;
     }
 
     /// <summary>
@@ -120,9 +123,12 @@ public partial class App
             {
                 await plugin.OnStart(this, cancellationToken);
             }
+
+            Status = Apps.Status.Started;
         }
         catch (Exception ex)
         {
+            Status = Apps.Status.Stopped;
             await Events.Emit(
                 null!,
                 EventType.Error,

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -284,8 +284,9 @@ public partial class App
         var i = -1;
         async Task<object?> Next(IContext<IActivity> context)
         {
+            if (i + 1 == routes.Count) return data;
+
             i++;
-            if (i == routes.Count) return data;
             var res = await routes[i].Invoke(context);
 
             if (res is not null)

--- a/Libraries/Microsoft.Teams.Apps/AppRouting.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppRouting.cs
@@ -48,7 +48,7 @@ public partial class App
 
         foreach (var method in methods)
         {
-            var attrs = method.GetCustomAttributes<Events.EventAttribute>(true);
+            var attrs = method.GetCustomAttributes<EventAttribute>(true);
 
             foreach (var attr in attrs)
             {

--- a/Libraries/Microsoft.Teams.Apps/Response.cs
+++ b/Libraries/Microsoft.Teams.Apps/Response.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -10,8 +11,34 @@ namespace Microsoft.Teams.Apps;
 /// <summary>
 /// Represents a response returned by a bot when it receives an activity.
 /// </summary>
+public class Response<T> : Response where T : notnull
+{
+    [JsonPropertyName("body")]
+    [JsonPropertyOrder(1)]
+    public new T Body { get; set; }
+
+    public Response(T body) : base(HttpStatusCode.OK)
+    {
+        Body = body;
+    }
+
+    public Response(HttpStatusCode status, T body) : base(status)
+    {
+        Body = body;
+    }
+}
+
+/// <summary>
+/// Represents a response returned by a bot when it receives an activity.
+/// </summary>
 public class Response
 {
+    /// <summary>
+    /// Response metadata containing information
+    /// about the handling of the activity
+    /// </summary>
+    public MetaData Meta { get; set; }
+
     /// <summary>
     /// The HTTP status code of the response.
     /// </summary>
@@ -26,8 +53,16 @@ public class Response
     [JsonPropertyOrder(1)]
     public object? Body { get; set; }
 
-    public Response(HttpStatusCode status, object? body = null)
+    public Response(object? body)
     {
+        Meta = [];
+        Status = HttpStatusCode.OK;
+        Body = body;
+    }
+
+    public Response(HttpStatusCode status = HttpStatusCode.OK, object? body = null)
+    {
+        Meta = [];
         Status = status;
         Body = body;
     }
@@ -40,19 +75,71 @@ public class Response
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         });
     }
-}
 
-/// <summary>
-/// Represents a response returned by a bot when it receives an activity.
-/// </summary>
-public class Response<T> : Response where T : notnull
-{
-    [JsonPropertyName("body")]
-    [JsonPropertyOrder(1)]
-    public new T Body { get; set; }
-
-    public Response(HttpStatusCode status, T body) : base(status, body)
+    /// <summary>
+    /// Response metadata containing information
+    /// about the handling of the activity
+    /// </summary>
+    public class MetaData : IDictionary<string, object?>
     {
-        Body = body;
+        /// <summary>
+        /// The number of activity routes that
+        /// were called while processing the activity
+        /// </summary>
+        [JsonIgnore]
+        public int Routes
+        {
+            get => GetOrDefault<int>("routes");
+            set => Data["routes"] = value;
+        }
+
+        /// <summary>
+        /// The elapse time in milliseconds
+        /// </summary>
+        [JsonIgnore]
+        public int Elapse
+        {
+            get => GetOrDefault<int>("elapse");
+            set => Data["elapse"] = value;
+        }
+
+        [JsonIgnore]
+        public ICollection<string> Keys => Data.Keys;
+
+        [JsonIgnore]
+        public ICollection<object?> Values => Data.Values;
+
+        [JsonIgnore]
+        public int Count => Data.Count;
+
+        [JsonIgnore]
+        public bool IsReadOnly => Data.IsReadOnly;
+
+        [JsonIgnore]
+        public object? this[string key]
+        {
+            get => Data[key];
+            set => Data[key] = value;
+        }
+
+        /// <summary>
+        /// Custom metadata
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object?> Data = new Dictionary<string, object?>();
+
+        public object? GetOrDefault(string key) => Data.ContainsKey(key) ? Data[key] : null;
+        public T? GetOrDefault<T>(string key) => Data.ContainsKey(key) ? (T?)Data[key] : default;
+        public void Add(string key, object? value) => Data.Add(key, value);
+        public bool ContainsKey(string key) => Data.ContainsKey(key);
+        public bool Remove(string key) => Data.Remove(key);
+        public bool TryGetValue(string key, out object? value) => Data.TryGetValue(key, out value);
+        public void Add(KeyValuePair<string, object?> item) => Data.Add(item);
+        public void Clear() => Data.Clear();
+        public bool Contains(KeyValuePair<string, object?> item) => Data.Contains(item);
+        public void CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex) => Data.CopyTo(array, arrayIndex);
+        public bool Remove(KeyValuePair<string, object?> item) => Data.Remove(item);
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => Data.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/Libraries/Microsoft.Teams.Apps/Routing/Route.cs
+++ b/Libraries/Microsoft.Teams.Apps/Routing/Route.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Teams.Apps.Routing;
 
 public interface IRoute
 {
+    public string? Name { get; }
+    public RouteType Type { get; }
+
     public bool Select(IActivity activity);
     public Task<object?> Invoke(IContext<IActivity> context);
 }
@@ -19,6 +22,7 @@ public interface IRoute
 public class Route : IRoute
 {
     public string? Name { get; set; }
+    public RouteType Type { get; set; } = RouteType.User;
     public required Func<IActivity, bool> Selector { get; set; }
     public required Func<IContext<IActivity>, Task<object?>> Handler { get; set; }
 
@@ -28,6 +32,8 @@ public class Route : IRoute
 
 public class AttributeRoute : IRoute
 {
+    public string? Name => Attr.Name?.Value;
+    public RouteType Type { get; set; } = RouteType.User;
     public required ActivityAttribute Attr { get; set; }
     public required MethodInfo Method { get; set; }
     public object? Object { get; set; }

--- a/Libraries/Microsoft.Teams.Apps/Routing/Route.cs
+++ b/Libraries/Microsoft.Teams.Apps/Routing/Route.cs
@@ -21,7 +21,7 @@ public interface IRoute
 
 public class Route : IRoute
 {
-    public string? Name { get; set; }
+    public required string Name { get; set; }
     public RouteType Type { get; set; } = RouteType.User;
     public required Func<IActivity, bool> Selector { get; set; }
     public required Func<IContext<IActivity>, Task<object?>> Handler { get; set; }

--- a/Libraries/Microsoft.Teams.Apps/Routing/RouteType.cs
+++ b/Libraries/Microsoft.Teams.Apps/Routing/RouteType.cs
@@ -1,0 +1,10 @@
+namespace Microsoft.Teams.Apps.Routing;
+
+/// <summary>
+/// who registered the route
+/// </summary>
+public enum RouteType
+{
+    System,
+    User,
+}

--- a/Libraries/Microsoft.Teams.Apps/Routing/Router.cs
+++ b/Libraries/Microsoft.Teams.Apps/Routing/Router.cs
@@ -30,6 +30,16 @@ public class Router : IRouter
 
     public IRouter Register(IRoute route)
     {
+        if (route.Type == RouteType.User)
+        {
+            var i = _routes.FindIndex(r => r.Name == route.Name && r.Type == RouteType.System);
+
+            if (i > -1)
+            {
+                _routes.RemoveAt(i);
+            }
+        }
+
         _routes.Add(route);
         return this;
     }

--- a/Libraries/Microsoft.Teams.Apps/Routing/Router.cs
+++ b/Libraries/Microsoft.Teams.Apps/Routing/Router.cs
@@ -48,20 +48,21 @@ public class Router : IRouter
     {
         return Register(new Route()
         {
+            Name = "activity",
             Selector = _ => true,
             Handler = handler
         });
     }
 
-    public IRouter Register(string? name, Func<IContext<IActivity>, Task<object?>> handler)
+    public IRouter Register(string name, Func<IContext<IActivity>, Task<object?>> handler)
     {
         return Register(new Route()
         {
             Name = name,
             Handler = handler,
-            Selector = (activity) =>
+            Selector = activity =>
             {
-                if (name is null || name == "activity") return true;
+                if (name == "activity") return true;
                 if (activity.Type.Equals(name)) return true;
                 return false;
             }

--- a/Libraries/Microsoft.Teams.Apps/Status.cs
+++ b/Libraries/Microsoft.Teams.Apps/Status.cs
@@ -1,0 +1,12 @@
+namespace Microsoft.Teams.Apps;
+
+/// <summary>
+/// Represents the current status
+/// of an App instance
+/// </summary>
+public enum Status
+{
+    Ready,
+    Started,
+    Stopped,
+}

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Graph/ContextExtensions.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Graph/ContextExtensions.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Teams.Apps;
+﻿using Microsoft.Graph;
 using Microsoft.Teams.Api.Activities;
-using Microsoft.Graph;
+using Microsoft.Teams.Apps;
 
 namespace Microsoft.Teams.Extensions.Graph;
 

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.Stream.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.Stream.cs
@@ -7,6 +7,7 @@ using Microsoft.Teams.Api;
 using Microsoft.Teams.Api.Activities;
 using Microsoft.Teams.Api.Entities;
 using Microsoft.Teams.Apps.Plugins;
+
 using static Microsoft.Teams.Common.Extensions.TaskExtensions;
 
 namespace Microsoft.Teams.Plugins.AspNetCore;
@@ -184,7 +185,7 @@ public partial class AspNetCorePlugin
                 {
                     _timeout = new Timer(_ =>
                     {
-                       _ = Flush();
+                        _ = Flush();
                     }, null, 500, Timeout.Infinite);
                 }
 

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Teams.Api.Activities;
-using Microsoft.Teams.Api.Auth;
 using Microsoft.Teams.Api.Clients;
 using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Events;
@@ -21,9 +20,6 @@ public partial class AspNetCorePlugin : ISenderPlugin, IAspNetCorePlugin
 
     [Dependency]
     public IHttpClient Client { get; set; }
-
-    [Dependency("BotToken", optional: true)]
-    public IToken? BotToken { get; set; }
 
     public event EventFunction Events;
 

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.cs
@@ -27,13 +27,6 @@ public partial class AspNetCorePlugin : ISenderPlugin, IAspNetCorePlugin
 
     public event EventFunction Events;
 
-    private readonly IServiceProvider _services;
-
-    public AspNetCorePlugin(IServiceProvider provider)
-    {
-        _services = provider;
-    }
-
     public IApplicationBuilder Configure(IApplicationBuilder builder)
     {
         return builder;

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.cs
@@ -1,4 +1,4 @@
-﻿﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Builder;

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Controllers/MessageController.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Controllers/MessageController.cs
@@ -48,6 +48,14 @@ public class MessageController : ControllerBase
             Services = HttpContext.RequestServices
         }, _lifetime.ApplicationStopping);
 
+        // convert response metadata to headers
+        foreach (var (key, value) in res.Meta)
+        {
+            var str = value?.ToString();
+            if (string.IsNullOrEmpty(str)) continue;
+            Response.Headers.Append($"X-Teams-{char.ToUpper(key[0]) + key[1..]}", str);
+        }
+
         return Results.Json(res.Body, statusCode: (int)res.Status);
     }
 }

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.External/Microsoft.Teams.Plugins.External.Mcp/Microsoft.Teams.Plugins.External.Mcp.csproj
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.External/Microsoft.Teams.Plugins.External.Mcp/Microsoft.Teams.Plugins.External.Mcp.csproj
@@ -25,8 +25,8 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.10" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.1.0-preview.10" />
+    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.*" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Samples.BotBuilder/appsettings.Development.json
+++ b/Samples/Samples.BotBuilder/appsettings.Development.json
@@ -3,6 +3,10 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "Microsoft.Teams": {
+      "Enable": "*",
+      "Level": "debug"
     }
   },
   "MicrosoftAppType": "",

--- a/Samples/Samples.BotBuilder/appsettings.json
+++ b/Samples/Samples.BotBuilder/appsettings.json
@@ -3,6 +3,10 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "Microsoft.Teams": {
+      "Enable": "*",
+      "Level": "debug"
     }
   },
   "AllowedHosts": "*",

--- a/Samples/Samples.Echo/appsettings.Development.json
+++ b/Samples/Samples.Echo/appsettings.Development.json
@@ -3,6 +3,14 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "Microsoft.Teams": {
+      "Enable": "*",
+      "Level": "debug"
     }
+  },
+  "Teams": {
+    "ClientId": "",
+    "ClientSecret": ""
   }
 }

--- a/Samples/Samples.Echo/appsettings.json
+++ b/Samples/Samples.Echo/appsettings.json
@@ -3,7 +3,15 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "Microsoft.Teams": {
+      "Enable": "*",
+      "Level": "debug"
     }
+  },
+  "Teams": {
+    "ClientId": "",
+    "ClientSecret": ""
   },
   "AllowedHosts": "*"
 }

--- a/Samples/Samples.Graph/Program.cs
+++ b/Samples/Samples.Graph/Program.cs
@@ -2,8 +2,8 @@ using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Activities;
 using Microsoft.Teams.Apps.Events;
 using Microsoft.Teams.Apps.Extensions;
-using Microsoft.Teams.Plugins.AspNetCore.Extensions;
 using Microsoft.Teams.Extensions.Graph;
+using Microsoft.Teams.Plugins.AspNetCore.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/Samples/Samples.Graph/appsettings.Development.json
+++ b/Samples/Samples.Graph/appsettings.Development.json
@@ -3,6 +3,10 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "Microsoft.Teams": {
+      "Enable": "*",
+      "Level": "debug"
     }
   },
   "AllowedHosts": "*",

--- a/Samples/Samples.Graph/appsettings.json
+++ b/Samples/Samples.Graph/appsettings.json
@@ -3,6 +3,10 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "Microsoft.Teams": {
+      "Enable": "*",
+      "Level": "debug"
     }
   },
   "AllowedHosts": "*",

--- a/Samples/Samples.Lights/appsettings.Development.json
+++ b/Samples/Samples.Lights/appsettings.Development.json
@@ -3,6 +3,18 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "Microsoft.Teams": {
+      "Enable": "*",
+      "Level": "debug"
     }
+  },
+  "Teams": {
+    "ClientId": "",
+    "ClientSecret": ""
+  },
+  "OpenAI": {
+    "Model": "",
+    "ApiKey": ""
   }
 }

--- a/Samples/Samples.Lights/appsettings.json
+++ b/Samples/Samples.Lights/appsettings.json
@@ -3,7 +3,19 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "Microsoft.Teams": {
+      "Enable": "*",
+      "Level": "debug"
     }
+  },
+  "Teams": {
+    "ClientId": "",
+    "ClientSecret": ""
+  },
+  "OpenAI": {
+    "Model": "",
+    "ApiKey": ""
   },
   "AllowedHosts": "*"
 }

--- a/Samples/Samples.Mcp/appsettings.Development.json
+++ b/Samples/Samples.Mcp/appsettings.Development.json
@@ -3,6 +3,14 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "Microsoft.Teams": {
+      "Enable": "*",
+      "Level": "debug"
     }
+  },
+  "Teams": {
+    "ClientId": "",
+    "ClientSecret": ""
   }
 }

--- a/Samples/Samples.Mcp/appsettings.json
+++ b/Samples/Samples.Mcp/appsettings.json
@@ -3,7 +3,15 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "Microsoft.Teams": {
+      "Enable": "*",
+      "Level": "debug"
     }
+  },
+  "Teams": {
+    "ClientId": "",
+    "ClientSecret": ""
   },
   "AllowedHosts": "*"
 }

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/ActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/ActivityTests.cs
@@ -36,6 +36,7 @@ public class ActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(1, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(2, res.Meta.Routes);
     }
 
     [Fact]
@@ -55,6 +56,7 @@ public class ActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(1, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(2, res.Meta.Routes);
     }
 
     [Fact]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelCreatedActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelCreatedActivityTests.cs
@@ -49,6 +49,7 @@ public class ChannelCreatedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class ChannelCreatedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelDeletedActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelDeletedActivityTests.cs
@@ -49,6 +49,7 @@ public class ChannelDeletedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class ChannelDeletedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelMemberAddedActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelMemberAddedActivityTests.cs
@@ -49,6 +49,7 @@ public class ChannelMemberAddedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class ChannelMemberAddedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelMemberRemovedActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelMemberRemovedActivityTests.cs
@@ -49,6 +49,7 @@ public class ChannelMemberRemovedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class ChannelMemberRemovedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelRenamedActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelRenamedActivityTests.cs
@@ -49,6 +49,7 @@ public class ChannelRenamedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class ChannelRenamedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelRestoredActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelRestoredActivityTests.cs
@@ -49,6 +49,7 @@ public class ChannelRestoredActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class ChannelRestoredActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelSharedActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelSharedActivityTests.cs
@@ -49,6 +49,7 @@ public class ChannelSharedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class ChannelSharedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelUnSharedActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Channels/ChannelUnSharedActivityTests.cs
@@ -49,6 +49,7 @@ public class ChannelUnSharedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class ChannelUnSharedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/ConversationEndActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/ConversationEndActivityTests.cs
@@ -42,6 +42,7 @@ public class ConversationEndActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -61,6 +62,7 @@ public class ConversationEndActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/ConversationUpdateActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/ConversationUpdateActivityTests.cs
@@ -42,6 +42,7 @@ public class ConversationUpdateActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -61,6 +62,7 @@ public class ConversationUpdateActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Members/MembersAddedActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Members/MembersAddedActivityTests.cs
@@ -46,6 +46,7 @@ public class MembersAddedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -68,6 +69,7 @@ public class MembersAddedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Members/MembersRemovedActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Members/MembersRemovedActivityTests.cs
@@ -46,6 +46,7 @@ public class MembersRemovedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -68,6 +69,7 @@ public class MembersRemovedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Teams/TeamArchivedActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Teams/TeamArchivedActivityTests.cs
@@ -49,6 +49,7 @@ public class TeamArchivedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class TeamArchivedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Teams/TeamDeletedActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Teams/TeamDeletedActivityTests.cs
@@ -49,6 +49,7 @@ public class TeamDeletedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class TeamDeletedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Teams/TeamRenamedActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Teams/TeamRenamedActivityTests.cs
@@ -49,6 +49,7 @@ public class TeamRenamedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class TeamRenamedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Teams/TeamRestoredActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Teams/TeamRestoredActivityTests.cs
@@ -49,6 +49,7 @@ public class TeamRestoredActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class TeamRestoredActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Teams/TeamUnArchivedActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Conversations/Teams/TeamUnArchivedActivityTests.cs
@@ -49,6 +49,7 @@ public class TeamUnArchivedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class TeamUnArchivedActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Installs/InstallActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Installs/InstallActivityTests.cs
@@ -46,6 +46,7 @@ public class InstallActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -69,6 +70,7 @@ public class InstallActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Installs/InstallUpdateActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Installs/InstallUpdateActivityTests.cs
@@ -45,6 +45,7 @@ public class InstallUpdateActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -64,6 +65,7 @@ public class InstallUpdateActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Installs/UnInstallActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Installs/UnInstallActivityTests.cs
@@ -46,6 +46,7 @@ public class UnInstallActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -69,6 +70,7 @@ public class UnInstallActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/AdaptiveCards/ActionActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/AdaptiveCards/ActionActivityTests.cs
@@ -57,6 +57,7 @@ public class AdaptiveCardsActionActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -77,6 +78,7 @@ public class AdaptiveCardsActionActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/Configs/FetchActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/Configs/FetchActivityTests.cs
@@ -46,6 +46,7 @@ public class ConfigsFetchActionActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -66,6 +67,7 @@ public class ConfigsFetchActionActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/Configs/SubmitActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/Configs/SubmitActivityTests.cs
@@ -46,6 +46,7 @@ public class ConfigsSubmitActionActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -66,6 +67,7 @@ public class ConfigsSubmitActionActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/SearchActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/SearchActivityTests.cs
@@ -55,6 +55,7 @@ public class SearchActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -100,6 +101,7 @@ public class SearchActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(3, calls);
         Assert.Equal(2, _controller.Calls);
+        Assert.Equal(5, res.Meta.Routes);
     }
 
     [Fact]
@@ -145,6 +147,7 @@ public class SearchActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(3, calls);
         Assert.Equal(2, _controller.Calls);
+        Assert.Equal(5, res.Meta.Routes);
     }
 
     [Fact]
@@ -165,6 +168,7 @@ public class SearchActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [Fact]
@@ -208,6 +212,7 @@ public class SearchActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(2, _controller.Calls);
+        Assert.Equal(4, res.Meta.Routes);
     }
 
     [Fact]
@@ -251,6 +256,7 @@ public class SearchActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(2, _controller.Calls);
+        Assert.Equal(4, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Messages/MessageActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Messages/MessageActivityTests.cs
@@ -43,6 +43,7 @@ public class MessageActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -62,6 +63,7 @@ public class MessageActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Messages/MessageDeleteActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Messages/MessageDeleteActivityTests.cs
@@ -42,6 +42,7 @@ public class MessageDeleteActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -61,6 +62,7 @@ public class MessageDeleteActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Messages/MessageReactionActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Messages/MessageReactionActivityTests.cs
@@ -44,6 +44,7 @@ public class MessageReactionActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(2, _controller.Calls);
+        Assert.Equal(4, res.Meta.Routes);
     }
 
     [Fact]
@@ -63,6 +64,7 @@ public class MessageReactionActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [Fact]
@@ -101,6 +103,7 @@ public class MessageReactionActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(3, calls);
         Assert.Equal(2, _controller.Calls);
+        Assert.Equal(5, res.Meta.Routes);
     }
 
     [Fact]
@@ -139,6 +142,7 @@ public class MessageReactionActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(3, calls);
         Assert.Equal(2, _controller.Calls);
+        Assert.Equal(5, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Messages/MessageUpdateActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Messages/MessageUpdateActivityTests.cs
@@ -43,6 +43,7 @@ public class MessageUpdateActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -62,6 +63,7 @@ public class MessageUpdateActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/TypingActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/TypingActivityTests.cs
@@ -43,6 +43,7 @@ public class TypingActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(1, _controller.Calls);
+        Assert.Equal(3, res.Meta.Routes);
     }
 
     [Fact]
@@ -62,6 +63,7 @@ public class TypingActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(0, calls);
         Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
     }
 
     [TeamsController]

--- a/Tests/Microsoft.Teams.Apps.Tests/Routing/RouterTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Routing/RouterTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.Teams.Api.Activities;
+using Microsoft.Teams.Apps.Routing;
+
+namespace Micosoft.Teams.Apps.Tests.Routing;
+
+public class RouterTests
+{
+    private readonly Router _router;
+
+    public RouterTests()
+    {
+        _router = new();
+    }
+
+    [Fact]
+    public void Should_Register_Routes()
+    {
+        _router.Register(ActivityType.Message, ctx =>
+        {
+            return Task.FromResult<object?>(null);
+        });
+
+        _router.Register(new Route()
+        {
+            Name = ActivityType.Message,
+            Selector = activity =>
+            {
+                if (activity is MessageActivity message)
+                {
+                    return message.Text == "hi";
+                }
+
+                return false;
+            },
+            Handler = ctx =>
+            {
+                return Task.FromResult<object?>(null);
+            }
+        });
+
+        Assert.Single(_router.Select(new MessageActivity()));
+        Assert.Equal(2, _router.Select(new MessageActivity("hi")).Count);
+    }
+
+    [Fact]
+    public void Should_Override_System_Route()
+    {
+        _router.Register(new Route()
+        {
+            Name = ActivityType.Message,
+            Type = RouteType.System,
+            Selector = activity =>
+            {
+                if (activity is MessageActivity message)
+                {
+                    return message.Text == "hi";
+                }
+
+                return false;
+            },
+            Handler = ctx =>
+            {
+                return Task.FromResult<object?>(null);
+            }
+        });
+
+        _router.Register(ActivityType.Message, ctx =>
+        {
+            return Task.FromResult<object?>(null);
+        });
+
+        Assert.Single(_router.Select(new MessageActivity()));
+        Assert.Single(_router.Select(new MessageActivity("hi")));
+    }
+}

--- a/Tests/Microsoft.Teams.Common.Tests/Logging/ConsoleLoggerTests.cs
+++ b/Tests/Microsoft.Teams.Common.Tests/Logging/ConsoleLoggerTests.cs
@@ -1,5 +1,5 @@
-﻿using System.Text;
-using System.Reflection;
+﻿using System.Reflection;
+using System.Text;
 
 using Microsoft.Teams.Common.Logging;
 using Microsoft.Teams.Common.Text;


### PR DESCRIPTION
this PR includes changes to ensure:

1. app tokens that expire are refreshed as needed
2. default system registered routes (for now token exchange/verify state), i.e. activity routes registered by the app as a default, should be replaced when the developer registers their own to allow customization.
3. adds metadata to the apps `Response` object, giving the caller insight into how many routes were invoked and elapse time (among others). (this is also to support Agents SDK integration)