### PR TITLE
Add `App.Use` to enable middlewares in routing logic 

### DIFF
--- a/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.Send.cs
+++ b/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.Send.cs
@@ -13,11 +13,6 @@ public partial class ChatPrompt<TOptions>
         return await Send(message, null, null, cancellationToken);
     }
 
-    public async Task<ModelMessage<string>> Send(string text, OnStreamChunk? onChunk = null, CancellationToken cancellationToken = default)
-    {
-        return await Send(text, null, onChunk, cancellationToken);
-    }
-
     public Task<ModelMessage<string>> Send(string text, IChatPrompt<TOptions>.RequestOptions? options = null, OnStreamChunk? onChunk = null, CancellationToken cancellationToken = default)
     {
         var message = UserMessage.Text(text);

--- a/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.Send.cs
+++ b/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.Send.cs
@@ -13,6 +13,11 @@ public partial class ChatPrompt<TOptions>
         return await Send(message, null, null, cancellationToken);
     }
 
+    public async Task<ModelMessage<string>> Send(string text, OnStreamChunk? onChunk = null, CancellationToken cancellationToken = default)
+    {
+        return await Send(text, null, onChunk, cancellationToken);
+    }
+
     public Task<ModelMessage<string>> Send(string text, IChatPrompt<TOptions>.RequestOptions? options = null, OnStreamChunk? onChunk = null, CancellationToken cancellationToken = default)
     {
         var message = UserMessage.Text(text);

--- a/Libraries/Microsoft.Teams.Apps/AppRouting.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppRouting.cs
@@ -185,7 +185,12 @@ public partial class App
     /// <returns></returns>
     public App Use(Func<IContext<IActivity>, Task<object?>> handler)
     {
-        Router.Register(handler);
+        Router.Register(new Route() {
+            Name = "middleware",
+            Type = RouteType.User,
+            Selector = _ => true,
+            Handler = handler
+        });
         return this;
     }
 }

--- a/Libraries/Microsoft.Teams.Apps/AppRouting.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppRouting.cs
@@ -29,7 +29,7 @@ public partial class App
         foreach (var method in methods)
         {
             var attrs = method.GetCustomAttributes<ActivityAttribute>(true);
-             
+
             foreach (var attr in attrs)
             {
                 var route = new AttributeRoute() { Attr = attr, Method = method, Object = controller };

--- a/Libraries/Microsoft.Teams.Apps/AppRouting.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppRouting.cs
@@ -29,7 +29,7 @@ public partial class App
         foreach (var method in methods)
         {
             var attrs = method.GetCustomAttributes<ActivityAttribute>(true);
-
+             
             foreach (var attr in attrs)
             {
                 var route = new AttributeRoute() { Attr = attr, Method = method, Object = controller };
@@ -176,5 +176,16 @@ public partial class App
 
             return new Response(HttpStatusCode.PreconditionFailed);
         }
+    }
+
+    /// <summary>
+    /// Register a middleware.
+    /// </summary>
+    /// <param name="handler">Callback to invoke.</param>
+    /// <returns></returns>
+    public App Use(Func<IContext<IActivity>, Task<object?>> handler)
+    {
+        Router.Register(handler);
+        return this;
     }
 }

--- a/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.Teams.Api.Auth;
+﻿using Microsoft.Teams.Api;
+using Microsoft.Teams.Api.Activities;
+using Microsoft.Teams.Api.Auth;
 using Microsoft.Teams.Api.Clients;
+using Microsoft.Teams.Apps.Plugins;
 using Microsoft.Teams.Common.Http;
 
 using Moq;
@@ -213,5 +216,75 @@ public class AppTests
 
         // assert
         Assert.True(tokenFactoryInvoked);
+    }
+
+    [Fact]
+    public async Task Test_App_Process_Should_Call_Middleware()
+    {
+        // arrange
+        var client = new Mock<Common.Http.HttpClient>();
+        var app = new App();
+        var sender = new Mock<ISenderPlugin>();
+        sender.Setup(s => s.CreateStream(It.IsAny<ConversationReference>(), It.IsAny<CancellationToken>())).Returns(new Mock<IStreamer>().Object);
+        var token = new Mock<IToken>();
+        var activity = new MessageActivity()
+        {
+            From = new() { Id = "testId" }
+        };
+
+        // act
+        var middlewareCalled = false;
+        app.Use(async (context) =>
+        {
+            middlewareCalled = true;
+            await context.Next();
+            return null;
+        });
+        await app.Process(sender.Object, token.Object, activity);
+        
+        // assert
+        Assert.True(middlewareCalled);
+    }
+
+    [Fact]
+    public async Task Test_App_Process_Should_Call_Middlewares_In_Order()
+    {
+        // arrange
+        var client = new Mock<Common.Http.HttpClient>();
+        var app = new App();
+        var sender = new Mock<ISenderPlugin>();
+        sender.Setup(s => s.CreateStream(It.IsAny<ConversationReference>(), It.IsAny<CancellationToken>())).Returns(new Mock<IStreamer>().Object);
+        var token = new Mock<IToken>();
+        var activity = new MessageActivity()
+        {
+            From = new() { Id = "testId" }
+        };
+
+        // act
+        var firstMiddlewareCalled = false;
+        var secondMiddlewareCalled = false;
+        var middlewaresCalledInOrder = false;
+        app.Use(async (context) =>
+        {
+            firstMiddlewareCalled = true;
+            var middleware = await context.Next();
+            if ((string?)middleware == "middleware2" && secondMiddlewareCalled)
+            {
+                middlewaresCalledInOrder = true;
+            }
+
+            return null;
+        });
+        app.Use(async (context) =>
+        {
+            secondMiddlewareCalled = true;
+            return "middleware2";
+        });
+        await app.Process(sender.Object, token.Object, activity);
+
+        // assert
+        Assert.True(middlewaresCalledInOrder);
+        Assert.True(secondMiddlewareCalled);
+        Assert.True(firstMiddlewareCalled);
     }
 }

--- a/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
@@ -275,10 +275,10 @@ public class AppTests
 
             return null;
         });
-        app.Use(async (context) =>
+        app.Use((context) =>
         {
             secondMiddlewareCalled = true;
-            return "middleware2";
+            return Task.FromResult((object?)"middleware2");
         });
         await app.Process(sender.Object, token.Object, activity);
 


### PR DESCRIPTION
### Middleware support in `App`:

* Added a `Use` method to the `App` class, allowing registration of middleware functions that process activities. This enables chaining of custom logic during activity processing.
* Parity with [TS SDK](https://github.com/microsoft/teams.ts/blob/08f92b23b79f060b069e47d9ecfe5c61dbeaa143/packages/apps/src/app.routing.ts#L56)
* **Caveat:** It is only available w/ minimal api-style activity handling since controller-style handlers are not registered in order (because there is no reliable way to determine that). It wouldn't make much sense to add a middleware when you can't control the  order of execution.