### PR TITLE
Bump to `v2.0.0-preview.13`

### DIFF
--- a/Libraries/Directory.Build.props
+++ b/Libraries/Directory.Build.props
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Product>Microsoft Teams SDK</Product>
-    <Version>2.0.0-preview.12</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
@@ -18,7 +17,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
-
   <PropertyGroup>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>$([MSBuild]::GetPathOfFileAbove('key.snk'))</AssemblyOriginatorKeyFile>

--- a/Libraries/Directory.Build.targets
+++ b/Libraries/Directory.Build.targets
@@ -1,0 +1,14 @@
+<Project>
+  <Choose>
+    <When Condition="$([System.String]::Copy('$(PackageId)').StartsWith('Microsoft.Teams.Plugins.External.Mcp'))">
+      <PropertyGroup>
+        <Version>2.0.0-preview.13</Version>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <Version>2.0.0-preview.13</Version>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+</Project>

--- a/Libraries/Directory.Build.targets
+++ b/Libraries/Directory.Build.targets
@@ -2,13 +2,13 @@
   <Choose>
     <When Condition="$([System.String]::Copy('$(PackageId)').StartsWith('Microsoft.Teams.Plugins.External.Mcp'))">
       <PropertyGroup>
-        <!--- package version for `Microsoft.Teams.Plugins.External.Mcp` and `Microsoft.Teams.Plugins.External.McpClient` packages --->
+        <!-- package version for `Microsoft.Teams.Plugins.External.Mcp` and `Microsoft.Teams.Plugins.External.McpClient` packages -->
         <Version>2.0.0-preview.13</Version>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <!--- package version for all other packages --->
+        <!-- package version for all other packages -->
         <Version>2.0.0-preview.13</Version>
       </PropertyGroup>
     </Otherwise>

--- a/Libraries/Directory.Build.targets
+++ b/Libraries/Directory.Build.targets
@@ -2,11 +2,13 @@
   <Choose>
     <When Condition="$([System.String]::Copy('$(PackageId)').StartsWith('Microsoft.Teams.Plugins.External.Mcp'))">
       <PropertyGroup>
+        <!--- package version for `Microsoft.Teams.Plugins.External.Mcp` and `Microsoft.Teams.Plugins.External.McpClient` packages --->
         <Version>2.0.0-preview.13</Version>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
+        <!--- package version for all other packages --->
         <Version>2.0.0-preview.13</Version>
       </PropertyGroup>
     </Otherwise>

--- a/Libraries/Microsoft.Teams.AI.Models.OpenAI/Microsoft.Teams.AI.Models.OpenAI.csproj
+++ b/Libraries/Microsoft.Teams.AI.Models.OpenAI/Microsoft.Teams.AI.Models.OpenAI.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.AI.Models.OpenAI</PackageId>
     <PackageDescription>OpenAI model implementations to be used with `Microsoft.Teams.AI`. Supports all OpenAI-like API models.</PackageDescription>

--- a/Libraries/Microsoft.Teams.AI/Microsoft.Teams.AI.csproj
+++ b/Libraries/Microsoft.Teams.AI/Microsoft.Teams.AI.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.AI</PackageId>
     <PackageDescription>AI tools/utilities.</PackageDescription>

--- a/Libraries/Microsoft.Teams.Api/Microsoft.Teams.Api.csproj
+++ b/Libraries/Microsoft.Teams.Api/Microsoft.Teams.Api.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Api</PackageId>
     <PackageDescription>Model and client implementations used to send and receive requests from Teams.</PackageDescription>

--- a/Libraries/Microsoft.Teams.Apps.Testing/Microsoft.Teams.Apps.Testing.csproj
+++ b/Libraries/Microsoft.Teams.Apps.Testing/Microsoft.Teams.Apps.Testing.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Apps.Testing</PackageId>
     <PackageDescription>A package used to making testing apps easier.</PackageDescription>

--- a/Libraries/Microsoft.Teams.Apps/Microsoft.Teams.Apps.csproj
+++ b/Libraries/Microsoft.Teams.Apps/Microsoft.Teams.Apps.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Apps</PackageId>
     <PackageDescription>A package used to create apps/bots that can send/receive activities.</PackageDescription>

--- a/Libraries/Microsoft.Teams.Cards/Microsoft.Teams.Cards.csproj
+++ b/Libraries/Microsoft.Teams.Cards/Microsoft.Teams.Cards.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Cards</PackageId>
     <PackageDescription>An Adaptive Cards implementation with support for Teams-specific Adaptive Card elements.</PackageDescription>

--- a/Libraries/Microsoft.Teams.Common/Microsoft.Teams.Common.csproj
+++ b/Libraries/Microsoft.Teams.Common/Microsoft.Teams.Common.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Common</PackageId>
     <PackageDescription>Common modules used to provide utility functionality to the other packages while minimizing external dependencies.</PackageDescription>

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Extensions.Configuration.csproj
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Extensions.Configuration.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Extensions.Configuration</PackageId>
     <PackageDescription>Teams Configuration Extensions</PackageDescription>

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Graph/Microsoft.Teams.Extensions.Graph.csproj
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Graph/Microsoft.Teams.Extensions.Graph.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <Import Project="..\..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
     <PropertyGroup>
         <PackageId>Microsoft.Teams.Extensions.Graph</PackageId>
         <PackageDescription>Teams Context Extensions</PackageDescription>

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Hosting/Microsoft.Teams.Extensions.Hosting.csproj
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Hosting/Microsoft.Teams.Extensions.Hosting.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Extensions.Hosting</PackageId>
     <PackageDescription>Teams Hosting Extensions</PackageDescription>

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Logging/Microsoft.Teams.Extensions.Logging.csproj
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Logging/Microsoft.Teams.Extensions.Logging.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Extensions.Logging</PackageId>
     <PackageDescription>Teams Logging Extensions</PackageDescription>

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore.BotBuilder/Microsoft.Teams.Plugins.AspNetCore.BotBuilder.csproj
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore.BotBuilder/Microsoft.Teams.Plugins.AspNetCore.BotBuilder.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Plugins.AspNetCore.BotBuilder</PackageId>
     <PackageDescription>Teams AspNetCore BotBuilder Plugin</PackageDescription>

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore.DevTools/Microsoft.Teams.Plugins.AspNetCore.DevTools.csproj
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore.DevTools/Microsoft.Teams.Plugins.AspNetCore.DevTools.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Plugins.AspNetCore.DevTools</PackageId>
     <PackageDescription>Teams AspNetCore DevTools Plugin</PackageDescription>

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Microsoft.Teams.Plugins.AspNetCore.csproj
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Microsoft.Teams.Plugins.AspNetCore.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Plugins.AspNetCore</PackageId>
     <PackageDescription>Teams AspNetCore Plugin</PackageDescription>

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.External/Microsoft.Teams.Plugins.External.Mcp/Microsoft.Teams.Plugins.External.Mcp.csproj
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.External/Microsoft.Teams.Plugins.External.Mcp/Microsoft.Teams.Plugins.External.Mcp.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\..\Libraries\Directory.Build.props" Condition="'$(Version)' == ''" />
-
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Plugins.External.Mcp</PackageId>
     <PackageDescription>Teams MCP Plugin</PackageDescription>

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.External/Microsoft.Teams.Plugins.External.McpClient/Microsoft.Teams.Plugins.External.McpClient.csproj
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.External/Microsoft.Teams.Plugins.External.McpClient/Microsoft.Teams.Plugins.External.McpClient.csproj
@@ -2,9 +2,6 @@
 <!-- Licensed under the MIT License.-->
 
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <Import Project="..\..\..\Libraries\Directory.Build.props" Condition="'$(Version)' == ''" />
-
     <PropertyGroup>
         <PackageId>Microsoft.Teams.Plugins.External.McpClient</PackageId>
         <PackageDescription>Teams MCP Client Plugin</PackageDescription>


### PR DESCRIPTION
This pull request updates the versioning approach for the Microsoft Teams SDK libraries and plugins. The main change is the removal of explicit version numbers from individual `.csproj` files and the centralization of version management using MSBuild targets. This simplifies version control and ensures consistency across all projects.

**Centralized version management:**

* Added a new `Directory.Build.targets` file that sets the package version to `2.0.0-preview.13` for all projects, ensuring a single point of version control. (`Libraries/Directory.Build.targets`). It also sets up separate package version specification for the `Microsoft.Teams.Plugins.External.Mcp` and `Microsoft.Teams.Plugins.External.McpClient` packages.
* Removed the `<Version>` property from `Directory.Build.props` to avoid conflicts and duplication. (`Libraries/Directory.Build.props`)

**Project configuration cleanup:**

* Removed all `<Import Project="..\Directory.Build.props" ... />` statements from individual `.csproj` files as it is automatically imported. I was able to verify it by doing `dotnet build <package>.csproj \pp:preprocessed.xml` to see the resolved csproj. 

These changes make it easier to maintain and update package versions across all libraries and plugins, reducing the risk of inconsistencies.