### PR TITLE
Entra token validation for remote function calling

### DIFF
--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/HostApplicationBuilder.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/HostApplicationBuilder.cs
@@ -104,6 +104,12 @@ public static class HostApplicationBuilderExtensions
         public const string AuthorizationPolicy = "TeamsJWTPolicy";
     }
 
+    public static class EntraTokenAuthConstants
+    {
+        public const string AuthenticationScheme = "EntraTokenJWTScheme";
+        public const string AuthorizationPolicy = "EntraTokenJWTPolicy"; 
+    }
+
     /// <summary>
     /// adds authentication and authorization to validate incoming Teams tokens
     /// </summary>
@@ -120,20 +126,27 @@ public static class HostApplicationBuilderExtensions
         var teamsValidationSettings = new TeamsValidationSettings();
         teamsValidationSettings.AddDefaultAudiences(settings.ClientId);
 
-        builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-        .AddJwtBearer(TeamsTokenAuthConstants.AuthenticationScheme, options =>
-        {
-            TokenValidator.ConfigureValidation(options, teamsValidationSettings.Issuers, teamsValidationSettings.Audiences, teamsValidationSettings.OpenIdMetadataUrl);
-        });
+        builder.Services.
+            AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(TeamsTokenAuthConstants.AuthenticationScheme, options =>
+            {
+                TokenValidator.ConfigureValidation(options, teamsValidationSettings.Issuers, teamsValidationSettings.Audiences, teamsValidationSettings.OpenIdMetadataUrl);
+            })
+            .AddJwtBearer(EntraTokenAuthConstants.AuthenticationScheme, options =>
+            {
+                TokenValidator.ConfigureValidation(options, teamsValidationSettings.GetValidIssuersForTenant(settings.TenantId), teamsValidationSettings.Audiences, teamsValidationSettings.GetTenantSpecificOpenIdMetadataUrl(settings.TenantId));
+            });
+
 
         // add [Authorize(Policy="..")] support for endpoints
         builder.Services.AddAuthorization(options =>
         {
+            // token validation policy for SMBA tokens
             options.AddPolicy(TeamsTokenAuthConstants.AuthorizationPolicy, policy =>
             {
                 if (skipAuth)
                 {
-                    // bypass authentication
+                    // bypass authentication when running in dev tools
                     policy.RequireAssertion(_ => true);
                 }
                 else
@@ -141,6 +154,13 @@ public static class HostApplicationBuilderExtensions
                     policy.AddAuthenticationSchemes(TeamsTokenAuthConstants.AuthenticationScheme);
                     policy.RequireAuthenticatedUser();
                 }
+            });
+
+            // token validation policy for Entra tokens, used when tab apps invoke remote functions
+            options.AddPolicy(EntraTokenAuthConstants.AuthorizationPolicy, policy =>
+            {
+                policy.AddAuthenticationSchemes(EntraTokenAuthConstants.AuthenticationScheme);
+                policy.RequireAuthenticatedUser();
             });
         });
 

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/TeamsValidationSettings.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/TeamsValidationSettings.cs
@@ -23,4 +23,19 @@ public class TeamsValidationSettings
         if (ClientId is not null && !Audiences.Contains(apiAudience))
             Audiences.Add(apiAudience);
     }
+
+    public IEnumerable<string> GetValidIssuersForTenant(string? tenantId) 
+    {
+        var validIssuers = new List<string>();
+        if (!string.IsNullOrEmpty(tenantId))
+        {
+            validIssuers.Add($"https://login.microsoftonline.com/{tenantId}/");
+        }
+        return validIssuers;
+    }
+
+    public string GetTenantSpecificOpenIdMetadataUrl(string? tenantId)
+    {
+        return $"https://login.microsoftonline.com/{tenantId ?? "common"}/v2.0/.well-known/openid-configuration";
+    }
 }

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/TokenValidator.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/TokenValidator.cs
@@ -19,7 +19,7 @@ public static class TokenValidator
 
         options.TokenValidationParameters = new TokenValidationParameters
         {
-            ValidateIssuer = true,
+            ValidateIssuer = validIssuers.Any(),
             ValidateAudience = true,
             ValidateLifetime = true,
             ValidateIssuerSigningKey = true,

--- a/Microsoft.Teams.sln
+++ b/Microsoft.Teams.sln
@@ -65,6 +65,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Teams.Extensions.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Tab", "Samples\Samples.Tab\Samples.Tab.csproj", "{1F168FCB-B034-43E3-B27C-C0C2E0D23D89}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Teams.Plugins.AspNetCore.Tests", "Tests\Microsoft.Teams.Plugins.AspNetCore.Tests\Microsoft.Teams.Plugins.AspNetCore.Tests.csproj", "{D256BF45-8DBE-751B-850F-E4A19BB2D369}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -375,6 +377,18 @@ Global
 		{1F168FCB-B034-43E3-B27C-C0C2E0D23D89}.Release|x64.Build.0 = Release|Any CPU
 		{1F168FCB-B034-43E3-B27C-C0C2E0D23D89}.Release|x86.ActiveCfg = Release|Any CPU
 		{1F168FCB-B034-43E3-B27C-C0C2E0D23D89}.Release|x86.Build.0 = Release|Any CPU
+		{D256BF45-8DBE-751B-850F-E4A19BB2D369}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D256BF45-8DBE-751B-850F-E4A19BB2D369}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D256BF45-8DBE-751B-850F-E4A19BB2D369}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D256BF45-8DBE-751B-850F-E4A19BB2D369}.Debug|x64.Build.0 = Debug|Any CPU
+		{D256BF45-8DBE-751B-850F-E4A19BB2D369}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D256BF45-8DBE-751B-850F-E4A19BB2D369}.Debug|x86.Build.0 = Debug|Any CPU
+		{D256BF45-8DBE-751B-850F-E4A19BB2D369}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D256BF45-8DBE-751B-850F-E4A19BB2D369}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D256BF45-8DBE-751B-850F-E4A19BB2D369}.Release|x64.ActiveCfg = Release|Any CPU
+		{D256BF45-8DBE-751B-850F-E4A19BB2D369}.Release|x64.Build.0 = Release|Any CPU
+		{D256BF45-8DBE-751B-850F-E4A19BB2D369}.Release|x86.ActiveCfg = Release|Any CPU
+		{D256BF45-8DBE-751B-850F-E4A19BB2D369}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -408,6 +422,7 @@ Global
 		{DDDCE455-DF26-5A96-3944-23439F0FA243} = {E2648928-28DE-6B24-129A-26A0E8B5B70E}
 		{7F2AC320-D203-B440-D85B-BB7A1AE3AA94} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{1F168FCB-B034-43E3-B27C-C0C2E0D23D89} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
+		{D256BF45-8DBE-751B-850F-E4A19BB2D369} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {378263F2-C2B2-4DB1-83CF-CA228AF03ABF}


### PR DESCRIPTION
This change adds Entra token validation for when tab apps invoke remote functions implemented in the .NET library.

How tested:
 - Happy test is fine: in a test app hosted in Teams, I can call a remote function with a bearer token, and the token is validated & the call succeeds
 - If I pass an invalid or unsuitable token, the call is blocked with a 401. 