### PR TITLE
Auto create function params

### DIFF
--- a/Libraries/Microsoft.Teams.AI/Function.cs
+++ b/Libraries/Microsoft.Teams.AI/Function.cs
@@ -57,7 +57,7 @@ public class Function : IFunction
 
     [JsonPropertyName("parameters")]
     [JsonPropertyOrder(2)]
-    public JsonSchema Parameters { get; set; }
+    public JsonSchema? Parameters { get; set; }
 
     [JsonIgnore]
     public Delegate Handler { get; set; }
@@ -80,7 +80,7 @@ public class Function : IFunction
 
     internal Task<object?> Invoke(FunctionCall call)
     {
-        if (call.Arguments is not null)
+        if (call.Arguments is not null && Parameters is not null)
         {
             var valid = Parameters.Evaluate(JsonNode.Parse(call.Arguments), new() { EvaluateAs = SpecVersion.DraftNext });
 
@@ -128,14 +128,14 @@ public class Function : IFunction
     /// <summary>
     /// Generates a JsonSchema for the parameters of a delegate handler using reflection
     /// </summary>
-    private static JsonSchema GenerateParametersSchema(Delegate handler)
+    private static JsonSchema? GenerateParametersSchema(Delegate handler)
     {
         var method = handler.GetMethodInfo();
         var methodParams = method.GetParameters();
 
         if (methodParams.Length == 0)
         {
-            return new JsonSchemaBuilder().Type(SchemaValueType.Object).Build();
+            return null;
         }
 
         var parameters = methodParams.Select(p =>

--- a/Libraries/Microsoft.Teams.AI/Function.cs
+++ b/Libraries/Microsoft.Teams.AI/Function.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 using Json.Schema;
+using Json.Schema.Generation;
 
 using Microsoft.Teams.AI.Annotations;
 using Microsoft.Teams.AI.Messages;
@@ -66,6 +67,7 @@ public class Function : IFunction
         Name = name;
         Description = description;
         Handler = handler;
+        Parameters = GenerateParametersSchema(handler);
     }
 
     public Function(string name, string? description, JsonSchema? parameters, Delegate handler)
@@ -74,6 +76,34 @@ public class Function : IFunction
         Description = description;
         Parameters = parameters;
         Handler = handler;
+    }
+
+    /// <summary>
+    /// Generates a JsonSchema for the parameters of a delegate handler using reflection
+    /// </summary>
+    private static JsonSchema? GenerateParametersSchema(Delegate handler)
+    {
+        var method = handler.GetMethodInfo();
+        var methodParams = method.GetParameters();
+
+        if (methodParams.Length == 0)
+        {
+            return null;
+        }
+
+        var parameters = methodParams.Select(p =>
+        {
+            var paramName = p.GetCustomAttribute<ParamAttribute>()?.Name ?? p.Name ?? p.Position.ToString();
+            var schema = new JsonSchemaBuilder().FromType(p.ParameterType).Build();
+            var required = !p.IsOptional;
+            return (paramName, schema, required);
+        });
+
+        return new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(parameters.Select(item => (item.paramName, item.schema)).ToArray())
+            .Required(parameters.Where(item => item.required).Select(item => item.paramName))
+            .Build();
     }
 
     internal Task<object?> Invoke(FunctionCall call)

--- a/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.Send.cs
+++ b/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.Send.cs
@@ -13,12 +13,17 @@ public partial class ChatPrompt<TOptions>
         return await Send(message, null, null, cancellationToken);
     }
 
-    public async Task<ModelMessage<string>> Send(string text, OnStreamChunk? onChunk = null, CancellationToken cancellationToken = default)
+    public async Task<ModelMessage<string>> Send(string text, CancellationToken cancellationToken = default)
+    {
+        return await Send(text, null, null, cancellationToken);
+    }
+
+    public async Task<ModelMessage<string>> Send(string text, OnStreamChunk? onChunk, CancellationToken cancellationToken = default)
     {
         return await Send(text, null, onChunk, cancellationToken);
     }
 
-    public Task<ModelMessage<string>> Send(string text, IChatPrompt<TOptions>.RequestOptions? options = null, OnStreamChunk? onChunk = null, CancellationToken cancellationToken = default)
+    public Task<ModelMessage<string>> Send(string text, IChatPrompt<TOptions>.RequestOptions? options, OnStreamChunk? onChunk = null, CancellationToken cancellationToken = default)
     {
         var message = UserMessage.Text(text);
         return Send((IMessage)message, options, onChunk, cancellationToken);

--- a/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.cs
+++ b/Libraries/Microsoft.Teams.AI/Prompts/ChatPrompt/ChatPrompt.cs
@@ -3,9 +3,6 @@
 
 using System.Reflection;
 
-using Json.Schema;
-using Json.Schema.Generation;
-
 using Microsoft.Teams.AI.Annotations;
 using Microsoft.Teams.AI.Messages;
 using Microsoft.Teams.AI.Models;
@@ -213,23 +210,9 @@ public partial class ChatPrompt<TOptions> : IChatPrompt<TOptions>
 
             if (functionAttribute is null) continue;
 
-            var parameters = method.GetParameters().Select(p =>
-            {
-                var name = p.GetCustomAttribute<ParamAttribute>()?.Name ?? p.Name ?? p.Position.ToString();
-                var schema = new JsonSchemaBuilder().FromType(p.ParameterType).Build();
-                var required = !p.IsOptional;
-                return (name, schema, required);
-            });
-
-            var schema = new JsonSchemaBuilder()
-                .Type(SchemaValueType.Object)
-                .Properties(parameters.Select(item => (item.name, item.schema)).ToArray())
-                .Required(parameters.Where(item => item.required).Select(item => item.name));
-
             var function = new Function(
                 functionAttribute.Name ?? method.Name,
                 functionAttribute.Description ?? functionDescriptionAttribute?.Description,
-                parameters.Count() > 0 ? schema.Build() : null,
                 method.CreateDelegate(value)
             );
 

--- a/Tests/Microsoft.Teams.AI.Tests/FunctionTests.cs
+++ b/Tests/Microsoft.Teams.AI.Tests/FunctionTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.Teams.AI.Annotations;
+
+namespace Microsoft.Teams.AI.Tests;
+
+public class FunctionTests
+{
+    [Fact]
+    public void Test_Function_GeneratesParametersSchema_FromDelegate()
+    {
+        // Arrange & Act
+        var function = new Function(
+            "test_function",
+            "A test function",
+            ([Param("name")] string name, int age) => $"Hello {name}, age {age}"
+        );
+
+        // Assert
+        Assert.NotNull(function.Parameters);
+    }
+
+    [Fact]
+    public void Test_Function_GeneratesParametersSchema_WithParamAttribute()
+    {
+        // Arrange & Act
+        var function = new Function(
+            "pokemon_search",
+            "Search for pokemon",
+            ([Param("pokemon_name")] string pokemonName) => $"Searching for {pokemonName}"
+        );
+
+        // Assert
+        Assert.NotNull(function.Parameters);
+    }
+
+    [Fact]
+    public void Test_Function_NoParameters_ReturnsNullSchema()
+    {
+        // Arrange & Act
+        var function = new Function(
+            "no_params_function",
+            "A function with no parameters",
+            () => "No params"
+        );
+
+        // Assert
+        Assert.Null(function.Parameters);
+    }
+
+    [Fact]
+    public void Test_Function_OptionalParameters_MarkedCorrectly()
+    {
+        // Arrange & Act
+        var function = new Function(
+            "optional_params_function",
+            "A function with optional parameters",
+            (string required, string optional = "default") => $"{required} {optional}"
+        );
+
+        // Assert
+        Assert.NotNull(function.Parameters);
+    }
+
+    [Fact]
+    public void Test_Function_MultipleParameters_GeneratesSchema()
+    {
+        // Arrange & Act
+        var function = new Function(
+            "multi_param_function",
+            "A function with multiple parameters",
+            (string name, int age, bool active) => $"{name} {age} {active}"
+        );
+
+        // Assert
+        Assert.NotNull(function.Parameters);
+    }
+}


### PR DESCRIPTION
When we add functions via .Function, we weren't auto-detecting the function params. This adds that functionality. The other thing this does is it adds an overload for Send("string"). Without this, Our overloads that don't have a second parameter don't work.









#### PR Dependency Tree


* **PR #166** 👈
  * **PR #167**
    * **PR #168**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)