### PR TITLE
Add overload for `.Use` middleware

### DIFF
--- a/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.Send.cs
+++ b/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.Send.cs
@@ -13,11 +13,6 @@ public partial class ChatPrompt<TOptions>
         return await Send(message, null, null, cancellationToken);
     }
 
-    public async Task<ModelMessage<string>> Send(string text, OnStreamChunk? onChunk = null, CancellationToken cancellationToken = default)
-    {
-        return await Send(text, null, onChunk, cancellationToken);
-    }
-
     public Task<ModelMessage<string>> Send(string text, IChatPrompt<TOptions>.RequestOptions? options = null, OnStreamChunk? onChunk = null, CancellationToken cancellationToken = default)
     {
         var message = UserMessage.Text(text);

--- a/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.Send.cs
+++ b/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.Send.cs
@@ -13,6 +13,11 @@ public partial class ChatPrompt<TOptions>
         return await Send(message, null, null, cancellationToken);
     }
 
+    public async Task<ModelMessage<string>> Send(string text, OnStreamChunk? onChunk = null, CancellationToken cancellationToken = default)
+    {
+        return await Send(text, null, onChunk, cancellationToken);
+    }
+
     public Task<ModelMessage<string>> Send(string text, IChatPrompt<TOptions>.RequestOptions? options = null, OnStreamChunk? onChunk = null, CancellationToken cancellationToken = default)
     {
         var message = UserMessage.Text(text);

--- a/Libraries/Microsoft.Teams.Apps/AppRouting.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppRouting.cs
@@ -185,7 +185,12 @@ public partial class App
     /// <returns></returns>
     public App Use(Func<IContext<IActivity>, Task<object?>> handler)
     {
-        Router.Register(handler);
+        Router.Register(new Route() {
+            Name = "middleware",
+            Type = RouteType.User,
+            Selector = _ => true,
+            Handler = handler
+        });
         return this;
     }
 }

--- a/Libraries/Microsoft.Teams.Apps/AppRouting.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppRouting.cs
@@ -193,4 +193,18 @@ public partial class App
         });
         return this;
     }
+
+    /// <summary>
+    /// Register a middleware.
+    /// </summary>
+    /// <param name="handler">Callback to invoke.</param>
+    /// <returns></returns>
+    public App Use(Func<IContext<IActivity>, Task> handler)
+    {
+        return Use(async (context) =>
+        {
+            await handler(context);
+            return null;
+        });
+    }
 }

--- a/Libraries/Microsoft.Teams.Apps/AppRouting.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppRouting.cs
@@ -29,7 +29,7 @@ public partial class App
         foreach (var method in methods)
         {
             var attrs = method.GetCustomAttributes<ActivityAttribute>(true);
-             
+
             foreach (var attr in attrs)
             {
                 var route = new AttributeRoute() { Attr = attr, Method = method, Object = controller };

--- a/Libraries/Microsoft.Teams.Apps/AppRouting.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppRouting.cs
@@ -29,7 +29,7 @@ public partial class App
         foreach (var method in methods)
         {
             var attrs = method.GetCustomAttributes<ActivityAttribute>(true);
-
+             
             foreach (var attr in attrs)
             {
                 var route = new AttributeRoute() { Attr = attr, Method = method, Object = controller };
@@ -176,5 +176,16 @@ public partial class App
 
             return new Response(HttpStatusCode.PreconditionFailed);
         }
+    }
+
+    /// <summary>
+    /// Register a middleware.
+    /// </summary>
+    /// <param name="handler">Callback to invoke.</param>
+    /// <returns></returns>
+    public App Use(Func<IContext<IActivity>, Task<object?>> handler)
+    {
+        Router.Register(handler);
+        return this;
     }
 }

--- a/Samples/Samples.Graph/Program.cs
+++ b/Samples/Samples.Graph/Program.cs
@@ -2,21 +2,36 @@ using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Activities;
 using Microsoft.Teams.Apps.Events;
 using Microsoft.Teams.Apps.Extensions;
+using Microsoft.Teams.Common.Logging;
 using Microsoft.Teams.Extensions.Graph;
+using Microsoft.Teams.Plugins.AspNetCore.DevTools.Extensions;
 using Microsoft.Teams.Plugins.AspNetCore.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
 var appBuilder = App.Builder()
-    .AddLogger(level: Microsoft.Teams.Common.Logging.LogLevel.Debug)
+    .AddLogger(new ConsoleLogger())
     // The name of the auth connection to use.
     // It should be the same as the OAuth connection name defined in the Azure Bot configuration.
     .AddOAuth("graph");
 
-builder.AddTeams(appBuilder);
+builder.AddTeams(appBuilder).AddTeamsDevTools();
 
 var app = builder.Build();
 var teams = app.UseTeams();
+
+teams.Use(async context =>
+{
+    var start = DateTime.UtcNow;
+    try
+    {
+        await context.Next();
+    } catch
+    {
+        context.Log.Error("error occurred during activity processing");
+    }
+    context.Log.Debug($"request took {(DateTime.UtcNow - start).TotalMilliseconds}ms");
+});
 
 teams.OnMessage("/signout", async context =>
 {

--- a/Samples/Samples.Graph/Program.cs
+++ b/Samples/Samples.Graph/Program.cs
@@ -10,7 +10,7 @@ using Microsoft.Teams.Plugins.AspNetCore.Extensions;
 var builder = WebApplication.CreateBuilder(args);
 
 var appBuilder = App.Builder()
-    .AddLogger(new ConsoleLogger())
+    .AddLogger(new ConsoleLogger(level: Microsoft.Teams.Common.Logging.LogLevel.Debug))
     // The name of the auth connection to use.
     // It should be the same as the OAuth connection name defined in the Azure Bot configuration.
     .AddOAuth("graph");

--- a/Samples/Samples.Graph/Samples.Graph.csproj
+++ b/Samples/Samples.Graph/Samples.Graph.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\Libraries\Microsoft.Teams.Extensions\Microsoft.Teams.Extensions.Hosting\Microsoft.Teams.Extensions.Hosting.csproj" />
     <ProjectReference Include="..\..\Libraries\Microsoft.Teams.Extensions\Microsoft.Teams.Extensions.Graph\Microsoft.Teams.Extensions.Graph.csproj" />
     <ProjectReference Include="..\..\Libraries\Microsoft.Teams.Plugins\Microsoft.Teams.Plugins.AspNetCore\Microsoft.Teams.Plugins.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\Libraries\Microsoft.Teams.Plugins\Microsoft.Teams.Plugins.AspNetCore.DevTools\Microsoft.Teams.Plugins.AspNetCore.DevTools.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
@@ -238,7 +238,6 @@ public class AppTests
         {
             middlewareCalled = true;
             await context.Next();
-            return null;
         });
         await app.Process(sender.Object, token.Object, activity);
         

--- a/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.Teams.Api.Auth;
+﻿using Microsoft.Teams.Api;
+using Microsoft.Teams.Api.Activities;
+using Microsoft.Teams.Api.Auth;
 using Microsoft.Teams.Api.Clients;
+using Microsoft.Teams.Apps.Plugins;
 using Microsoft.Teams.Common.Http;
 
 using Moq;
@@ -213,5 +216,75 @@ public class AppTests
 
         // assert
         Assert.True(tokenFactoryInvoked);
+    }
+
+    [Fact]
+    public async Task Test_App_Process_Should_Call_Middleware()
+    {
+        // arrange
+        var client = new Mock<Common.Http.HttpClient>();
+        var app = new App();
+        var sender = new Mock<ISenderPlugin>();
+        sender.Setup(s => s.CreateStream(It.IsAny<ConversationReference>(), It.IsAny<CancellationToken>())).Returns(new Mock<IStreamer>().Object);
+        var token = new Mock<IToken>();
+        var activity = new MessageActivity()
+        {
+            From = new() { Id = "testId" }
+        };
+
+        // act
+        var middlewareCalled = false;
+        app.Use(async (context) =>
+        {
+            middlewareCalled = true;
+            await context.Next();
+            return null;
+        });
+        await app.Process(sender.Object, token.Object, activity);
+        
+        // assert
+        Assert.True(middlewareCalled);
+    }
+
+    [Fact]
+    public async Task Test_App_Process_Should_Call_Middlewares_In_Order()
+    {
+        // arrange
+        var client = new Mock<Common.Http.HttpClient>();
+        var app = new App();
+        var sender = new Mock<ISenderPlugin>();
+        sender.Setup(s => s.CreateStream(It.IsAny<ConversationReference>(), It.IsAny<CancellationToken>())).Returns(new Mock<IStreamer>().Object);
+        var token = new Mock<IToken>();
+        var activity = new MessageActivity()
+        {
+            From = new() { Id = "testId" }
+        };
+
+        // act
+        var firstMiddlewareCalled = false;
+        var secondMiddlewareCalled = false;
+        var middlewaresCalledInOrder = false;
+        app.Use(async (context) =>
+        {
+            firstMiddlewareCalled = true;
+            var middleware = await context.Next();
+            if ((string?)middleware == "middleware2" && secondMiddlewareCalled)
+            {
+                middlewaresCalledInOrder = true;
+            }
+
+            return null;
+        });
+        app.Use(async (context) =>
+        {
+            secondMiddlewareCalled = true;
+            return "middleware2";
+        });
+        await app.Process(sender.Object, token.Object, activity);
+
+        // assert
+        Assert.True(middlewaresCalledInOrder);
+        Assert.True(secondMiddlewareCalled);
+        Assert.True(firstMiddlewareCalled);
     }
 }

--- a/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
@@ -275,10 +275,10 @@ public class AppTests
 
             return null;
         });
-        app.Use(async (context) =>
+        app.Use((context) =>
         {
             secondMiddlewareCalled = true;
-            return "middleware2";
+            return Task.FromResult((object?)"middleware2");
         });
         await app.Process(sender.Object, token.Object, activity);
 


### PR DESCRIPTION
Developers aren't forced to `return null` in the handlers if there's nothing to return.

> Changes added to graph samples are used in the docs snippets