### PR TITLE
Add convenience `Send` method overload to omit request options.

### DIFF
--- a/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.Send.cs
+++ b/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.Send.cs
@@ -13,6 +13,11 @@ public partial class ChatPrompt<TOptions>
         return await Send(message, null, null, cancellationToken);
     }
 
+    public async Task<ModelMessage<string>> Send(string text, OnStreamChunk? onChunk = null, CancellationToken cancellationToken = default)
+    {
+        return await Send(text, null, onChunk, cancellationToken);
+    }
+
     public Task<ModelMessage<string>> Send(string text, IChatPrompt<TOptions>.RequestOptions? options = null, OnStreamChunk? onChunk = null, CancellationToken cancellationToken = default)
     {
         var message = UserMessage.Text(text);


### PR DESCRIPTION
Convenience `Send` overload so devs can do:

`prompt.Send(context.Activity.Text, (chunk) => { ... })`

instead of 

`prompt.Send(context.Activity.Text, null, (chunk) => { ... })`

__
For simple use cases where request options isn't configured but streaming is.