### PR TITLE
Fix activity deserializer infinite recursion bug

### DIFF
--- a/Libraries/Microsoft.Teams.Api/Activities/Activity.JsonConverter.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Activity.JsonConverter.cs
@@ -45,7 +45,7 @@ public partial interface IActivity
                 "commandResult" => JsonSerializer.Deserialize<CommandResultActivity>(element.ToString(), options),
                 "event" => JsonSerializer.Deserialize<EventActivity>(element.ToString(), options),
                 "invoke" => JsonSerializer.Deserialize<InvokeActivity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<Activity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize activity '{type}' doesn't match any known types.")
             };
         }
 
@@ -167,7 +167,7 @@ public partial class Activity
                 "commandResult" => JsonSerializer.Deserialize<CommandResultActivity>(element.ToString(), options),
                 "event" => JsonSerializer.Deserialize<EventActivity>(element.ToString(), options),
                 "invoke" => JsonSerializer.Deserialize<InvokeActivity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<Activity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize activity '{type}' doesn't match any known types.")
             };
         }
 

--- a/Libraries/Microsoft.Teams.Api/Activities/EventActivity.JsonConverter.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/EventActivity.JsonConverter.cs
@@ -38,7 +38,7 @@ public partial class EventActivity
                 "application/vnd.microsoft.meetingParticipantJoin" => JsonSerializer.Deserialize<Events.MeetingParticipantJoinActivity>(element.ToString(), options),
                 "application/vnd.microsoft.meetingParticipantLeave" => JsonSerializer.Deserialize<Events.MeetingParticipantLeaveActivity>(element.ToString(), options),
                 "application/vnd.microsoft.readReceipt" => JsonSerializer.Deserialize<Events.ReadReceiptActivity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<EventActivity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize event activity '{name}' doesn't match any known types.")
             };
         }
 

--- a/Libraries/Microsoft.Teams.Api/Activities/InvokeActivity.JsonConverter.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/InvokeActivity.JsonConverter.cs
@@ -77,7 +77,7 @@ public partial class InvokeActivity
                 "fileConsent/invoke" => JsonSerializer.Deserialize<Invokes.FileConsentActivity>(element.ToString(), options),
                 "handoff/action" => JsonSerializer.Deserialize<Invokes.HandoffActivity>(element.ToString(), options),
                 "application/search" => JsonSerializer.Deserialize<Invokes.SearchActivity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<InvokeActivity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize invoke activity '{name}' doesn't match any known types.")
             };
         }
 

--- a/Libraries/Microsoft.Teams.Api/Activities/Invokes/AdaptiveCardActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Invokes/AdaptiveCardActivity.cs
@@ -53,7 +53,7 @@ public class AdaptiveCardActivity(Name.AdaptiveCards name) : InvokeActivity(new(
             return name switch
             {
                 "adaptiveCard/action" => JsonSerializer.Deserialize<AdaptiveCards.ActionActivity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<AdaptiveCardActivity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize adaptive card activity '{name}' doesn't match any known types.")
             };
         }
 

--- a/Libraries/Microsoft.Teams.Api/Activities/Invokes/ConfigActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Invokes/ConfigActivity.cs
@@ -56,7 +56,7 @@ public abstract class ConfigActivity(Name.Configs name) : InvokeActivity(new(nam
             {
                 "config/fetch" => JsonSerializer.Deserialize<Configs.FetchActivity>(element.ToString(), options),
                 "config/submit" => JsonSerializer.Deserialize<Configs.SubmitActivity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<ConfigActivity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize config activity '{name}' doesn't match any known types.")
             };
         }
 

--- a/Libraries/Microsoft.Teams.Api/Activities/Invokes/MessageActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Invokes/MessageActivity.cs
@@ -53,7 +53,7 @@ public abstract class MessageActivity(Name.Messages name) : InvokeActivity(new(n
             return name switch
             {
                 "message/submitAction" => JsonSerializer.Deserialize<Messages.SubmitActionActivity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<MessageActivity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize message activity '{name}' doesn't match any known types.")
             };
         }
 

--- a/Libraries/Microsoft.Teams.Api/Activities/Invokes/MessageExtensionActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Invokes/MessageExtensionActivity.cs
@@ -24,7 +24,7 @@ public abstract class MessageExtensionActivity(Name.MessageExtensions name) : In
     public MessageExtensions.FetchTaskActivity ToFetchTask() => (MessageExtensions.FetchTaskActivity)this;
     public MessageExtensions.QueryActivity ToQuery() => (MessageExtensions.QueryActivity)this;
     public MessageExtensions.QueryLinkActivity ToQueryLink() => (MessageExtensions.QueryLinkActivity)this;
-    public MessageExtensions.QuerySettingsUrlActivity ToQuerySettingsUrl() => (MessageExtensions.QuerySettingsUrlActivity)this;
+    public MessageExtensions.QuerySettingUrlActivity ToQuerySettingsUrl() => (MessageExtensions.QuerySettingUrlActivity)this;
     public MessageExtensions.SelectItemActivity ToSelectItem() => (MessageExtensions.SelectItemActivity)this;
     public MessageExtensions.SettingActivity ToSetting() => (MessageExtensions.SettingActivity)this;
     public MessageExtensions.SubmitActionActivity ToSubmitAction() => (MessageExtensions.SubmitActionActivity)this;
@@ -36,7 +36,7 @@ public abstract class MessageExtensionActivity(Name.MessageExtensions name) : In
         if (type == typeof(MessageExtensions.FetchTaskActivity)) return ToFetchTask();
         if (type == typeof(MessageExtensions.QueryActivity)) return ToQuery();
         if (type == typeof(MessageExtensions.QueryLinkActivity)) return ToQueryLink();
-        if (type == typeof(MessageExtensions.QuerySettingsUrlActivity)) return ToQuerySettingsUrl();
+        if (type == typeof(MessageExtensions.QuerySettingUrlActivity)) return ToQuerySettingsUrl();
         if (type == typeof(MessageExtensions.SelectItemActivity)) return ToSelectItem();
         if (type == typeof(MessageExtensions.SettingActivity)) return ToSetting();
         if (type == typeof(MessageExtensions.SubmitActionActivity)) return ToSubmitAction();
@@ -73,11 +73,11 @@ public abstract class MessageExtensionActivity(Name.MessageExtensions name) : In
                 "composeExtension/fetchTask" => JsonSerializer.Deserialize<MessageExtensions.FetchTaskActivity>(element.ToString(), options),
                 "composeExtension/query" => JsonSerializer.Deserialize<MessageExtensions.QueryActivity>(element.ToString(), options),
                 "composeExtension/queryLink" => JsonSerializer.Deserialize<MessageExtensions.QueryLinkActivity>(element.ToString(), options),
-                "composeExtension/querySettingsUrl" => JsonSerializer.Deserialize<MessageExtensions.QuerySettingsUrlActivity>(element.ToString(), options),
+                "composeExtension/querySettingUrl" => JsonSerializer.Deserialize<MessageExtensions.QuerySettingUrlActivity>(element.ToString(), options),
                 "composeExtension/selectItem" => JsonSerializer.Deserialize<MessageExtensions.SelectItemActivity>(element.ToString(), options),
                 "composeExtension/setting" => JsonSerializer.Deserialize<MessageExtensions.SettingActivity>(element.ToString(), options),
                 "composeExtension/submitAction" => JsonSerializer.Deserialize<MessageExtensions.SubmitActionActivity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<MessageExtensionActivity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize invoke activity '{name}' doesn't match any known types.")
             };
         }
 
@@ -113,7 +113,7 @@ public abstract class MessageExtensionActivity(Name.MessageExtensions name) : In
                 return;
             }
 
-            if (value is MessageExtensions.QuerySettingsUrlActivity querySettingsUrl)
+            if (value is MessageExtensions.QuerySettingUrlActivity querySettingsUrl)
             {
                 JsonSerializer.Serialize(writer, querySettingsUrl, options);
                 return;

--- a/Libraries/Microsoft.Teams.Api/Activities/Invokes/MessageExtensions/QuerySettingUrlActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Invokes/MessageExtensions/QuerySettingUrlActivity.cs
@@ -11,14 +11,14 @@ public partial class Name : StringEnum
 {
     public partial class MessageExtensions : StringEnum
     {
-        public static readonly MessageExtensions QuerySettingsUrl = new("composeExtension/querySettingsUrl");
-        public bool IsQuerySettingsUrl => QuerySettingsUrl.Equals(Value);
+        public static readonly MessageExtensions QuerySettingUrl = new("composeExtension/querySettingUrl");
+        public bool IsQuerySettingsUrl => QuerySettingUrl.Equals(Value);
     }
 }
 
 public static partial class MessageExtensions
 {
-    public class QuerySettingsUrlActivity() : MessageExtensionActivity(Name.MessageExtensions.QuerySettingsUrl)
+    public class QuerySettingUrlActivity() : MessageExtensionActivity(Name.MessageExtensions.QuerySettingUrl)
     {
         /// <summary>
         /// A value that is associated with the activity.

--- a/Libraries/Microsoft.Teams.Api/Activities/Invokes/SignInActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Invokes/SignInActivity.cs
@@ -56,7 +56,7 @@ public abstract class SignInActivity(Name.SignIn name) : InvokeActivity(new(name
             {
                 "signin/tokenExchange" => JsonSerializer.Deserialize<SignIn.TokenExchangeActivity>(element.ToString(), options),
                 "signin/verifyState" => JsonSerializer.Deserialize<SignIn.VerifyStateActivity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<SignInActivity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize signin activity '{name}' doesn't match any known types.")
             };
         }
 

--- a/Libraries/Microsoft.Teams.Api/Activities/Invokes/TabActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Invokes/TabActivity.cs
@@ -56,7 +56,7 @@ public abstract class TabActivity(Name.Tabs name) : InvokeActivity(new(name.Valu
             {
                 "tab/fetch" => JsonSerializer.Deserialize<Tabs.FetchActivity>(element.ToString(), options),
                 "tab/submit" => JsonSerializer.Deserialize<Tabs.SubmitActivity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<TabActivity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize tab activity '{name}' doesn't match any known types.")
             };
         }
 

--- a/Libraries/Microsoft.Teams.Api/Activities/Invokes/TaskActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Invokes/TaskActivity.cs
@@ -56,7 +56,7 @@ public abstract class TaskActivity(Name.Tasks name) : InvokeActivity(new(name.Va
             {
                 "task/fetch" => JsonSerializer.Deserialize<Tasks.FetchActivity>(element.ToString(), options),
                 "task/submit" => JsonSerializer.Deserialize<Tasks.SubmitActivity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<TaskActivity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize task activity '{name}' doesn't match any known types.")
             };
         }
 

--- a/Libraries/Microsoft.Teams.Api/Entities/Entity.cs
+++ b/Libraries/Microsoft.Teams.Api/Entities/Entity.cs
@@ -53,7 +53,7 @@ public interface IEntity
                 "mention" => JsonSerializer.Deserialize<MentionEntity>(element.ToString(), options),
                 "message" or "https://schema.org/Message" => JsonSerializer.Deserialize<IMessageEntity>(element.ToString(), options),
                 "streaminfo" => JsonSerializer.Deserialize<StreamInfoEntity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<Entity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize entity '{type}' doesn't match any known types.")
             };
         }
 
@@ -147,7 +147,7 @@ public class Entity : IEntity
                 "mention" => JsonSerializer.Deserialize<MentionEntity>(element.ToString(), options),
                 "message" or "https://schema.org/Message" => (Entity?)JsonSerializer.Deserialize<IMessageEntity>(element.ToString(), options),
                 "streaminfo" => JsonSerializer.Deserialize<StreamInfoEntity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<Entity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize entity activity '{type}' doesn't match any known types.")
             };
         }
 

--- a/Libraries/Microsoft.Teams.Api/Entities/OMessageEntity.cs
+++ b/Libraries/Microsoft.Teams.Api/Entities/OMessageEntity.cs
@@ -46,7 +46,7 @@ public class OMessageEntity : Entity, IMessageEntity
             {
                 "Claim" => JsonSerializer.Deserialize<CitationEntity>(element.ToString(), options),
                 "CreativeWork" => JsonSerializer.Deserialize<SensitiveUsageEntity>(element.ToString(), options),
-                _ => JsonSerializer.Deserialize<OMessageEntity>(element.ToString(), options)
+                _ => throw new JsonException($"failed to deserialize omessage entity '{oType}' doesn't match any known types.")
             };
         }
 

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QuerySettingsUrlActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/MessageExtensions/QuerySettingsUrlActivity.cs
@@ -10,52 +10,52 @@ namespace Microsoft.Teams.Apps.Activities.Invokes;
 public static partial class MessageExtension
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
-    public class QuerySettingsUrlAttribute() : InvokeAttribute(Api.Activities.Invokes.Name.MessageExtensions.QuerySettingsUrl, typeof(MessageExtensions.QuerySettingsUrlActivity))
+    public class QuerySettingsUrlAttribute() : InvokeAttribute(Api.Activities.Invokes.Name.MessageExtensions.QuerySettingUrl, typeof(MessageExtensions.QuerySettingUrlActivity))
     {
-        public override object Coerce(IContext<IActivity> context) => context.ToActivityType<MessageExtensions.QuerySettingsUrlActivity>();
+        public override object Coerce(IContext<IActivity> context) => context.ToActivityType<MessageExtensions.QuerySettingUrlActivity>();
     }
 }
 
 public static partial class AppInvokeActivityExtensions
 {
-    public static App OnQuerySettingsUrl(this App app, Func<IContext<MessageExtensions.QuerySettingsUrlActivity>, Task> handler)
+    public static App OnQuerySettingsUrl(this App app, Func<IContext<MessageExtensions.QuerySettingUrlActivity>, Task> handler)
     {
         app.Router.Register(new Route()
         {
-            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QuerySettingsUrl]),
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QuerySettingUrl]),
             Type = app.Status is null ? RouteType.System : RouteType.User,
             Handler = async context =>
             {
-                await handler(context.ToActivityType<MessageExtensions.QuerySettingsUrlActivity>());
+                await handler(context.ToActivityType<MessageExtensions.QuerySettingUrlActivity>());
                 return null;
             },
-            Selector = activity => activity is MessageExtensions.QuerySettingsUrlActivity
+            Selector = activity => activity is MessageExtensions.QuerySettingUrlActivity
         });
 
         return app;
     }
 
-    public static App OnQuerySettingsUrl(this App app, Func<IContext<MessageExtensions.QuerySettingsUrlActivity>, Task<Response<Api.MessageExtensions.Response>>> handler)
+    public static App OnQuerySettingsUrl(this App app, Func<IContext<MessageExtensions.QuerySettingUrlActivity>, Task<Response<Api.MessageExtensions.Response>>> handler)
     {
         app.Router.Register(new Route()
         {
-            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QuerySettingsUrl]),
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QuerySettingUrl]),
             Type = app.Status is null ? RouteType.System : RouteType.User,
-            Handler = async context => await handler(context.ToActivityType<MessageExtensions.QuerySettingsUrlActivity>()),
-            Selector = activity => activity is MessageExtensions.QuerySettingsUrlActivity
+            Handler = async context => await handler(context.ToActivityType<MessageExtensions.QuerySettingUrlActivity>()),
+            Selector = activity => activity is MessageExtensions.QuerySettingUrlActivity
         });
 
         return app;
     }
 
-    public static App OnQuerySettingsUrl(this App app, Func<IContext<MessageExtensions.QuerySettingsUrlActivity>, Task<Api.MessageExtensions.Response>> handler)
+    public static App OnQuerySettingsUrl(this App app, Func<IContext<MessageExtensions.QuerySettingUrlActivity>, Task<Api.MessageExtensions.Response>> handler)
     {
         app.Router.Register(new Route()
         {
-            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QuerySettingsUrl]),
+            Name = string.Join("/", [ActivityType.Invoke, Name.MessageExtensions.QuerySettingUrl]),
             Type = app.Status is null ? RouteType.System : RouteType.User,
-            Handler = async context => await handler(context.ToActivityType<MessageExtensions.QuerySettingsUrlActivity>()),
-            Selector = activity => activity is MessageExtensions.QuerySettingsUrlActivity
+            Handler = async context => await handler(context.ToActivityType<MessageExtensions.QuerySettingUrlActivity>()),
+            Selector = activity => activity is MessageExtensions.QuerySettingUrlActivity
         });
 
         return app;

--- a/Samples/Samples.MessageExtensions/Program.cs
+++ b/Samples/Samples.MessageExtensions/Program.cs
@@ -159,7 +159,7 @@ public static partial class Program
 
         [MessageExtension.QuerySettingsUrl]
         public Microsoft.Teams.Api.MessageExtensions.Response OnMessageExtensionQuerySettingsUrl(
-            [Context] Microsoft.Teams.Api.Activities.Invokes.MessageExtensions.QuerySettingsUrlActivity activity,
+            [Context] Microsoft.Teams.Api.Activities.Invokes.MessageExtensions.QuerySettingUrlActivity activity,
             [Context] IContext.Client client,
             [Context] Microsoft.Teams.Common.Logging.ILogger log)
         {

--- a/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/AdaptiveCards/AdaptiveCardsTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/AdaptiveCards/AdaptiveCardsTests.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using Microsoft.Teams.Api.Activities.Invokes;
+using static Microsoft.Teams.Api.Activities.Invokes.AdaptiveCards;
+
+namespace Microsoft.Teams.Api.Tests.Activities.Invokes.AdaptiveCards;
+
+public class AdaptiveCardsTests
+{
+    private static AdaptiveCardActivity? Deserialize(string json) => JsonSerializer.Deserialize<AdaptiveCardActivity>(json);
+
+    [Fact]
+    public void AdaptiveCard_MissingName_Throws()
+    {
+        var json = "{\"type\":\"invoke\"}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("must have a 'name'", ex.Message);
+    }
+
+    [Fact]
+    public void AdaptiveCard_NullName_Throws()
+    {
+        var json = "{\"type\":\"invoke\",\"name\":null}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("failed to deserialize invoke activity 'name' property", ex.Message);
+    }
+
+    [Fact]
+    public void AdaptiveCard_UnknownName_Throws()
+    {
+        var json = "{\"type\":\"invoke\",\"name\":\"adaptiveCard/unknown\"}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("doesn't match any known types", ex.Message);
+    }
+}

--- a/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/Configs/ConfigsTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/Configs/ConfigsTests.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+using Microsoft.Teams.Api.Activities.Invokes;
+using static Microsoft.Teams.Api.Activities.Invokes.Configs;
+
+namespace Microsoft.Teams.Api.Tests.Activities.Invokes.Configs;
+
+public class ConfigsTests
+{
+    private static ConfigActivity? Deserialize(string json) => JsonSerializer.Deserialize<ConfigActivity>(json);
+
+    [Theory]
+    [InlineData("config/fetch", typeof(FetchActivity))]
+    [InlineData("config/submit", typeof(SubmitActivity))]
+    public void Config_Known(string name, Type expected)
+    {
+        var json = $"{{\"type\":\"invoke\",\"name\":\"{name}\"}}";
+        var activity = Deserialize(json);
+        Assert.NotNull(activity);
+        Assert.Equal(expected, activity!.GetType());
+        Assert.True(activity.Name.IsConfig);
+    }
+
+    [Fact]
+    public void Config_MissingName_Throws()
+    {
+        var json = "{\"type\":\"invoke\"}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("must have a 'name'", ex.Message);
+    }
+
+    [Fact]
+    public void Config_NullName_Throws()
+    {
+        var json = "{\"type\":\"invoke\",\"name\":null}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("failed to deserialize invoke activity 'name' property", ex.Message);
+    }
+
+    [Fact]
+    public void Config_UnknownName_Throws()
+    {
+        var json = "{\"type\":\"invoke\",\"name\":\"config/other\"}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("doesn't match any known types", ex.Message);
+    }
+}

--- a/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/MessageExtensions/MessageExtensionsTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/MessageExtensions/MessageExtensionsTests.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using Microsoft.Teams.Api.Activities.Invokes;
+using static Microsoft.Teams.Api.Activities.Invokes.MessageExtensions;
+
+namespace Microsoft.Teams.Api.Tests.Activities.Invokes.MessageExtensions;
+
+public class MessageExtensionsTests
+{
+    private static MessageExtensionActivity? Deserialize(string json) => JsonSerializer.Deserialize<MessageExtensionActivity>(json);
+
+    [Fact]
+    public void MessageExtension_MissingName_Throws()
+    {
+        var json = "{\"type\":\"invoke\"}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("must have a 'name'", ex.Message);
+    }
+
+    [Fact]
+    public void MessageExtension_NullName_Throws()
+    {
+        var json = "{\"type\":\"invoke\",\"name\":null}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("failed to deserialize invoke activity 'name' property", ex.Message);
+    }
+
+    [Fact]
+    public void MessageExtension_UnknownName_Throws()
+    {
+        var json = "{\"type\":\"invoke\",\"name\":\"composeExtension/other\"}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("doesn't match any known types", ex.Message);
+    }
+}

--- a/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/MessageExtensions/QuerySettingsUrlMEActivityTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/MessageExtensions/QuerySettingsUrlMEActivityTests.cs
@@ -74,7 +74,7 @@ public class QuerySettingsUrlMEActivityTests
         string expectedPath = "Activity.Invoke.ComposeExtension/querySettingUrl";
         Assert.Equal(expectedPath, activity.GetPath());
         Assert.Equal(File.ReadAllText(
-            @"../../../Json/Activity/Invokes/QuerySettingsUrlMEActivity.json"
+            @"../../../Json/Activity/Invokes/QuerySettingUrlMEActivity.json"
         ), json);
     }
 
@@ -93,7 +93,7 @@ public class QuerySettingsUrlMEActivityTests
         string expectedPath = "Activity.Invoke.ComposeExtension/querySettingUrl";
         Assert.Equal(expectedPath, activity.GetPath());
         Assert.Equal(File.ReadAllText(
-            @"../../../Json/Activity/Invokes/QuerySettingsUrlMEActivity.json"
+            @"../../../Json/Activity/Invokes/QuerySettingUrlMEActivity.json"
         ), json);
     }
 

--- a/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/MessageExtensions/QuerySettingsUrlMEActivityTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/MessageExtensions/QuerySettingsUrlMEActivityTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Teams.Api.Tests.Activities.Invokes;
 
 public class QuerySettingsUrlMEActivityTests
 {
-    private QuerySettingsUrlActivity SetupQuerySettingsUrlActivity()
+    private QuerySettingUrlActivity SetupQuerySettingsUrlActivity()
     {
         IList<IEntity> _entityList =
         [
@@ -23,7 +23,7 @@ public class QuerySettingsUrlMEActivityTests
                 Timezone = "GMT-8",
             }
         ];
-        return new QuerySettingsUrlActivity()
+        return new QuerySettingUrlActivity()
         {
             Value = new Query()
             {
@@ -71,7 +71,7 @@ public class QuerySettingsUrlMEActivityTests
             DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
         });
 
-        string expectedPath = "Activity.Invoke.ComposeExtension/querySettingsUrl";
+        string expectedPath = "Activity.Invoke.ComposeExtension/querySettingUrl";
         Assert.Equal(expectedPath, activity.GetPath());
         Assert.Equal(File.ReadAllText(
             @"../../../Json/Activity/Invokes/QuerySettingsUrlMEActivity.json"
@@ -90,7 +90,7 @@ public class QuerySettingsUrlMEActivityTests
             DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
         });
 
-        string expectedPath = "Activity.Invoke.ComposeExtension/querySettingsUrl";
+        string expectedPath = "Activity.Invoke.ComposeExtension/querySettingUrl";
         Assert.Equal(expectedPath, activity.GetPath());
         Assert.Equal(File.ReadAllText(
             @"../../../Json/Activity/Invokes/QuerySettingsUrlMEActivity.json"
@@ -109,21 +109,21 @@ public class QuerySettingsUrlMEActivityTests
             DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
         });
 
-        string expectedPath = "Activity.Invoke.ComposeExtension/querySettingsUrl";
+        string expectedPath = "Activity.Invoke.ComposeExtension/querySettingUrl";
         Assert.Equal(expectedPath, activity.GetPath());
         Assert.Equal(File.ReadAllText(
-            @"../../../Json/Activity/Invokes/QuerySettingsUrlMEActivity.json"
+            @"../../../Json/Activity/Invokes/QuerySettingUrlMEActivity.json"
         ), json);
     }
 
     [Fact]
     public void QuerySettingsUrlMEActivity_JsonDeserialize()
     {
-        var json = File.ReadAllText(@"../../../Json/Activity/Invokes/QuerySettingsUrlMEActivity.json");
-        var activity = JsonSerializer.Deserialize<QuerySettingsUrlActivity>(json);
+        var json = File.ReadAllText(@"../../../Json/Activity/Invokes/QuerySettingUrlMEActivity.json");
+        var activity = JsonSerializer.Deserialize<QuerySettingUrlActivity>(json);
         var expected = SetupQuerySettingsUrlActivity();
 
-        string expectedPath = "Activity.Invoke.ComposeExtension/querySettingsUrl";
+        string expectedPath = "Activity.Invoke.ComposeExtension/querySettingUrl";
         Assert.Equal(expectedPath, activity!.GetPath());
 
         Assert.Equal(expected.ToString(), activity.ToString());
@@ -133,13 +133,13 @@ public class QuerySettingsUrlMEActivityTests
     [Fact]
     public void QuerySettingsUrlMEActivity_JsonDeserialize_Derived()
     {
-        var json = File.ReadAllText(@"../../../Json/Activity/Invokes/QuerySettingsUrlMEActivity.json");
+        var json = File.ReadAllText(@"../../../Json/Activity/Invokes/QuerySettingUrlMEActivity.json");
         var activity = JsonSerializer.Deserialize<MessageExtensionActivity>(json);
         var expected = SetupQuerySettingsUrlActivity();
 
         Assert.Equal(expected.ToString(), activity!.ToString());
         Assert.NotNull(activity.ToMessageExtension());
-        var expectedSubmitException = "Unable to cast object of type 'QuerySettingsUrlActivity' to type 'Microsoft.Teams.Api.Activities.Invokes.TaskActivity'.";
+        var expectedSubmitException = "Unable to cast object of type 'QuerySettingUrlActivity' to type 'Microsoft.Teams.Api.Activities.Invokes.TaskActivity'.";
         var ex = Assert.Throws<System.InvalidCastException>(() => activity.ToTask());
         Assert.Equal(expectedSubmitException, ex.Message);
     }
@@ -147,7 +147,7 @@ public class QuerySettingsUrlMEActivityTests
     [Fact]
     public void QuerySettingsUrlMEActivity_JsonDeserialize_Derived_Interface()
     {
-        var json = File.ReadAllText(@"../../../Json/Activity/Invokes/QuerySettingsUrlMEActivity.json");
+        var json = File.ReadAllText(@"../../../Json/Activity/Invokes/QuerySettingUrlMEActivity.json");
         var activity = JsonSerializer.Deserialize<InvokeActivity>(json);
         var expected = SetupQuerySettingsUrlActivity();
 
@@ -155,7 +155,7 @@ public class QuerySettingsUrlMEActivityTests
         Assert.Equal(expected.ToString(), activity.ToString());
         Assert.NotNull(activity.ToMessageExtension());
 
-        var expectedSubmitException = "Unable to cast object of type 'QuerySettingsUrlActivity' to type 'Microsoft.Teams.Api.Activities.Invokes.SignInActivity'.";
+        var expectedSubmitException = "Unable to cast object of type 'QuerySettingUrlActivity' to type 'Microsoft.Teams.Api.Activities.Invokes.SignInActivity'.";
         var ex = Assert.Throws<System.InvalidCastException>(() => activity.ToSignIn());
         Assert.Equal(expectedSubmitException, ex.Message);
     }
@@ -163,7 +163,7 @@ public class QuerySettingsUrlMEActivityTests
     [Fact]
     public void QuerySettingsUrlMEActivity_JsonDeserialize_Derived_Activity_Interface()
     {
-        var json = File.ReadAllText(@"../../../Json/Activity/Invokes/QuerySettingsUrlMEActivity.json");
+        var json = File.ReadAllText(@"../../../Json/Activity/Invokes/QuerySettingUrlMEActivity.json");
         var activity = JsonSerializer.Deserialize<Activity>(json);
         var expected = SetupQuerySettingsUrlActivity();
 

--- a/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/Messages/MessagesTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/Messages/MessagesTests.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using Microsoft.Teams.Api.Activities.Invokes;
+
+namespace Microsoft.Teams.Api.Tests.Activities.Invokes.MessageInvokes; // keep adjusted namespace
+
+public class MessagesTests
+{
+    private static MessageActivity? Deserialize(string json) => JsonSerializer.Deserialize<MessageActivity>(json);
+
+    [Fact]
+    public void Message_MissingName_Throws()
+    {
+        var json = "{\"type\":\"invoke\"}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("must have a 'name'", ex.Message);
+    }
+
+    [Fact]
+    public void Message_NullName_Throws()
+    {
+        var json = "{\"type\":\"invoke\",\"name\":null}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("failed to deserialize invoke activity 'name' property", ex.Message);
+    }
+
+    [Fact]
+    public void Message_UnknownName_Throws()
+    {
+        var json = "{\"type\":\"invoke\",\"name\":\"message/other\"}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("doesn't match any known types", ex.Message);
+    }
+}

--- a/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/SignIn/SignInTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/SignIn/SignInTests.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using Microsoft.Teams.Api.Activities.Invokes;
+
+namespace Microsoft.Teams.Api.Tests.Activities.Invokes.SignIn;
+
+public class SignInTests
+{
+    private static SignInActivity? Deserialize(string json) => JsonSerializer.Deserialize<SignInActivity>(json);
+
+    [Fact]
+    public void SignIn_MissingName_Throws()
+    {
+        var json = "{\"type\":\"invoke\"}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("must have a 'name'", ex.Message);
+    }
+
+    [Fact]
+    public void SignIn_NullName_Throws()
+    {
+        var json = "{\"type\":\"invoke\",\"name\":null}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("failed to deserialize invoke activity 'name' property", ex.Message);
+    }
+
+    [Fact]
+    public void SignIn_UnknownName_Throws()
+    {
+        var json = "{\"type\":\"invoke\",\"name\":\"signin/other\"}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("doesn't match any known types", ex.Message);
+    }
+}

--- a/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/Tasks/TasksTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/Activities/Invokes/Tasks/TasksTests.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using Microsoft.Teams.Api.Activities.Invokes;
+
+namespace Microsoft.Teams.Api.Tests.Activities.Invokes.Tasks;
+
+public class TasksTests
+{
+    private static TaskActivity? Deserialize(string json) => JsonSerializer.Deserialize<TaskActivity>(json);
+
+    [Fact]
+    public void Task_MissingName_Throws()
+    {
+        var json = "{\"type\":\"invoke\"}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("must have a 'name'", ex.Message);
+    }
+
+    [Fact]
+    public void Task_NullName_Throws()
+    {
+        var json = "{\"type\":\"invoke\",\"name\":null}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("failed to deserialize invoke activity 'name' property", ex.Message);
+    }
+
+    [Fact]
+    public void Task_UnknownName_Throws()
+    {
+        var json = "{\"type\":\"invoke\",\"name\":\"task/other\"}";
+        var ex = Assert.Throws<JsonException>(() => Deserialize(json));
+        Assert.Contains("doesn't match any known types", ex.Message);
+    }
+}

--- a/Tests/Microsoft.Teams.Api.Tests/Entities/EntitiesTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/Entities/EntitiesTests.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using Microsoft.Teams.Api.Entities;
+
+namespace Microsoft.Teams.Api.Tests.Entities;
+
+public class EntitiesTests
+{
+    private static IEntity? DeserializeEntity(string json) => JsonSerializer.Deserialize<IEntity>(json);
+    private static Entity? DeserializeBase(string json) => JsonSerializer.Deserialize<Entity>(json);
+    private static OMessageEntity? DeserializeOMessage(string json) => JsonSerializer.Deserialize<OMessageEntity>(json);
+
+    [Fact]
+    public void Entity_MissingType_Throws()
+    {
+        var json = "{}";
+        var ex = Assert.Throws<JsonException>(() => DeserializeEntity(json));
+        Assert.Contains("entity must have a 'type'", ex.Message);
+    }
+
+    [Fact]
+    public void Entity_NullType_Throws()
+    {
+        var json = "{\"type\":null}";
+        var ex = Assert.Throws<JsonException>(() => DeserializeEntity(json));
+        Assert.Contains("failed to deserialize entity 'type' property", ex.Message);
+    }
+
+    [Fact]
+    public void Entity_UnknownType_Throws()
+    {
+        var json = "{\"type\":\"other\"}";
+        var ex = Assert.Throws<JsonException>(() => DeserializeEntity(json));
+        Assert.Contains("doesn't match any known types", ex.Message);
+    }
+
+    // Base Entity converter path
+    [Fact]
+    public void BaseEntity_Message_DispatchesToMessageEntity()
+    {
+        var json = "{\"type\":\"message\"}";
+        var entity = DeserializeBase(json);
+        Assert.NotNull(entity);
+    }
+
+    [Fact]
+    public void OMessage_MissingOType_Throws()
+    {
+        var json = "{\"type\":\"https://schema.org/Message\"}";
+        var ex = Assert.Throws<JsonException>(() => DeserializeOMessage(json));
+        Assert.Contains("must have a '@type'", ex.Message);
+    }
+
+    [Fact]
+    public void OMessage_NullOType_Throws()
+    {
+        var json = "{\"type\":\"https://schema.org/Message\",\"@type\":null}";
+        var ex = Assert.Throws<JsonException>(() => DeserializeOMessage(json));
+        Assert.Contains("failed to deserialize 'https://schema.org/Message' entity '@type' property", ex.Message);
+    }
+
+    [Fact]
+    public void OMessage_UnknownOType_Throws()
+    {
+        var json = "{\"type\":\"https://schema.org/Message\",\"@type\":\"Other\"}";
+        var ex = Assert.Throws<JsonException>(() => DeserializeOMessage(json));
+        Assert.Contains("doesn't match any known types", ex.Message);
+    }
+}

--- a/Tests/Microsoft.Teams.Api.Tests/Json/Activity/Invokes/QuerySettingUrlMEActivity.json
+++ b/Tests/Microsoft.Teams.Api.Tests/Json/Activity/Invokes/QuerySettingUrlMEActivity.json
@@ -2,7 +2,7 @@
   "id": "id:data",
   "type": "invoke",
   "channelId": "msteams",
-  "name": "composeExtension/querySettingsUrl",
+  "name": "composeExtension/querySettingUrl",
   "value": {
     "commandId": "searchCmd",
     "parameters": [


### PR DESCRIPTION
This pull request introduces stricter error handling for deserialization of activities and entities in the Microsoft Teams API codebase, and also corrects a naming inconsistency for the "QuerySettingsUrl" activity, standardizing it to "QuerySettingUrl" throughout the codebase. The most important changes are as follows:

**Error Handling Improvements:**

* Replaces fallback deserialization to base types with explicit `JsonException` throws in all activity and entity JSON converters when an unknown type is encountered. This ensures that only recognized activity/entity types are deserialized and helps catch unexpected or malformed data early. [[1]](diffhunk://#diff-920cb13ff64033134157a73545c9d9090b7704c37e6ec43f830a7de9decd1282L48-R48) [[2]](diffhunk://#diff-920cb13ff64033134157a73545c9d9090b7704c37e6ec43f830a7de9decd1282L170-R170) [[3]](diffhunk://#diff-d194daff89e0c527acf335469a2829b813f4dee2c19facf3c5f768e19c2d086bL41-R41) [[4]](diffhunk://#diff-0ec561ec594786978bbb164a853e96d0b21b527d955b43bd98f83a2322a5c070L80-R80) [[5]](diffhunk://#diff-3bd6c0f6af82fb3816d3f85848cea59613e03ed3e4594f741b6a0c1701eef027L56-R56) [[6]](diffhunk://#diff-2808a8b8f8ddf0702c120b9e9df5297923311bce2e0fe0a706aa8fa751d1931fL59-R59) [[7]](diffhunk://#diff-112b347ff334324e509c1b02a76539b7d6d6d18e8fc5b75ca0ac6747f544630eL56-R56) [[8]](diffhunk://#diff-34c1f3258016466f1436d9a90559dff7bfada6227d3c6377eb268511ddbf34f4L59-R59) [[9]](diffhunk://#diff-4146d02145cb59cb276d6757ebfedf4159752c35291368b6ad1b25c741802b67L59-R59) [[10]](diffhunk://#diff-70e3f6339ec97d0055e2156cda7938ea7ae3f3818905385d843c09092dd72690L59-R59) [[11]](diffhunk://#diff-7aa2f8d74e32117c5599f62e144de8df9a7431d2d050d98423b5dde7dc5dccf8L56-R56) [[12]](diffhunk://#diff-7aa2f8d74e32117c5599f62e144de8df9a7431d2d050d98423b5dde7dc5dccf8L150-R150) [[13]](diffhunk://#diff-40f82a5b9a9eb59196fb45bec37d586e8d9edf6740ec1eee40381776dd0815b7L49-R49)

**Naming Consistency and Refactoring:**

* Renames all references of `QuerySettingsUrlActivity` to `QuerySettingUrlActivity` and updates the corresponding string identifier from `"composeExtension/querySettingsUrl"` to `"composeExtension/querySettingUrl"`. This affects class names, switch cases, method names, and attribute usage across multiple files, ensuring uniformity and preventing mismatches during deserialization or routing. [[1]](diffhunk://#diff-6ac5d284d51a16c3670aa89427d29b1a82078b3a7d5ca09b203343b2cd310ff0L27-R27) [[2]](diffhunk://#diff-6ac5d284d51a16c3670aa89427d29b1a82078b3a7d5ca09b203343b2cd310ff0L39-R39) [[3]](diffhunk://#diff-6ac5d284d51a16c3670aa89427d29b1a82078b3a7d5ca09b203343b2cd310ff0L76-R80) [[4]](diffhunk://#diff-6ac5d284d51a16c3670aa89427d29b1a82078b3a7d5ca09b203343b2cd310ff0L116-R116) [[5]](diffhunk://#diff-bb471df45859442cdc1c702229cb2340885541f7ef7b4b26f271077bf1b50a13L14-R21) [[6]](diffhunk://#diff-42d3c882e4d5afb960954fe2d0150edb74f5b39d92901137b5b10201d97a1192L13-R58) [[7]](diffhunk://#diff-7ea639fc1e8547567ba6a43cf4d3b968179b31af7a80ed09a06d2a5c0522ad14L162-R162)

These changes together improve the reliability of activity/entity handling and ensure that the codebase consistently uses the correct naming for the QuerySettingUrl activity.