### PR TITLE
Add condition to push NuGet packages only from the main branch

### DIFF
--- a/.azdo/ci.yaml
+++ b/.azdo/ci.yaml
@@ -32,6 +32,7 @@ stages:
 
       - task: NuGetCommand@2
         displayName: 'Push NuGet Packages'
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
         inputs:
           command: push
           packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'


### PR DESCRIPTION
This pull request introduces a small but important change to the `.azdo/ci.yaml` pipeline configuration. The change ensures that the "Push NuGet Packages" step only runs when the build succeeds and the source branch is `main`.

* Added a condition to the "Push NuGet Packages" pipeline task so that it only executes on successful builds from the `main` branch (`.azdo/ci.yaml`).