### PR TITLE
Fix ADO CI build

### DIFF
--- a/.azdo/ci.yaml
+++ b/.azdo/ci.yaml
@@ -27,7 +27,7 @@ stages:
       - script: dotnet restore 
         displayName: 'Restore'
 
-      - script: dotnet build  --no-restore
+      - script: dotnet build --configuration $(buildConfiguration) --no-restore
         displayName: 'Build'
       
       - task: DotNetCoreCLI@2


### PR DESCRIPTION
This pull request updates the build step in the Azure DevOps CI pipeline to ensure the correct build configuration is used during the build process.

Pipeline configuration improvement:

* The `dotnet build` command in `.azdo/ci.yaml` now explicitly uses the `$(buildConfiguration)` variable for configuration, ensuring builds are run with the intended settings.