### PR TITLE
[Bug] Add singleton factory method for scoped prompt

### DIFF
--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Hosting/Microsoft.Teams.AI.Models.OpenAI.Extensions/ServiceCollection.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Hosting/Microsoft.Teams.AI.Models.OpenAI.Extensions/ServiceCollection.cs
@@ -73,6 +73,20 @@ public static class ServiceCollectionExtensions
             return OpenAIChatPrompt.From(model, value, (options ?? new()).WithLogger(logger));
         });
 
-        return collection.AddScoped<IChatPrompt>(provider => provider.GetRequiredService<OpenAIChatPrompt>());
+        collection.AddScoped<IChatPrompt>(provider => provider.GetRequiredService<OpenAIChatPrompt>());
+
+        // Add a singleton factory for creating scoped prompts 
+        // required when added as dependency to singleton controllers
+        collection.AddSingleton<Func<OpenAIChatPrompt>>(provider =>
+        {
+            var serviceProvider = provider;
+            return () =>
+            {
+                var scope = serviceProvider.CreateScope();
+                return scope.ServiceProvider.GetRequiredService<OpenAIChatPrompt>();
+            };
+        });
+
+        return collection;
     }
 }

--- a/Samples/Samples.Lights/Controller.cs
+++ b/Samples/Samples.Lights/Controller.cs
@@ -9,7 +9,7 @@ using Microsoft.Teams.Apps.Annotations;
 namespace Samples.Lights;
 
 [TeamsController]
-public class Controller(OpenAIChatPrompt _prompt)
+public class Controller(Func<OpenAIChatPrompt> _promptFactory)
 {
     [Message("/history")]
     public async Task OnHistory(IContext<MessageActivity> context)
@@ -26,7 +26,7 @@ public class Controller(OpenAIChatPrompt _prompt)
     {
         var state = State.From(context);
 
-        await _prompt.Send(context.Activity.Text, new() { Messages = state.Messages }, (chunk) => Task.Run(() =>
+        await _promptFactory().Send(context.Activity.Text, new() { Messages = state.Messages }, (chunk) => Task.Run(() =>
         {
             context.Stream.Emit(chunk);
         }), context.CancellationToken);

--- a/Samples/Samples.Lights/Properties/launchSettings.json
+++ b/Samples/Samples.Lights/Properties/launchSettings.json
@@ -7,7 +7,7 @@
       "launchBrowser": true,
       "applicationUrl": "http://localhost:5298",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Local"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "https": {
@@ -16,7 +16,7 @@
       "launchBrowser": true,
       "applicationUrl": "https://localhost:7110;http://localhost:5298",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Local"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }


### PR DESCRIPTION
Issue : https://github.com/microsoft/teams.net/issues/109

Problem:
In `Samples.Lights.`
`Controller` should be registered as a singleton.
`LightsPrompt` is a scoped service because it varies per request (it maintains state that is accessed via request context).
ASP.NET Core DI forbids injecting a scoped service into a singleton.

Solution: 
A singleton factory is added that creates a new scope and resolves OpenAIChatPrompt from that scope:
```
 var scope = serviceProvider.CreateScope();
 return scope.ServiceProvider.GetRequiredService<OpenAIChatPrompt>();
```
This singleton factory is injected into Controller