### PR TITLE
Add default scopes for token refresh

### DIFF
--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -80,7 +80,7 @@ public partial class App
 
                 if (Token.IsExpired)
                 {
-                    var res = Credentials.Resolve(TokenClient, [.. Token.Scopes])
+                    var res = Credentials.Resolve(TokenClient, [.. Token.Scopes.DefaultIfEmpty(BotTokenClient.BotScope)])
                     .ConfigureAwait(false)
                     .GetAwaiter()
                     .GetResult();


### PR DESCRIPTION
Fixes https://github.com/microsoft/teams.net/issues/172 by checking if the auth server echoed back all scopes. If not, default scope is set