### PR TITLE
[fix] When client id is empty, skip auth correctly

### DIFF
--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/HostApplicationBuilder.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/HostApplicationBuilder.cs
@@ -112,13 +112,11 @@ public static class HostApplicationBuilderExtensions
     {
         var settings = builder.Configuration.GetTeams();
 
-        if (string.IsNullOrEmpty(settings.ClientId))
-        {
-            return builder;
-        }
-
         var teamsValidationSettings = new TeamsValidationSettings();
-        teamsValidationSettings.AddDefaultAudiences(settings.ClientId);
+        if (!string.IsNullOrEmpty(settings.ClientId))
+        {
+            teamsValidationSettings.AddDefaultAudiences(settings.ClientId);
+        }
 
         builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         .AddJwtBearer(TeamsTokenAuthConstants.AuthenticationScheme, options =>
@@ -131,7 +129,7 @@ public static class HostApplicationBuilderExtensions
         {
             options.AddPolicy(TeamsTokenAuthConstants.AuthorizationPolicy, policy =>
             {
-                if (skipAuth)
+                if (skipAuth || string.IsNullOrEmpty(settings.ClientId))
                 {
                     // bypass authentication
                     policy.RequireAssertion(_ => true);

--- a/Samples/Samples.Echo/Properties/launchSettings.json
+++ b/Samples/Samples.Echo/Properties/launchSettings.json
@@ -7,7 +7,7 @@
       "launchBrowser": false,
       "applicationUrl": "http://localhost:5298",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Local"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "https": {
@@ -16,7 +16,7 @@
       "launchBrowser": false,
       "applicationUrl": "https://localhost:7265;http://localhost:5298",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Local"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }


### PR DESCRIPTION
Currently, if ClientID is empty, we do not register the auth policy or scheme, resulting in Policy not found errors at the endpoint.

We now register the policy but bypass authentication if clientID is empty