### PR TITLE
Update samples to use Local environment

### DIFF
--- a/Samples/Samples.AI/Properties/launchSettings.json
+++ b/Samples/Samples.AI/Properties/launchSettings.json
@@ -4,10 +4,10 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "http://localhost:3978",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Local"
       }
     }
   }

--- a/Samples/Samples.BotBuilder/Properties/launchSettings.json
+++ b/Samples/Samples.BotBuilder/Properties/launchSettings.json
@@ -7,7 +7,7 @@
       "launchBrowser": false,
       "applicationUrl": "http://localhost:3978",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Local"
       }
     }
   }

--- a/Samples/Samples.Cards/Properties/launchSettings.json
+++ b/Samples/Samples.Cards/Properties/launchSettings.json
@@ -4,10 +4,10 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "http://localhost:3978",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Local"
       }
     }
   }

--- a/Samples/Samples.Dialogs/Properties/launchSettings.json
+++ b/Samples/Samples.Dialogs/Properties/launchSettings.json
@@ -4,10 +4,10 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "http://localhost:3978",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Local"
       }
     }
   }

--- a/Samples/Samples.Graph/Properties/launchSettings.json
+++ b/Samples/Samples.Graph/Properties/launchSettings.json
@@ -7,7 +7,7 @@
       "launchBrowser": false,
       "applicationUrl": "http://localhost:3978",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Local"
       }
     }
   }

--- a/Samples/Samples.Lights/Properties/launchSettings.json
+++ b/Samples/Samples.Lights/Properties/launchSettings.json
@@ -4,10 +4,10 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "http://localhost:3978",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Local"
       }
     }
   }

--- a/Samples/Samples.Mcp/Properties/launchSettings.json
+++ b/Samples/Samples.Mcp/Properties/launchSettings.json
@@ -4,10 +4,10 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "http://localhost:3978",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Local"
       }
     }
   }

--- a/Samples/Samples.McpClient/Properties/launchSettings.json
+++ b/Samples/Samples.McpClient/Properties/launchSettings.json
@@ -4,10 +4,10 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "http://localhost:3978",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Local"
       }
     }
   }

--- a/Samples/Samples.Meetings/Properties/launchSettings.json
+++ b/Samples/Samples.Meetings/Properties/launchSettings.json
@@ -4,10 +4,10 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "http://localhost:3978",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Local"
       }
     }
   }

--- a/Samples/Samples.MessageExtensions/Properties/launchSettings.json
+++ b/Samples/Samples.MessageExtensions/Properties/launchSettings.json
@@ -4,10 +4,10 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "http://localhost:3978",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Local"
       }
     }
   }

--- a/Samples/Samples.Tab/Properties/launchSettings.json
+++ b/Samples/Samples.Tab/Properties/launchSettings.json
@@ -4,10 +4,10 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "http://localhost:3978",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Local"
       }
     }
   }


### PR DESCRIPTION
I would like to gitignore launchSettings, but since it's already in git history we cannot (easily).

What is gitignored is `launchSettings.Local.json` so changing all samples to use that by default, and also do not launch any browser.