### PR TITLE
Fix message extension link unfurling sample to use "preview"

### DIFF
--- a/Samples/Samples.MessageExtensions/Program.cs
+++ b/Samples/Samples.MessageExtensions/Program.cs
@@ -390,7 +390,16 @@ public static partial class Program
             var attachment = new Microsoft.Teams.Api.MessageExtensions.Attachment
             {
                 ContentType = new Microsoft.Teams.Api.ContentType("application/vnd.microsoft.card.adaptive"),
-                Content = card
+                Content = card,
+                Preview = new Microsoft.Teams.Api.MessageExtensions.Attachment
+                {
+                    ContentType = Microsoft.Teams.Api.ContentType.ThumbnailCard,
+                    Content = new ThumbnailCard
+                    {
+                        Title = "Link Preview",
+                        Text = url
+                    }
+                }
             };
 
             return new Microsoft.Teams.Api.MessageExtensions.Response


### PR DESCRIPTION
Without this, the card won't render