### PR TITLE
Fix Invoke Response

### DIFF
--- a/core/samples/CompatBot/EchoBot.cs
+++ b/core/samples/CompatBot/EchoBot.cs
@@ -100,7 +100,7 @@ internal class EchoBot(TeamsBotApplication teamsBotApp, ConversationState conver
         return new InvokeResponse
         {
             Status = 200,
-            Body = "invokes from compat bot"
+            Body = new { value = "invokes from compat bot" }
         };
     }
 

--- a/core/src/Microsoft.Teams.Bot.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Context.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Teams.Bot.Core;
 using Microsoft.Teams.Bot.Apps.Schema;
+using Microsoft.Teams.Bot.Core;
 
 namespace Microsoft.Teams.Bot.Apps;
 

--- a/core/src/Microsoft.Teams.Bot.Apps/Handlers/ConversationUpdateHandler.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Handlers/ConversationUpdateHandler.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using Microsoft.Teams.Bot.Core.Schema;
 using Microsoft.Teams.Bot.Apps.Schema;
+using Microsoft.Teams.Bot.Core.Schema;
 
 namespace Microsoft.Teams.Bot.Apps.Handlers;
 

--- a/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsActivity.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsActivity.cs
@@ -4,8 +4,8 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
-using Microsoft.Teams.Bot.Core.Schema;
 using Microsoft.Teams.Bot.Apps.Schema.Entities;
+using Microsoft.Teams.Bot.Core.Schema;
 
 namespace Microsoft.Teams.Bot.Apps.Schema;
 

--- a/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsActivityBuilder.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsActivityBuilder.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Teams.Bot.Core.Schema;
 using Microsoft.Teams.Bot.Apps.Schema.Entities;
+using Microsoft.Teams.Bot.Core.Schema;
 
 namespace Microsoft.Teams.Bot.Apps.Schema;
 

--- a/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsActivityJsonContext.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsActivityJsonContext.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
-using Microsoft.Teams.Bot.Core.Schema;
 using Microsoft.Teams.Bot.Apps.Schema.Entities;
+using Microsoft.Teams.Bot.Core.Schema;
 
 namespace Microsoft.Teams.Bot.Apps.Schema;
 

--- a/core/src/Microsoft.Teams.Bot.Apps/TeamsApiClient.Models.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/TeamsApiClient.Models.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
-using Microsoft.Teams.Bot.Core.Schema;
 using Microsoft.Teams.Bot.Apps.Schema;
+using Microsoft.Teams.Bot.Core.Schema;
 
 namespace Microsoft.Teams.Bot.Apps;
 

--- a/core/src/Microsoft.Teams.Bot.Apps/TeamsApiClient.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/TeamsApiClient.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using Microsoft.Teams.Bot.Core.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Teams.Bot.Core.Http;
 using Microsoft.Teams.Bot.Core.Schema;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Teams.Bot.Apps;
 

--- a/core/src/Microsoft.Teams.Bot.Apps/TeamsBotApplication.HostingExtensions.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/TeamsBotApplication.HostingExtensions.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Teams.Bot.Core.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
+using Microsoft.Teams.Bot.Core.Hosting;
 
 namespace Microsoft.Teams.Bot.Apps;
 

--- a/core/src/Microsoft.Teams.Bot.Apps/TeamsBotApplication.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/TeamsBotApplication.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Http;
-using Microsoft.Teams.Bot.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Teams.Bot.Apps.Handlers;
 using Microsoft.Teams.Bot.Apps.Schema;
+using Microsoft.Teams.Bot.Core;
 
 namespace Microsoft.Teams.Bot.Apps;
 

--- a/core/src/Microsoft.Teams.Bot.Apps/TeamsBotApplicationBuilder.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/TeamsBotApplicationBuilder.cs
@@ -3,11 +3,11 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Teams.Bot.Core;
-using Microsoft.Teams.Bot.Core.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Teams.Bot.Core;
+using Microsoft.Teams.Bot.Core.Hosting;
 
 namespace Microsoft.Teams.Bot.Apps;
 

--- a/core/src/Microsoft.Teams.Bot.Compat/CompatActivity.cs
+++ b/core/src/Microsoft.Teams.Bot.Compat/CompatActivity.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT License.
 
 using System.Text;
-
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers;
-using Microsoft.Teams.Bot.Core.Schema;
 using Microsoft.Bot.Schema;
 using Microsoft.Teams.Bot.Apps.Schema;
+using Microsoft.Teams.Bot.Core.Schema;
 using Newtonsoft.Json;
 
 namespace Microsoft.Teams.Bot.Compat;

--- a/core/src/Microsoft.Teams.Bot.Compat/CompatAdapter.cs
+++ b/core/src/Microsoft.Teams.Bot.Compat/CompatAdapter.cs
@@ -4,10 +4,10 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Teams.Bot.Core;
-using Microsoft.Teams.Bot.Core.Schema;
 using Microsoft.Bot.Schema;
 using Microsoft.Teams.Bot.Apps;
+using Microsoft.Teams.Bot.Core;
+using Microsoft.Teams.Bot.Core.Schema;
 
 
 namespace Microsoft.Teams.Bot.Compat;

--- a/core/src/Microsoft.Teams.Bot.Compat/CompatAdapterMiddleware.cs
+++ b/core/src/Microsoft.Teams.Bot.Compat/CompatAdapterMiddleware.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 using Microsoft.Bot.Builder;
+using Microsoft.Teams.Bot.Apps;
 using Microsoft.Teams.Bot.Core;
 using Microsoft.Teams.Bot.Core.Schema;
-using Microsoft.Teams.Bot.Apps;
 
 namespace Microsoft.Teams.Bot.Compat;
 

--- a/core/src/Microsoft.Teams.Bot.Compat/CompatConversations.cs
+++ b/core/src/Microsoft.Teams.Bot.Compat/CompatConversations.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 using Microsoft.Bot.Connector;
-using Microsoft.Teams.Bot.Core;
-using Microsoft.Teams.Bot.Core.Schema;
 using Microsoft.Bot.Schema;
 using Microsoft.Rest;
+using Microsoft.Teams.Bot.Core;
+using Microsoft.Teams.Bot.Core.Schema;
 
 // TODO: Figure out what to do with Agentic Identities. They're all "nulls" here right now.
 // The identity is dependent on the incoming payload or supplied in for proactive scenarios.

--- a/core/src/Microsoft.Teams.Bot.Core/BotApplication.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/BotApplication.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Http;
-using Microsoft.Teams.Bot.Core.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Teams.Bot.Core.Schema;
 
 namespace Microsoft.Teams.Bot.Core;
 

--- a/core/src/Microsoft.Teams.Bot.Core/ConversationClient.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/ConversationClient.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using Microsoft.Teams.Bot.Core.Http;
 using Microsoft.Teams.Bot.Core.Schema;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Teams.Bot.Core;
 

--- a/core/src/Microsoft.Teams.Bot.Core/Hosting/BotAuthenticationHandler.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Hosting/BotAuthenticationHandler.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT License.
 
 using System.Net.Http.Headers;
-
-using Microsoft.Teams.Bot.Core.Schema;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Web;
+using Microsoft.Teams.Bot.Core.Schema;
 
 namespace Microsoft.Teams.Bot.Core.Hosting;
 

--- a/core/src/Microsoft.Teams.Bot.Core/Http/BotHttpClient.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Http/BotHttpClient.cs
@@ -7,8 +7,8 @@ using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Teams.Bot.Core.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Teams.Bot.Core.Hosting;
 
 namespace Microsoft.Teams.Bot.Core.Http;
 /// <summary>

--- a/core/src/Microsoft.Teams.Bot.Core/UserTokenClient.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/UserTokenClient.cs
@@ -3,10 +3,10 @@
 
 using System.Text;
 using System.Text.Json;
-using Microsoft.Teams.Bot.Core.Http;
-using Microsoft.Teams.Bot.Core.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Teams.Bot.Core.Http;
+using Microsoft.Teams.Bot.Core.Schema;
 
 namespace Microsoft.Teams.Bot.Core;
 


### PR DESCRIPTION
Reorganize and clean up using directives across the codebase for consistency. In CompatBotAdapter, add indented JSON logging for InvokeResponse bodies, set HTTP status code from InvokeResponse.Status, and serialize only the response body. Update EchoBot to return an object for InvokeResponse body instead of a plain string. No core logic changes; improves maintainability and debugging.