### PR TITLE
Bump core packages to `v2.0.0` and mcp plugin packages to `v2.0.0-preview.14`

### DIFF
--- a/Libraries/Directory.Build.targets
+++ b/Libraries/Directory.Build.targets
@@ -3,13 +3,13 @@
     <When Condition="$([System.String]::Copy('$(PackageId)').StartsWith('Microsoft.Teams.Plugins.External.Mcp'))">
       <PropertyGroup>
         <!-- package version for `Microsoft.Teams.Plugins.External.Mcp` and `Microsoft.Teams.Plugins.External.McpClient` packages -->
-        <Version>2.0.0-preview.13</Version>
+        <Version>2.0.0-preview.14</Version>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
         <!-- package version for all other packages -->
-        <Version>2.0.0-preview.13</Version>
+        <Version>2.0.0</Version>
       </PropertyGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
This pull request updates the package versions in the `Libraries/Directory.Build.targets` file. The preview version for `Microsoft.Teams.Plugins.External.Mcp` packages is incremented, and the version for all other packages is set to the stable release.

- Versioning updates:
  * Updated the version for `Microsoft.Teams.Plugins.External.Mcp` and `Microsoft.Teams.Plugins.External.McpClient` packages from `2.0.0-preview.13` to `2.0.0-preview.14`.
  * Updated the version for all other packages from `2.0.0-preview.13` to the stable `2.0.0`.