### PR TITLE
Fix App Send Targeted Messages by updating ConversationReference User

### DIFF
--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -195,7 +195,7 @@ public partial class App
 
         if (isTargeted && activity.Recipient is null)
         {
-            throw new ArgumentException("activity.Recipient is required for targeted messages");
+            throw new ArgumentException("activity.Recipient is required for targeted messages", nameof(activity));
         }
 
         var reference = new ConversationReference()


### PR DESCRIPTION
## Problem
`App.Send()` cannot send targeted messages because it builds `ConversationReference`, dropping the required `User` field that specifies the recipient id for targeted messages.

## Fix
- Set `ConversationReference.User = activity.Recipient` when `isTargeted=true` in `App.Send()`
- This ensures the sender plugin can properly set the outgoing activity's recipient
- Maintains backward compatibility for non-targeted messages (`User` remains `null`)