### PR TITLE
Update Directory.Build.targets

### DIFF
--- a/Libraries/Directory.Build.targets
+++ b/Libraries/Directory.Build.targets
@@ -3,13 +3,13 @@
     <When Condition="$([System.String]::Copy('$(PackageId)').StartsWith('Microsoft.Teams.Plugins.External.Mcp'))">
       <PropertyGroup>
         <!-- package version for `Microsoft.Teams.Plugins.External.Mcp` and `Microsoft.Teams.Plugins.External.McpClient` packages -->
-        <Version>2.0.3-preview.14</Version>
+        <Version>2.0.4-preview.14</Version>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
         <!-- package version for all other packages -->
-        <Version>2.0.3</Version>
+        <Version>2.0.4</Version>
       </PropertyGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
This pull request updates the package version numbers for the `Microsoft.Teams.Plugins.External.Mcp` family and other packages. The change ensures that all packages now use the new `2.0.4` version series.

Version updates:

* Updated the `Version` property for `Microsoft.Teams.Plugins.External.Mcp` and `Microsoft.Teams.Plugins.External.McpClient` packages from `2.0.3-preview.14` to `2.0.4-preview.14` in `Libraries/Directory.Build.targets`.
* Updated the `Version` property for all other packages from `2.0.3` to `2.0.4` in `Libraries/Directory.Build.targets`.