### PR TITLE
[Bug] Fix redundant/circular dependency 

### DIFF
--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Hosting/Microsoft.Teams.AI.Models.OpenAI.Extensions/ServiceCollection.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Hosting/Microsoft.Teams.AI.Models.OpenAI.Extensions/ServiceCollection.cs
@@ -18,7 +18,6 @@ public static class ServiceCollectionExtensions
         collection.AddSingleton(model);
         collection.AddSingleton<IChatModel<ChatCompletionOptions>, OpenAIChatModel>(provider => provider.GetRequiredService<OpenAIChatModel>());
         collection.AddSingleton(prompt);
-        collection.AddSingleton(provider => provider.GetRequiredService<OpenAIChatPrompt>());
         return collection.AddSingleton<IChatPrompt>(provider => provider.GetRequiredService<OpenAIChatPrompt>());
     }
 
@@ -30,7 +29,6 @@ public static class ServiceCollectionExtensions
         collection.AddSingleton(chatModel);
         collection.AddSingleton<IChatModel<ChatCompletionOptions>, OpenAIChatModel>(provider => provider.GetRequiredService<OpenAIChatModel>());
         collection.AddSingleton(prompt);
-        collection.AddSingleton(provider => provider.GetRequiredService<OpenAIChatPrompt>());
         return collection.AddSingleton<IChatPrompt>(provider => provider.GetRequiredService<OpenAIChatPrompt>());
     }
 


### PR DESCRIPTION
Issue : https://github.com/microsoft/teams.net/issues/113
`collection.AddSingleton(prompt)` registers an instance of `OpenAIChatPrompt` in the DI container.
`collection.AddSingleton(provider => provider.GetRequiredService<OpenAIChatPrompt>())` tries to register a factory that resolves the exact same type .

Leads to app hanging during run time