### PR TITLE
Review app Hosting and Auth pipeline

### DIFF
--- a/core/src/Microsoft.Teams.Bot.Core/Hosting/AuthenticationSchemeOptions.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Hosting/AuthenticationSchemeOptions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Teams.Bot.Core.Hosting;
+
+/// <summary>
+/// Options for determining which authentication scheme to use.
+/// </summary>
+internal sealed class AuthenticationSchemeOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether to use Agent authentication (true) or Bot authentication (false).
+    /// </summary>
+    public bool UseAgentAuth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the scope value used to determine the authentication scheme.
+    /// </summary>
+    public string Scope { get; set; } = "https://api.botframework.com/.default";
+}

--- a/core/src/Microsoft.Teams.Bot.Core/Hosting/BotClientOptions.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Hosting/BotClientOptions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Teams.Bot.Core.Hosting;
+
+/// <summary>
+/// Options for configuring bot client HTTP clients.
+/// </summary>
+internal sealed class BotClientOptions
+{
+    /// <summary>
+    /// Gets or sets the scope for bot authentication.
+    /// </summary>
+    public string Scope { get; set; } = "https://api.botframework.com/.default";
+
+    /// <summary>
+    /// Gets or sets the configuration section name.
+    /// </summary>
+    public string SectionName { get; set; } = "AzureAd";
+}


### PR DESCRIPTION
This pull request refactors and improves the bot application hosting and authentication pipeline. The main goals are to defer configuration reading until the service provider is built, avoid building the service provider during service registration (an anti-pattern), and improve logging flexibility and reliability. New options classes are introduced to cleanly pass configuration, and authentication/authorization registration is made safer and more robust.

Key changes include:

**Configuration and Options Refactoring:**

* Introduced `BotClientOptions` and `AuthenticationSchemeOptions` classes to encapsulate bot client and authentication scheme configuration, deferring configuration reading until the service provider is available. [[1]](diffhunk://#diff-65196a45c43063ad64be1ce1c69cd1cf0ddcc2f8b999b5679d74bb6d4a610ff0R1-R20) [[2]](diffhunk://#diff-13be7f71b9314c04c36d3d24e99723628e236cfc008159b22f6d9a862f8c75e0R1-R20)
* Refactored `AddTeamsBotApplication` and `AddBotClient<TClient>` to register options and avoid building the service provider during registration, using `AddOptions<T>().Configure<IConfiguration>()` instead. [[1]](diffhunk://#diff-a5c655bf5836d61efb23de5aba33c6dc81b61cabaf9341f68c9f2a28afc48b58L26-R47) [[2]](diffhunk://#diff-32c43eec964cc43a0cc857afbe1da981ec6000ac6c95c94aef469c4ce859ebe7L96-R163)
* Updated MSAL configuration to pass the logger as a parameter and select configuration and logger from service descriptors if available, only building a temporary provider as a fallback.

**Authentication and Authorization Pipeline:**

* Refactored `AddAuthorization` to accept an optional logger and to select configuration and logger from service descriptors, only building a temporary provider if necessary.
* Improved JWT Bearer authentication to resolve the logger from request services at runtime, ensuring correct logging context and using a `NullLogger` fallback. [[1]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70L106-R121) [[2]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70L127-R156) [[3]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70L145-R166) [[4]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70L156-R177)

**Middleware and Endpoint Registration:**

* Changed `UseBotApplication<TApp>` to operate on `IEndpointRouteBuilder` instead of `IApplicationBuilder`, improving flexibility and ensuring authentication/authorization middleware is added safely.

**Logging Improvements:**

* Ensured that loggers are created from `ILoggerFactory` if available, otherwise defaulting to `NullLogger`, and that logging is robust throughout the authentication and configuration process. [[1]](diffhunk://#diff-32c43eec964cc43a0cc857afbe1da981ec6000ac6c95c94aef469c4ce859ebe7L65-R81) [[2]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70L75-R102) [[3]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70L127-R156)

**General Code Quality:**

* Added missing `using` directives for LINQ and other dependencies. [[1]](diffhunk://#diff-32c43eec964cc43a0cc857afbe1da981ec6000ac6c95c94aef469c4ce859ebe7R4-R10) [[2]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70R5)

These changes collectively improve the reliability, maintainability, and testability of the bot application hosting and authentication infrastructure.

---

**Configuration and Options Refactoring:**

- Introduced `BotClientOptions` and `AuthenticationSchemeOptions` classes for encapsulating bot client and authentication scheme configuration, deferring configuration reading until the service provider is available. [[1]](diffhunk://#diff-65196a45c43063ad64be1ce1c69cd1cf0ddcc2f8b999b5679d74bb6d4a610ff0R1-R20) [[2]](diffhunk://#diff-13be7f71b9314c04c36d3d24e99723628e236cfc008159b22f6d9a862f8c75e0R1-R20)
- Refactored `AddTeamsBotApplication` and `AddBotClient<TClient>` to use options registration and avoid building the service provider during registration. [[1]](diffhunk://#diff-a5c655bf5836d61efb23de5aba33c6dc81b61cabaf9341f68c9f2a28afc48b58L26-R47) [[2]](diffhunk://#diff-32c43eec964cc43a0cc857afbe1da981ec6000ac6c95c94aef469c4ce859ebe7L96-R163)
- Updated MSAL configuration to pass the logger as a parameter and to select configuration/logger from service descriptors, only building a temporary provider if necessary.

**Authentication and Authorization Pipeline:**

- Refactored `AddAuthorization` to accept an optional logger, select configuration/logger from service descriptors, and only build a temporary provider as a fallback.
- Improved JWT Bearer authentication to resolve the logger from request services at runtime and use a `NullLogger` fallback, ensuring robust logging. [[1]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70L106-R121) [[2]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70L127-R156) [[3]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70L145-R166) [[4]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70L156-R177)

**Middleware and Endpoint Registration:**

- Changed `UseBotApplication<TApp>` to work with `IEndpointRouteBuilder` instead of `IApplicationBuilder`, ensuring authentication/authorization middleware is added correctly and improving endpoint mapping flexibility.

**Logging Improvements:**

- Ensured loggers are created from `ILoggerFactory` when available, otherwise using a `NullLogger`, and improved logging reliability throughout the configuration and authentication process. [[1]](diffhunk://#diff-32c43eec964cc43a0cc857afbe1da981ec6000ac6c95c94aef469c4ce859ebe7L65-R81) [[2]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70L75-R102) [[3]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70L127-R156)

**General Code Quality:**

- Added missing `using` directives for LINQ and other dependencies. [[1]](diffhunk://#diff-32c43eec964cc43a0cc857afbe1da981ec6000ac6c95c94aef469c4ce859ebe7R4-R10) [[2]](diffhunk://#diff-d3d44d1fb1f7c0af05be370ba32f80e12a136f7876e896ecf1a9facf97655c70R5)