### PR TITLE
Add copyright and MIT license headers to all files

### DIFF
--- a/core/.editorconfig
+++ b/core/.editorconfig
@@ -29,6 +29,8 @@ dotnet_sort_system_directives_first = true
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 
+file_header_template = Copyright (c) Microsoft Corporation.\nLicensed under the MIT License.
+
 # Test projects can be more lenient
 [tests/**/*.cs]
 dotnet_diagnostic.CS8602.severity = warning

--- a/core/samples/CompatBot/EchoBot.cs
+++ b/core/samples/CompatBot/EchoBot.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Teams;
 using Microsoft.Bot.Schema;
@@ -10,7 +13,7 @@ public class ConversationData
 
 }
 
-class EchoBot(ConversationState conversationState) : TeamsActivityHandler
+internal class EchoBot(ConversationState conversationState) : TeamsActivityHandler
 {
     public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
     {

--- a/core/samples/CompatBot/Program.cs
+++ b/core/samples/CompatBot/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using CompatBot;
 
 using Microsoft.Bot.Builder;

--- a/core/samples/CoreBot/Program.cs
+++ b/core/samples/CoreBot/Program.cs
@@ -1,4 +1,5 @@
-
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Bot.Core;
 using Microsoft.Bot.Core.Hosting;

--- a/core/samples/Proactive/Program.cs
+++ b/core/samples/Proactive/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.Bot.Core.Hosting;
 
 using Proactive;

--- a/core/samples/Proactive/Worker.cs
+++ b/core/samples/Proactive/Worker.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.Bot.Core;
 using Microsoft.Bot.Core.Schema;
 
@@ -5,7 +8,7 @@ namespace Proactive;
 
 public class Worker(ConversationClient conversationClient, ILogger<Worker> logger) : BackgroundService
 {
-    const string ConversationId = "a:17vxw6pGQOb3Zfh8acXT8m_PqHycYpaFgzu2mFMUfkT-h0UskMctq5ZPPc7FIQxn2bx7rBSm5yE_HeUXsCcKZBrv77RgorB3_1_pAdvMhi39ClxQgawzyQ9GBFkdiwOxT";
+    private const string ConversationId = "a:17vxw6pGQOb3Zfh8acXT8m_PqHycYpaFgzu2mFMUfkT-h0UskMctq5ZPPc7FIQxn2bx7rBSm5yE_HeUXsCcKZBrv77RgorB3_1_pAdvMhi39ClxQgawzyQ9GBFkdiwOxT";
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {

--- a/core/src/Microsoft.Bot.Core.Compat/CompatActivity.cs
+++ b/core/src/Microsoft.Bot.Core.Compat/CompatActivity.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Text;
 
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers;

--- a/core/src/Microsoft.Bot.Core.Compat/CompatAdapter.cs
+++ b/core/src/Microsoft.Bot.Core.Compat/CompatAdapter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;

--- a/core/src/Microsoft.Bot.Core.Compat/CompatBotAdapter.cs
+++ b/core/src/Microsoft.Bot.Core.Compat/CompatBotAdapter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Core.Schema;
 using Microsoft.Bot.Schema;

--- a/core/src/Microsoft.Bot.Core.Compat/CompatHostingExtensions.cs
+++ b/core/src/Microsoft.Bot.Core.Compat/CompatHostingExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Core.Hosting;
 using Microsoft.Extensions.DependencyInjection;

--- a/core/src/Microsoft.Bot.Core.Compat/CompatMiddlewareAdapter.cs
+++ b/core/src/Microsoft.Bot.Core.Compat/CompatMiddlewareAdapter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Core.Schema;
 

--- a/core/src/Microsoft.Bot.Core/BotApplication.cs
+++ b/core/src/Microsoft.Bot.Core/BotApplication.cs
@@ -1,4 +1,5 @@
-
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Core.Hosting;

--- a/core/src/Microsoft.Bot.Core/BotHandlerException.cs
+++ b/core/src/Microsoft.Bot.Core/BotHandlerException.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Bot.Core.Schema;
 

--- a/core/src/Microsoft.Bot.Core/ConversationClient.cs
+++ b/core/src/Microsoft.Bot.Core/ConversationClient.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Net.Http.Json;
 
 using Microsoft.Bot.Core.Hosting;

--- a/core/src/Microsoft.Bot.Core/Hosting/AddBotApplicationExtensions.cs
+++ b/core/src/Microsoft.Bot.Core/Hosting/AddBotApplicationExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Core.Schema;

--- a/core/src/Microsoft.Bot.Core/Hosting/BotAuthenticationHandler.cs
+++ b/core/src/Microsoft.Bot.Core/Hosting/BotAuthenticationHandler.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Net.Http.Headers;
 
 using Microsoft.Bot.Core.Schema;

--- a/core/src/Microsoft.Bot.Core/ITurnMiddleWare.cs
+++ b/core/src/Microsoft.Bot.Core/ITurnMiddleWare.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.Bot.Core.Schema;
 
 namespace Microsoft.Bot.Core;

--- a/core/src/Microsoft.Bot.Core/Schema/ActivityTypes.cs
+++ b/core/src/Microsoft.Bot.Core/Schema/ActivityTypes.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.Bot.Core.Schema;
 
 /// <summary>

--- a/core/src/Microsoft.Bot.Core/Schema/ChannelData.cs
+++ b/core/src/Microsoft.Bot.Core/Schema/ChannelData.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.Bot.Core.Schema;
 
 /// <summary>

--- a/core/src/Microsoft.Bot.Core/Schema/Conversation.cs
+++ b/core/src/Microsoft.Bot.Core/Schema/Conversation.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.Bot.Core.Schema;
 
 /// <summary>

--- a/core/src/Microsoft.Bot.Core/Schema/ConversationAccount.cs
+++ b/core/src/Microsoft.Bot.Core/Schema/ConversationAccount.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.Bot.Core.Schema;
 
 /// <summary>

--- a/core/src/Microsoft.Bot.Core/Schema/CoreActivity.cs
+++ b/core/src/Microsoft.Bot.Core/Schema/CoreActivity.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Text.Json;
 using System.Text.Json.Nodes;
 

--- a/core/src/Microsoft.Bot.Core/Schema/CoreActivityJsonContext.cs
+++ b/core/src/Microsoft.Bot.Core/Schema/CoreActivityJsonContext.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.Bot.Core.Schema;
 
 /// <summary>

--- a/core/src/Microsoft.Bot.Core/TurnMiddleware.cs
+++ b/core/src/Microsoft.Bot.Core/TurnMiddleware.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections;
 

--- a/core/test/Microsoft.Bot.Core.Tests/ConversationClientTest.cs
+++ b/core/test/Microsoft.Bot.Core.Tests/ConversationClientTest.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Bot.Core.Hosting;
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Core.Hosting;
 using Microsoft.Bot.Core.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,12 +21,12 @@ public class ConversationClientTest
 
         IConfiguration configuration = builder.Build();
 
-        var services = new ServiceCollection();
+        ServiceCollection services = new();
         services.AddSingleton(configuration);
         services.AddBotApplicationClients();
         _serviceProvider = services.BuildServiceProvider();
         _conversationClient = _serviceProvider.GetRequiredService<ConversationClient>();
-        
+
     }
 
     [Fact]
@@ -39,12 +42,12 @@ public class ConversationClientTest
                 Id = Environment.GetEnvironmentVariable("TEST_CONVERSATIONID") ?? throw new InvalidOperationException("TEST_ConversationId environment variable not set")
             }
         };
-        var res = await _conversationClient.SendActivityAsync(activity, CancellationToken.None);
+        string res = await _conversationClient.SendActivityAsync(activity, CancellationToken.None);
         Assert.NotNull(res);
         Assert.Contains("\"id\"", res);
     }
 
-   
+
 
     [Fact]
     public async Task SendActivityToChannel()
@@ -59,7 +62,7 @@ public class ConversationClientTest
                 Id = "19:9f2af1bee7cc4a71af25ac72478fd5c6@thread.tacv2"
             }
         };
-        var res = await _conversationClient.SendActivityAsync(activity, CancellationToken.None);
+        string res = await _conversationClient.SendActivityAsync(activity, CancellationToken.None);
         Assert.NotNull(res);
         Assert.Contains("\"id\"", res);
     }
@@ -78,7 +81,7 @@ public class ConversationClientTest
             }
         };
 
-        await Assert.ThrowsAsync<HttpRequestException>(() 
+        await Assert.ThrowsAsync<HttpRequestException>(()
             => _conversationClient.SendActivityAsync(activity));
     }
 }

--- a/core/test/Microsoft.Bot.Core.UnitTests/BotApplicationTests.cs
+++ b/core/test/Microsoft.Bot.Core.UnitTests/BotApplicationTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Net;
 using System.Text;
 using Microsoft.AspNetCore.Http;

--- a/core/test/Microsoft.Bot.Core.UnitTests/ConversationClientTests.cs
+++ b/core/test/Microsoft.Bot.Core.UnitTests/ConversationClientTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Net;
 using Microsoft.Bot.Core.Schema;
 using Moq;

--- a/core/test/Microsoft.Bot.Core.UnitTests/MiddlewareTests.cs
+++ b/core/test/Microsoft.Bot.Core.UnitTests/MiddlewareTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Core.Schema;

--- a/core/test/Microsoft.Bot.Core.UnitTests/Schema/ActivityExtensibilityTests.cs
+++ b/core/test/Microsoft.Bot.Core.UnitTests/Schema/ActivityExtensibilityTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Text;
 using System.Text.Json.Serialization;
 

--- a/core/test/Microsoft.Bot.Core.UnitTests/Schema/CoreActivityTests.cs
+++ b/core/test/Microsoft.Bot.Core.UnitTests/Schema/CoreActivityTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.Bot.Core.Schema;
 
 namespace Microsoft.Bot.Core.UnitTests.Schema;


### PR DESCRIPTION
Added copyright and MIT license headers to all source and test files. Updated .editorconfig to enforce file header template for new files. Made minor code style improvements and access modifier updates. Ensured consistent attribution and licensing across the codebase.