### PR TITLE
Account Linking Url: Combined Auth Flow

### DIFF
--- a/Libraries/Microsoft.Teams.Api/Auth/ClientCredentials.cs
+++ b/Libraries/Microsoft.Teams.Api/Auth/ClientCredentials.cs
@@ -5,6 +5,10 @@ using Microsoft.Teams.Common.Http;
 
 namespace Microsoft.Teams.Api.Auth;
 
+/// <summary>
+/// ClientId / ClientSecret based credentials
+/// https://learn.microsoft.com/en-us/microsoft-365/agents-sdk/azure-bot-create-single-secret
+/// </summary>
 public class ClientCredentials : IHttpCredentials
 {
     public string ClientId { get; set; }

--- a/Libraries/Microsoft.Teams.Api/Auth/TokenCredentials.cs
+++ b/Libraries/Microsoft.Teams.Api/Auth/TokenCredentials.cs
@@ -7,6 +7,12 @@ namespace Microsoft.Teams.Api.Auth;
 
 public delegate Task<ITokenResponse> TokenFactory(string? tenantId, params string[] scopes);
 
+/// <summary>
+/// Provide a <code>TokenFactory</code> that will be invoked whenever
+/// the application needs a token.
+/// TokenCredentials should be used with 3rd party packages like MSAL/Azure.Identity
+/// to authenticate for any Federated/Managed Identity scenarios.
+/// </summary>
 public class TokenCredentials : IHttpCredentials
 {
     public string ClientId { get; set; }
@@ -26,7 +32,7 @@ public class TokenCredentials : IHttpCredentials
         Token = token;
     }
 
-    public async Task<ITokenResponse> Resolve(IHttpClient _client, string[] scopes, CancellationToken cancellationToken = default)
+    public async Task<ITokenResponse> Resolve(IHttpClient _, string[] scopes, CancellationToken cancellationToken = default)
     {
         return await Token(TenantId, scopes);
     }

--- a/Libraries/Microsoft.Teams.Api/Clients/ActivityClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/ActivityClient.cs
@@ -32,7 +32,7 @@ public class ActivityClient : Client
         ServiceUrl = serviceUrl;
     }
 
-    public async Task<Resource?> CreateAsync(string conversationId, IActivity activity, bool isTargeted = false)
+    public virtual async Task<Resource?> CreateAsync(string conversationId, IActivity activity, bool isTargeted = false)
     {
         var url = $"{ServiceUrl}v3/conversations/{conversationId}/activities";
         if (isTargeted)
@@ -50,7 +50,7 @@ public class ActivityClient : Client
         return body;
     }
 
-    public async Task<Resource?> UpdateAsync(string conversationId, string id, IActivity activity, bool isTargeted = false)
+    public virtual async Task<Resource?> UpdateAsync(string conversationId, string id, IActivity activity, bool isTargeted = false)
     {
         var url = $"{ServiceUrl}v3/conversations/{conversationId}/activities/{id}";
         if (isTargeted)
@@ -68,7 +68,7 @@ public class ActivityClient : Client
         return body;
     }
 
-    public async Task<Resource?> ReplyAsync(string conversationId, string id, IActivity activity, bool isTargeted = false)
+    public virtual async Task<Resource?> ReplyAsync(string conversationId, string id, IActivity activity, bool isTargeted = false)
     {
         activity.ReplyToId = id;
 
@@ -88,7 +88,7 @@ public class ActivityClient : Client
         return body;
     }
 
-    public async Task DeleteAsync(string conversationId, string id, bool isTargeted = false)
+    public virtual async Task DeleteAsync(string conversationId, string id, bool isTargeted = false)
     {
         var url = $"{ServiceUrl}v3/conversations/{conversationId}/activities/{id}";
         if (isTargeted)

--- a/Libraries/Microsoft.Teams.Api/Clients/BotClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/BotClient.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Teams.Api.Clients;
 public class BotClient : Client
 {
     public virtual BotTokenClient Token { get; }
-    public BotSignInClient SignIn { get; }
+    public virtual BotSignInClient SignIn { get; }
 
     public BotClient() : this(default)
     {

--- a/Libraries/Microsoft.Teams.Api/Clients/BotSignInClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/BotSignInClient.cs
@@ -27,7 +27,7 @@ public class BotSignInClient : Client
 
     }
 
-    public async Task<string> GetUrlAsync(GetUrlRequest request)
+    public virtual async Task<string> GetUrlAsync(GetUrlRequest request)
     {
         var query = QueryString.Serialize(request);
         var req = HttpRequest.Get(
@@ -38,7 +38,7 @@ public class BotSignInClient : Client
         return res.Body;
     }
 
-    public async Task<SignIn.UrlResponse> GetResourceAsync(GetResourceRequest request)
+    public virtual async Task<SignIn.UrlResponse> GetResourceAsync(GetResourceRequest request)
     {
         var query = QueryString.Serialize(request);
         var req = HttpRequest.Get(

--- a/Libraries/Microsoft.Teams.Api/Clients/BotTokenClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/BotTokenClient.cs
@@ -10,7 +10,7 @@ public class BotTokenClient : Client
     public static readonly string BotScope = "https://api.botframework.com/.default";
     public static readonly string GraphScope = "https://graph.microsoft.com/.default";
 
-    public BotTokenClient() : this(default)
+    public BotTokenClient() : base()
     {
 
     }
@@ -40,7 +40,7 @@ public class BotTokenClient : Client
         return await credentials.Resolve(http ?? _http, [BotScope], _cancellationToken);
     }
 
-    public async Task<ITokenResponse> GetGraphAsync(IHttpCredentials credentials, IHttpClient? http = null)
+    public virtual async Task<ITokenResponse> GetGraphAsync(IHttpCredentials credentials, IHttpClient? http = null)
     {
         return await credentials.Resolve(http ?? _http, [GraphScope], _cancellationToken);
     }

--- a/Libraries/Microsoft.Teams.Api/Clients/ConversationClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/ConversationClient.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Teams.Api.Clients;
 public class ConversationClient : Client
 {
     public readonly string ServiceUrl;
-    public readonly ActivityClient Activities;
-    public readonly MemberClient Members;
+    public virtual ActivityClient Activities { get; }
+    public virtual MemberClient Members { get; }
 
     public ConversationClient(string serviceUrl, CancellationToken cancellationToken = default) : base(cancellationToken)
     {
@@ -42,7 +42,7 @@ public class ConversationClient : Client
         Members = new MemberClient(serviceUrl, _http, cancellationToken);
     }
 
-    public async Task<ConversationResource> CreateAsync(CreateRequest request)
+    public virtual async Task<ConversationResource> CreateAsync(CreateRequest request)
     {
         var req = HttpRequest.Post($"{ServiceUrl}v3/conversations", body: request);
         var res = await _http.SendAsync<ConversationResource>(req, _cancellationToken);

--- a/Libraries/Microsoft.Teams.Api/Clients/MeetingClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/MeetingClient.cs
@@ -32,14 +32,14 @@ public class MeetingClient : Client
         ServiceUrl = serviceUrl;
     }
 
-    public async Task<Meeting> GetByIdAsync(string id)
+    public virtual async Task<Meeting> GetByIdAsync(string id)
     {
         var request = HttpRequest.Get($"{ServiceUrl}v1/meetings/{id}");
         var response = await _http.SendAsync<Meeting>(request, _cancellationToken);
         return response.Body;
     }
 
-    public async Task<MeetingParticipant> GetParticipantAsync(string meetingId, string id)
+    public virtual async Task<MeetingParticipant> GetParticipantAsync(string meetingId, string id)
     {
         var request = HttpRequest.Get($"{ServiceUrl}v1/meetings/{meetingId}/participants/{id}");
         var response = await _http.SendAsync<MeetingParticipant>(request, _cancellationToken);

--- a/Libraries/Microsoft.Teams.Api/Clients/MemberClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/MemberClient.cs
@@ -29,21 +29,21 @@ public class MemberClient : Client
         ServiceUrl = serviceUrl;
     }
 
-    public async Task<List<Account>> GetAsync(string conversationId)
+    public virtual async Task<List<Account>> GetAsync(string conversationId)
     {
         var request = HttpRequest.Get($"{ServiceUrl}v3/conversations/{conversationId}/members");
         var response = await _http.SendAsync<List<Account>>(request, _cancellationToken);
         return response.Body;
     }
 
-    public async Task<Account> GetByIdAsync(string conversationId, string memberId)
+    public virtual async Task<Account> GetByIdAsync(string conversationId, string memberId)
     {
         var request = HttpRequest.Get($"{ServiceUrl}v3/conversations/{conversationId}/members/{memberId}");
         var response = await _http.SendAsync<Account>(request, _cancellationToken);
         return response.Body;
     }
 
-    public async Task DeleteAsync(string conversationId, string memberId)
+    public virtual async Task DeleteAsync(string conversationId, string memberId)
     {
         var request = HttpRequest.Delete($"{ServiceUrl}v3/conversations/{conversationId}/members/{memberId}");
         await _http.SendAsync(request, _cancellationToken);

--- a/Libraries/Microsoft.Teams.Api/Clients/TeamClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/TeamClient.cs
@@ -29,14 +29,14 @@ public class TeamClient : Client
         ServiceUrl = serviceUrl;
     }
 
-    public async Task<Team> GetByIdAsync(string id)
+    public virtual async Task<Team> GetByIdAsync(string id)
     {
         var request = HttpRequest.Get($"{ServiceUrl}v3/teams/{id}");
         var response = await _http.SendAsync<Team>(request, _cancellationToken);
         return response.Body;
     }
 
-    public async Task<List<Channel>> GetConversationsAsync(string id)
+    public virtual async Task<List<Channel>> GetConversationsAsync(string id)
     {
         var request = HttpRequest.Get($"{ServiceUrl}v3/teams/{id}/conversations");
         var response = await _http.SendAsync<List<Channel>>(request, _cancellationToken);

--- a/Libraries/Microsoft.Teams.Api/Clients/UserClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/UserClient.cs
@@ -7,7 +7,12 @@ namespace Microsoft.Teams.Api.Clients;
 
 public class UserClient : Client
 {
-    public UserTokenClient Token { get; }
+    public virtual UserTokenClient Token { get; }
+
+    public UserClient() : base()
+    {
+        Token = new UserTokenClient(_http, _cancellationToken);
+    }
 
     public UserClient(CancellationToken cancellationToken = default) : base(cancellationToken)
     {

--- a/Libraries/Microsoft.Teams.Api/Clients/UserTokenClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/UserTokenClient.cs
@@ -17,7 +17,7 @@ public class UserTokenClient : Client
 
     public UserTokenClient() : base()
     {
-        
+
     }
 
     public UserTokenClient(CancellationToken cancellationToken = default) : base(cancellationToken)

--- a/Libraries/Microsoft.Teams.Api/Clients/UserTokenClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/UserTokenClient.cs
@@ -15,6 +15,11 @@ public class UserTokenClient : Client
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
+    public UserTokenClient() : base()
+    {
+        
+    }
+
     public UserTokenClient(CancellationToken cancellationToken = default) : base(cancellationToken)
     {
 
@@ -35,7 +40,7 @@ public class UserTokenClient : Client
 
     }
 
-    public async Task<Token.Response> GetAsync(GetTokenRequest request)
+    public virtual async Task<Token.Response> GetAsync(GetTokenRequest request)
     {
         var query = QueryString.Serialize(request);
         var req = HttpRequest.Get($"https://token.botframework.com/api/usertoken/GetToken?{query}");
@@ -43,7 +48,7 @@ public class UserTokenClient : Client
         return res.Body;
     }
 
-    public async Task<IDictionary<string, Token.Response>> GetAadAsync(GetAadTokenRequest request)
+    public virtual async Task<IDictionary<string, Token.Response>> GetAadAsync(GetAadTokenRequest request)
     {
         var query = QueryString.Serialize(request);
         var req = HttpRequest.Post($"https://token.botframework.com/api/usertoken/GetAadTokens?{query}", body: request);
@@ -51,7 +56,7 @@ public class UserTokenClient : Client
         return res.Body;
     }
 
-    public async Task<IList<Token.Status>> GetStatusAsync(GetTokenStatusRequest request)
+    public virtual async Task<IList<Token.Status>> GetStatusAsync(GetTokenStatusRequest request)
     {
         var query = QueryString.Serialize(request);
         var req = HttpRequest.Get($"https://token.botframework.com/api/usertoken/GetTokenStatus?{query}");
@@ -59,14 +64,14 @@ public class UserTokenClient : Client
         return res.Body;
     }
 
-    public async Task SignOutAsync(SignOutRequest request)
+    public virtual async Task SignOutAsync(SignOutRequest request)
     {
         var query = QueryString.Serialize(request);
         var req = HttpRequest.Delete($"https://token.botframework.com/api/usertoken/SignOut?{query}");
         await _http.SendAsync(req, _cancellationToken);
     }
 
-    public async Task<Token.Response> ExchangeAsync(ExchangeTokenRequest request)
+    public virtual async Task<Token.Response> ExchangeAsync(ExchangeTokenRequest request)
     {
         var query = QueryString.Serialize(new
         {

--- a/Libraries/Microsoft.Teams.Apps/AppBuilder.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppBuilder.cs
@@ -92,9 +92,16 @@ public partial class AppBuilder
         return this;
     }
 
+    public AppBuilder AddOAuth(OAuthSettings oauthSettings)
+    {
+        _options.OAuth = oauthSettings;
+        return this;
+    }
+
     public AppBuilder AddOAuth(string defaultConnectionName)
     {
-        _options.OAuth = new OAuthSettings(defaultConnectionName);
+        _options.OAuth ??= new();
+        _options.OAuth.DefaultConnectionName = defaultConnectionName;
         return this;
     }
 

--- a/Libraries/Microsoft.Teams.Apps/AppOptions.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppOptions.cs
@@ -7,14 +7,49 @@ namespace Microsoft.Teams.Apps;
 
 public class AppOptions
 {
+    /// <summary>
+    /// The applications optional storage provider that allows
+    /// the application to access shared dependencies.
+    /// </summary>
     public IServiceProvider? Provider { get; set; }
+
+    /// <summary>
+    /// The applications optional ILogger instance.
+    /// </summary>
     public Common.Logging.ILogger? Logger { get; set; }
+
+    /// <summary>
+    /// The applications optional IStorage instance.
+    /// </summary>
     public Common.Storage.IStorage<string, object>? Storage { get; set; }
+
+    /// <summary>
+    /// When provided, the application will use this <code>IHttpClient</code> instance
+    /// to send all http requests.
+    /// </summary>
     public Common.Http.IHttpClient? Client { get; set; }
+
+    /// <summary>
+    /// When provided, the application will use this <code>IHttpClientFactory</code> to
+    /// initialize a new client whenever needed.
+    /// </summary>
     public Common.Http.IHttpClientFactory? ClientFactory { get; set; }
+
+    /// <summary>
+    /// When provided, the application will use these credentials to resolve tokens it
+    /// uses to make API requests.
+    /// </summary>
     public Common.Http.IHttpCredentials? Credentials { get; set; }
+
+    /// <summary>
+    /// A list of plugins to import into the application.
+    /// </summary>
     public IList<IPlugin> Plugins { get; set; } = [];
-    public OAuthSettings OAuth { get; set; } = new OAuthSettings();
+
+    /// <summary>
+    /// User <code>OAuth</code> settings for the deferred (User) auth flows.
+    /// </summary>
+    public OAuthSettings OAuth { get; set; } = new();
 
     public AppOptions()
     {

--- a/Libraries/Microsoft.Teams.Apps/AppRouting.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppRouting.cs
@@ -154,7 +154,11 @@ public partial class App
                     Token = res
                 }
             );
-            return new Response(HttpStatusCode.OK);
+
+            return new Response(HttpStatusCode.OK, OAuth.AccountLinkingUrl is null ? null : new
+            {
+                accountLinkingUrl = OAuth.AccountLinkingUrl
+            });
         }
         catch (HttpException ex)
         {

--- a/Libraries/Microsoft.Teams.Apps/Contexts/Context.cs
+++ b/Libraries/Microsoft.Teams.Apps/Contexts/Context.cs
@@ -113,6 +113,12 @@ public partial interface IContext<TActivity> where TActivity : IActivity
     public Task<object?> Next();
 
     /// <summary>
+    /// called to continue the chain of route handlers,
+    /// if not called no other handlers in the sequence will be executed
+    /// </summary>
+    public Task<object?> Next(IContext<TActivity> context);
+
+    /// <summary>
     /// convert the context to that of another activity type
     /// </summary>
     public IContext<IActivity> ToActivityType();
@@ -168,6 +174,7 @@ public partial class Context<TActivity>(ISenderPlugin sender, IStreamer stream) 
     }
 
     public Task<object?> Next() => OnNext(ToActivityType());
+    public Task<object?> Next(IContext<TActivity> context) => OnNext(context.ToActivityType());
     public IContext<IActivity> ToActivityType() => ToActivityType<IActivity>();
     public IContext<TToActivity> ToActivityType<TToActivity>() where TToActivity : IActivity
     {

--- a/Libraries/Microsoft.Teams.Apps/Contexts/Context.cs
+++ b/Libraries/Microsoft.Teams.Apps/Contexts/Context.cs
@@ -113,9 +113,12 @@ public partial interface IContext<TActivity> where TActivity : IActivity
     public Task<object?> Next();
 
     /// <summary>
-    /// called to continue the chain of route handlers,
-    /// if not called no other handlers in the sequence will be executed
+    /// Called to continue the chain of route handlers using the specified context instance.
+    /// Use this overload when you want to invoke the next handler with a different or wrapped
+    /// <see cref="IContext{TActivity}"/> than the current one; if not called, no other handlers
+    /// in the sequence will be executed.
     /// </summary>
+    /// <param name="context">The context to pass to the next handler in the chain.</param>
     public Task<object?> Next(IContext<TActivity> context);
 
     /// <summary>

--- a/Libraries/Microsoft.Teams.Apps/OAuthSettings.cs
+++ b/Libraries/Microsoft.Teams.Apps/OAuthSettings.cs
@@ -1,7 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-public class OAuthSettings(string? connectionName = "graph")
+namespace Microsoft.Teams.Apps;
+
+/// <summary>
+/// Settings for Deferred (User) auth flows
+/// </summary>
+public class OAuthSettings
 {
-    public string DefaultConnectionName { get; set; } = connectionName;
+    /// <summary>
+    /// The default connection name to use
+    /// </summary>
+    public string DefaultConnectionName { get; set; } = "graph";
+
+    /// <summary>
+    /// URL used for client side combined authentication flow.
+    /// </summary>
+    public string? AccountLinkingUrl { get; set; }
 }

--- a/Libraries/Microsoft.Teams.Apps/OAuthSettings.cs
+++ b/Libraries/Microsoft.Teams.Apps/OAuthSettings.cs
@@ -14,7 +14,7 @@ public class OAuthSettings
     public string DefaultConnectionName { get; set; } = "graph";
 
     /// <summary>
-    /// URL used for client side combined authentication flow.
+    /// Url used for client to perform tab auth and link the NAA account to the bot login account.
     /// </summary>
     public string? AccountLinkingUrl { get; set; }
 }

--- a/Libraries/Microsoft.Teams.Apps/Routing/Router.cs
+++ b/Libraries/Microsoft.Teams.Apps/Routing/Router.cs
@@ -24,6 +24,7 @@ public class Router : IRouter
     public IList<IRoute> Select(IActivity activity)
     {
         return _routes
+            .OrderBy(route => route.Type == RouteType.User ? 0 : 1)
             .Where(route => route.Select(activity))
             .ToList();
     }

--- a/Libraries/Microsoft.Teams.Common/Http/HttpCredentials.cs
+++ b/Libraries/Microsoft.Teams.Common/Http/HttpCredentials.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.Teams.Common.Http;
 
+/// <summary>
+/// Http Credential resolver used to fetch some access token. 
+/// </summary>
 public interface IHttpCredentials
 {
     public Task<ITokenResponse> Resolve(IHttpClient client, string[] scopes, CancellationToken cancellationToken = default);

--- a/Libraries/Microsoft.Teams.Common/Http/HttpCredentials.cs
+++ b/Libraries/Microsoft.Teams.Common/Http/HttpCredentials.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.Teams.Common.Http;
 
 /// <summary>
-/// Http Credential resolver used to fetch some access token. 
+/// Http Credential resolver used to fetch some access token.
 /// </summary>
 public interface IHttpCredentials
 {

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
@@ -28,7 +28,7 @@ public class TeamsSettings
     public string? AccountLinkingUrl { get; set; }
 
     /// <summary>
-    /// true when <code>ClientId</code> OR <code>ClientSecret</code> are empty
+    /// True when <code>ClientId</code> OR <code>ClientSecret</code> are empty
     /// </summary>
     public bool Empty => string.IsNullOrEmpty(ClientId) || string.IsNullOrEmpty(ClientSecret);
 

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
@@ -13,7 +13,7 @@ public class TeamsSettings
     public string? ClientId { get; set; }
 
     /// <summary>
-    /// The secret (ie password) for your application.
+    /// The secret (i.e. password) for your application.
     /// </summary>
     public string? ClientSecret { get; set; }
 

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
@@ -7,15 +7,34 @@ namespace Microsoft.Teams.Apps.Extensions;
 
 public class TeamsSettings
 {
+    /// <summary>
+    /// The ID assigned to your application.
+    /// </summary>
     public string? ClientId { get; set; }
+
+    /// <summary>
+    /// The secret (ie password) for your application.
+    /// </summary>
     public string? ClientSecret { get; set; }
+
+    /// <summary>
+    /// The Tenant ID assigned to your application (for single tenant apps only)
+    /// </summary>
     public string? TenantId { get; set; }
 
-    public bool Empty
-    {
-        get { return ClientId == "" || ClientSecret == ""; }
-    }
+    /// <summary>
+    /// URL used for client side combined authentication flow.
+    /// </summary>
+    public string? AccountLinkingUrl { get; set; }
 
+    /// <summary>
+    /// true when <code>ClientId</code> OR <code>ClientSecret</code> are empty
+    /// </summary>
+    public bool Empty => string.IsNullOrEmpty(ClientId) || string.IsNullOrEmpty(ClientSecret);
+
+    /// <summary>
+    /// Apply settings to app options.
+    /// </summary>
     public AppOptions Apply(AppOptions? options = null)
     {
         options ??= new AppOptions();
@@ -23,6 +42,11 @@ public class TeamsSettings
         if (ClientId is not null && ClientSecret is not null && !Empty)
         {
             options.Credentials = new ClientCredentials(ClientId, ClientSecret, TenantId);
+        }
+
+        if (AccountLinkingUrl is null)
+        {
+            options.OAuth.AccountLinkingUrl = AccountLinkingUrl;
         }
 
         return options;

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
@@ -44,7 +44,7 @@ public class TeamsSettings
             options.Credentials = new ClientCredentials(ClientId, ClientSecret, TenantId);
         }
 
-        if (AccountLinkingUrl is null)
+        if (!string.IsNullOrEmpty(AccountLinkingUrl))
         {
             options.OAuth.AccountLinkingUrl = AccountLinkingUrl;
         }

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
@@ -23,7 +23,7 @@ public class TeamsSettings
     public string? TenantId { get; set; }
 
     /// <summary>
-    /// URL used for client side combined authentication flow.
+    /// Url used for client to perform tab auth and link the NAA account to the bot login account.
     /// </summary>
     public string? AccountLinkingUrl { get; set; }
 

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/SignIn/VerifyStateActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/SignIn/VerifyStateActivityTests.cs
@@ -24,7 +24,7 @@ public class VerifyStateActivityTests
             AccountLinkingUrl = "https://my-website.com/accounts/link"
         }
     });
-    
+
     private readonly IToken _token = Globals.Token;
 
     public VerifyStateActivityTests()
@@ -58,7 +58,7 @@ public class VerifyStateActivityTests
             ConnectionName = "graph",
             Token = tokenHandler.WriteToken(new JwtSecurityTokenHandler().CreateToken(tokenDescriptor))
         });
-        
+
         _app.Api = api.Object;
         _app.OnActivity(context =>
         {
@@ -108,7 +108,7 @@ public class VerifyStateActivityTests
             ConnectionName = "test",
             Token = tokenHandler.WriteToken(new JwtSecurityTokenHandler().CreateToken(tokenDescriptor))
         }));
-        
+
         _app.Api = api.Object;
         _app.OnActivity(context =>
         {

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/SignIn/VerifyStateActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/SignIn/VerifyStateActivityTests.cs
@@ -1,0 +1,138 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.Teams.Api.Activities;
+using Microsoft.Teams.Api.Activities.Invokes;
+using Microsoft.Teams.Api.Auth;
+using Microsoft.Teams.Api.Clients;
+using Microsoft.Teams.Apps.Activities;
+using Microsoft.Teams.Apps.Activities.Invokes;
+using Microsoft.Teams.Apps.Testing.Plugins;
+
+using Moq;
+
+namespace Microsoft.Teams.Apps.Tests.Activities;
+
+public class VerifyStateActivityTests
+{
+    private readonly App _app = new(new()
+    {
+        OAuth = new()
+        {
+            AccountLinkingUrl = "https://my-website.com/accounts/link"
+        }
+    });
+    
+    private readonly IToken _token = Globals.Token;
+
+    public VerifyStateActivityTests()
+    {
+        _app.AddPlugin(new TestPlugin());
+    }
+
+    [Fact]
+    public async Task Should_Return_AccountLinkingUrl()
+    {
+        var calls = 0;
+        var api = new Mock<ApiClient>("https://api.com", new CancellationToken());
+        var userClient = new Mock<UserClient>();
+        var userTokenClient = new Mock<UserTokenClient>();
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var tokenDescriptor = new SecurityTokenDescriptor()
+        {
+            Subject = new ClaimsIdentity(),
+            Expires = DateTime.UtcNow.AddHours(1), // Token expiration
+            Issuer = "test",
+            SigningCredentials = new SigningCredentials(
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes("test_test_test_test_test_test_test_test")),
+                SecurityAlgorithms.HmacSha256
+            )
+        };
+
+        api.SetupGet(_ => _.Users).Returns(userClient.Object);
+        userClient.SetupGet(_ => _.Token).Returns(userTokenClient.Object);
+        userTokenClient.Setup(_ => _.GetAsync(It.IsAny<UserTokenClient.GetTokenRequest>())).ReturnsAsync(new Api.Token.Response()
+        {
+            ConnectionName = "graph",
+            Token = tokenHandler.WriteToken(new JwtSecurityTokenHandler().CreateToken(tokenDescriptor))
+        });
+        
+        _app.Api = api.Object;
+        _app.OnActivity(context =>
+        {
+            calls++;
+            Assert.True(context.Activity.Type.IsInvoke);
+            Assert.True(((Activity)context.Activity).ToInvoke().Name.IsSignIn);
+            Assert.True(((Activity)context.Activity).ToInvoke().ToSignIn() is SignIn.VerifyStateActivity);
+            context.Api = api.Object;
+            return context.Next(context);
+        });
+
+        var res = await _app.Process<TestPlugin>(_token, new SignIn.VerifyStateActivity()
+        {
+            From = new Api.Account() { Id = "test_user_id" },
+            Value = new() { State = "test_state" }
+        });
+
+        Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
+        Assert.Equal(1, calls);
+        Assert.Equal(2, res.Meta.Routes);
+        Assert.Equivalent(res.Body, new { accountLinkingUrl = _app.OAuth.AccountLinkingUrl });
+    }
+
+    [Fact]
+    public async Task Should_Override_AccountLinkingUrl()
+    {
+        var calls = 0;
+        var api = new Mock<ApiClient>("https://api.com", new CancellationToken());
+        var userClient = new Mock<UserClient>();
+        var userTokenClient = new Mock<UserTokenClient>();
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var tokenDescriptor = new SecurityTokenDescriptor()
+        {
+            Subject = new ClaimsIdentity(),
+            Expires = DateTime.UtcNow.AddHours(1), // Token expiration
+            Issuer = "test",
+            SigningCredentials = new SigningCredentials(
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes("test_test_test_test_test_test_test_test")),
+                SecurityAlgorithms.HmacSha256
+            )
+        };
+
+        api.SetupGet(_ => _.Users).Returns(userClient.Object);
+        userClient.SetupGet(_ => _.Token).Returns(userTokenClient.Object);
+        userTokenClient.Setup(_ => _.GetAsync(It.IsAny<UserTokenClient.GetTokenRequest>())).Returns(Task.FromResult(new Api.Token.Response()
+        {
+            ConnectionName = "test",
+            Token = tokenHandler.WriteToken(new JwtSecurityTokenHandler().CreateToken(tokenDescriptor))
+        }));
+        
+        _app.Api = api.Object;
+        _app.OnActivity(context =>
+        {
+            calls++;
+            Assert.True(context.Activity.Type.IsInvoke);
+            Assert.True(((Activity)context.Activity).ToInvoke().Name.IsSignIn);
+            Assert.True(((Activity)context.Activity).ToInvoke().ToSignIn() is SignIn.VerifyStateActivity);
+            return context.Next();
+        });
+
+        _app.OnVerifyState(context =>
+        {
+            calls++;
+            return Task.FromResult<object?>(new { accountLinkingUrl = "test_linking_url" });
+        });
+
+        var res = await _app.Process<TestPlugin>(_token, new SignIn.VerifyStateActivity()
+        {
+            Value = new() { State = "test_state" }
+        });
+
+        Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
+        Assert.Equal(2, calls);
+        Assert.Equal(2, res.Meta.Routes);
+        Assert.Equal(res.Body, new { accountLinkingUrl = "test_linking_url" });
+    }
+}

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/SignIn/VerifyStateActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/SignIn/VerifyStateActivityTests.cs
@@ -56,7 +56,7 @@ public class VerifyStateActivityTests
         userTokenClient.Setup(_ => _.GetAsync(It.IsAny<UserTokenClient.GetTokenRequest>())).ReturnsAsync(new Api.Token.Response()
         {
             ConnectionName = "graph",
-            Token = tokenHandler.WriteToken(new JwtSecurityTokenHandler().CreateToken(tokenDescriptor))
+            Token = tokenHandler.WriteToken(tokenHandler.CreateToken(tokenDescriptor))
         });
 
         _app.Api = api.Object;
@@ -106,7 +106,7 @@ public class VerifyStateActivityTests
         userTokenClient.Setup(_ => _.GetAsync(It.IsAny<UserTokenClient.GetTokenRequest>())).Returns(Task.FromResult(new Api.Token.Response()
         {
             ConnectionName = "test",
-            Token = tokenHandler.WriteToken(new JwtSecurityTokenHandler().CreateToken(tokenDescriptor))
+            Token = tokenHandler.WriteToken(tokenHandler.CreateToken(tokenDescriptor))
         }));
 
         _app.Api = api.Object;
@@ -133,6 +133,6 @@ public class VerifyStateActivityTests
         Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
         Assert.Equal(2, calls);
         Assert.Equal(2, res.Meta.Routes);
-        Assert.Equal(res.Body, new { accountLinkingUrl = "test_linking_url" });
+        Assert.Equivalent(res.Body, new { accountLinkingUrl = "test_linking_url" });
     }
 }


### PR DESCRIPTION
To support the new combined auth flow, developers can now optionally configure an `accountLinkingUrl` that when present, will be returned by the apps default verify state invoke handler to the server.

https://skype.visualstudio.com/SCC/_git/async_messaging_botapiservice/pullrequest/1264762?_a=files&path=/BotNotifications.Library/Services/SendBotInvokeHandler.cs