### PR TITLE
Add Azure Monitor telemetry and improve logging/configs

### DIFF
--- a/core/samples/CompatBot/CompatBot.csproj
+++ b/core/samples/CompatBot/CompatBot.csproj
@@ -1,13 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.Bot.Core.Compat\Microsoft.Bot.Core.Compat.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Microsoft.Bot.Core.Compat\Microsoft.Bot.Core.Compat.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/core/samples/CompatBot/EchoBot.cs
+++ b/core/samples/CompatBot/EchoBot.cs
@@ -3,7 +3,9 @@
 
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Teams;
+using Microsoft.Bot.Core;
 using Microsoft.Bot.Schema;
+using Microsoft.Bot.Schema.Teams;
 
 namespace CompatBot;
 
@@ -13,7 +15,7 @@ public class ConversationData
 
 }
 
-internal class EchoBot(ConversationState conversationState) : TeamsActivityHandler
+internal class EchoBot(ConversationState conversationState, ILogger<EchoBot> logger) : TeamsActivityHandler
 {
     public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
     {
@@ -24,16 +26,42 @@ internal class EchoBot(ConversationState conversationState) : TeamsActivityHandl
 
     protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
     {
+        logger.LogInformation("EchoBot OnMessageActivityAsync " + BotApplication.Version);
+
         IStatePropertyAccessor<ConversationData> conversationStateAccessors = conversationState.CreateProperty<ConversationData>(nameof(ConversationData));
         ConversationData conversationData = await conversationStateAccessors.GetAsync(turnContext, () => new ConversationData(), cancellationToken);
 
         string replyText = $"Echo from BF Compat [{conversationData.MessageCount++}]: {turnContext.Activity.Text}";
         await turnContext.SendActivityAsync(MessageFactory.Text(replyText, replyText), cancellationToken);
-        await turnContext.SendActivityAsync(MessageFactory.Text($"[Send a proactive message `/api/notify/{turnContext.Activity.Conversation.Id}`"), cancellationToken);
+        // await turnContext.SendActivityAsync(MessageFactory.Text($"Send a proactive message `/api/notify/{turnContext.Activity.Conversation.Id}`"), cancellationToken);
     }
 
     protected override async Task OnMessageReactionActivityAsync(ITurnContext<IMessageReactionActivity> turnContext, CancellationToken cancellationToken)
     {
         await turnContext.SendActivityAsync(MessageFactory.Text("Message reaction received."), cancellationToken);
     }
+
+    //protected override async Task OnInstallationUpdateActivityAsync(ITurnContext<IInstallationUpdateActivity> turnContext, CancellationToken cancellationToken)
+    //{
+    //    await turnContext.SendActivityAsync(MessageFactory.Text("Installation update received."), cancellationToken);
+    //    await turnContext.SendActivityAsync(MessageFactory.Text($"Send a proactive messages to  `/api/notify/{turnContext.Activity.Conversation.Id}`"), cancellationToken);
+    //}
+
+    //protected override async Task OnInstallationUpdateAddAsync(ITurnContext<IInstallationUpdateActivity> turnContext, CancellationToken cancellationToken)
+    //{
+    //    await turnContext.SendActivityAsync(MessageFactory.Text("Installation update Add received."), cancellationToken);
+    //    await turnContext.SendActivityAsync(MessageFactory.Text($"Send a proactive messages to  `/api/notify/{turnContext.Activity.Conversation.Id}`"), cancellationToken);
+    //}
+
+    //protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+    //{
+    //    await turnContext.SendActivityAsync(MessageFactory.Text("Welcome."), cancellationToken);
+    //    await turnContext.SendActivityAsync(MessageFactory.Text($"Send a proactive messages to  `/api/notify/{turnContext.Activity.Conversation.Id}`"), cancellationToken);
+    //}
+
+    //protected override async Task OnTeamsMeetingStartAsync(MeetingStartEventDetails meeting, ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
+    //{
+    //    await turnContext.SendActivityAsync(MessageFactory.Text("Welcome to meeting: "), cancellationToken);
+    //    await turnContext.SendActivityAsync(MessageFactory.Text($"{meeting.Title} {meeting.MeetingType}"), cancellationToken);
+    //}
 }

--- a/core/samples/CompatBot/Program.cs
+++ b/core/samples/CompatBot/Program.cs
@@ -1,18 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using CompatBot;
 
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Core;
-
-// using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Core.Compat;
 using Microsoft.Bot.Schema;
 
-WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+// using Microsoft.Bot.Connector.Authentication;
 
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+builder.Services.AddOpenTelemetry().UseAzureMonitor();
 builder.AddCompatAdapter();
 
 //builder.Services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
@@ -28,6 +29,7 @@ builder.Services.AddSingleton(conversationState);
 builder.Services.AddTransient<IBot, EchoBot>();
 
 WebApplication app = builder.Build();
+
 
 app.MapPost("/api/messages", async (IBotFrameworkHttpAdapter adapter, IBot bot, HttpRequest request, HttpResponse response, CancellationToken ct) =>
     await adapter.ProcessAsync(request, response, bot, ct));

--- a/core/samples/CompatBot/appsettings.json
+++ b/core/samples/CompatBot/appsettings.json
@@ -1,9 +1,9 @@
 {
+  "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000;",
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
-      "Microsoft.AspNetCore": "Warning",
-      "Microsoft.Bot": "Debug"
+      "Microsoft.Bot": "Trace"
     }
   },
   "AllowedHosts": "*"

--- a/core/samples/CoreBot/CoreBot.csproj
+++ b/core/samples/CoreBot/CoreBot.csproj
@@ -1,13 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.Bot.Core\Microsoft.Bot.Core.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Microsoft.Bot.Core\Microsoft.Bot.Core.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/core/samples/CoreBot/Program.cs
+++ b/core/samples/CoreBot/Program.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.Bot.Core;
 using Microsoft.Bot.Core.Hosting;
 using Microsoft.Bot.Core.Schema;
 
 WebApplicationBuilder webAppBuilder = WebApplication.CreateSlimBuilder(args);
+webAppBuilder.Services.AddOpenTelemetry().UseAzureMonitor();
 webAppBuilder.Services.AddBotApplication<BotApplication>();
 WebApplication webApp = webAppBuilder.Build();
 BotApplication botApp = webApp.UseBotApplication<BotApplication>();
@@ -15,7 +17,14 @@ botApp.OnActivity = async (activity, cancellationToken) =>
 {
     string replyText = $"CoreBot running on SDK {BotApplication.Version}.";
     replyText += $"\r\nYou sent: `{activity.Text}` in activity of type `{activity.Type}`.";
-    replyText += $"\r\n to Conversation ID: `{activity.Conversation.Id}` type: `{activity.Conversation.Properties["conversationType"]}`";
+
+    string? conversationType = "unknown conversation type";
+    if (activity.Conversation.Properties.TryGetValue("conversationType", out var ctProp))
+    {
+        conversationType = ctProp?.ToString();
+    }
+
+    replyText += $"\r\n to Conversation ID: `{activity.Conversation.Id}` conv type: `{conversationType}`";
     CoreActivity replyActivity = activity.CreateReplyMessageActivity(replyText);
     await botApp.SendActivityAsync(replyActivity, cancellationToken);
 };

--- a/core/samples/CoreBot/appsettings.json
+++ b/core/samples/CoreBot/appsettings.json
@@ -1,11 +1,10 @@
 {
+  "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000;",
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning",
+      "Default": "Warning",
       "Microsoft.Bot.Core": "Trace"
     }
   },
-  "AllowedHosts": "*",
-  "Urls": "http://localhost:3978"
+  "AllowedHosts": "*"
 }

--- a/core/samples/Proactive/Worker.cs
+++ b/core/samples/Proactive/Worker.cs
@@ -9,6 +9,8 @@ namespace Proactive;
 public class Worker(ConversationClient conversationClient, ILogger<Worker> logger) : BackgroundService
 {
     private const string ConversationId = "a:17vxw6pGQOb3Zfh8acXT8m_PqHycYpaFgzu2mFMUfkT-h0UskMctq5ZPPc7FIQxn2bx7rBSm5yE_HeUXsCcKZBrv77RgorB3_1_pAdvMhi39ClxQgawzyQ9GBFkdiwOxT";
+    private const string FromId = "28:56653e9d-2158-46ee-90d7-675c39642038";
+    private const string ServiceUrl = "https://smba.trafficmanager.net/teams/";
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -19,11 +21,9 @@ public class Worker(ConversationClient conversationClient, ILogger<Worker> logge
                 CoreActivity proactiveMessage = new()
                 {
                     Text = $"Proactive hello at {DateTimeOffset.Now}",
-                    ServiceUrl = new Uri("https://smba.trafficmanager.net/amer/56653e9d-2158-46ee-90d7-675c39642038/"),
-                    Conversation = new()
-                    {
-                        Id = ConversationId
-                    }
+                    ServiceUrl = new Uri(ServiceUrl),
+                    From = new() { Id = FromId },
+                    Conversation = new() { Id = ConversationId }
                 };
                 string aid = await conversationClient.SendActivityAsync(proactiveMessage, stoppingToken);
                 logger.LogInformation("Activity {Aid} sent", aid);

--- a/core/src/Microsoft.Bot.Core/ConversationClient.cs
+++ b/core/src/Microsoft.Bot.Core/ConversationClient.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
-
+using System.Net.Mime;
+using System.Text;
 using Microsoft.Bot.Core.Hosting;
 using Microsoft.Bot.Core.Schema;
 
@@ -34,12 +36,11 @@ public class ConversationClient(HttpClient httpClient)
         ArgumentNullException.ThrowIfNullOrWhiteSpace(activity.Conversation.Id);
         ArgumentNullException.ThrowIfNull(activity.ServiceUrl);
 
-        using HttpRequestMessage request = new(
-            HttpMethod.Post,
-            $"{activity.ServiceUrl.ToString().TrimEnd('/')}/v3/conversations/{activity.Conversation.Id}/activities/")
-        {
-            Content = JsonContent.Create(activity, options: CoreActivity.DefaultJsonOptions),
-        };
+        string url = $"{activity.ServiceUrl.ToString().TrimEnd('/')}/v3/conversations/{activity.Conversation.Id}/activities/";
+
+        using StringContent content = new(activity.ToJson(), Encoding.UTF8, MediaTypeNames.Application.Json);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, url) { Content = content };
 
         request.Options.Set(BotAuthenticationHandler.AgenticIdentityKey, AgenticIdentity);
 


### PR DESCRIPTION
Integrate Azure Monitor Application Insights telemetry into both CompatBot and CoreBot using OpenTelemetry. Update appsettings.json to include a placeholder Application Insights connection string and adjust logging levels for better diagnostics. Refactor EchoBot to accept an ILogger and log version info; comment out some unused message handlers. Improve CoreBot reply robustness by safely extracting conversation type. Reformat project files for consistency and explicitly add Azure Monitor package. Update Proactive Worker to use constants for ServiceUrl and FromId. Refactor ConversationClient to use StringContent for activity payloads, ensuring correct JSON serialization and content type.