### PR TITLE
Fix ConversationAccount 

### DIFF
--- a/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsConversationAccount.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsConversationAccount.cs
@@ -16,18 +16,13 @@ namespace Microsoft.Teams.Bot.Apps.Schema;
 /// conversations to access Teams-specific metadata.</remarks>
 public class TeamsConversationAccount : ConversationAccount
 {
-    /// <summary>
-    /// Conversation account.
-    /// </summary>
-    public ConversationAccount ConversationAccount { get; set; }
-
+    
     /// <summary>
     /// Initializes a new instance of the TeamsConversationAccount class.
     /// </summary>
     [JsonConstructor]
     public TeamsConversationAccount()
     {
-        ConversationAccount = new ConversationAccount();
         Id = string.Empty;
         Name = string.Empty;
     }
@@ -42,8 +37,6 @@ public class TeamsConversationAccount : ConversationAccount
     public TeamsConversationAccount(ConversationAccount conversationAccount)
     {
         ArgumentNullException.ThrowIfNull(conversationAccount);
-        ConversationAccount = conversationAccount;
-        Properties = conversationAccount.Properties;
         Id = conversationAccount.Id ?? string.Empty;
         Name = conversationAccount.Name ?? string.Empty;
 

--- a/core/test/Microsoft.Teams.Bot.Apps.UnitTests/TeamsActivityTests.cs
+++ b/core/test/Microsoft.Teams.Bot.Apps.UnitTests/TeamsActivityTests.cs
@@ -282,6 +282,26 @@ public class TeamsActivityTests
         Assert.Equal("test invokes", feedback);
     }
 
+    [Fact]
+    public void Serialize_Does_Not_Repeat_AAdObjectId()
+    {
+        var coreActivity = CoreActivity.FromJsonString("""
+            {
+                "type": "message",
+                "recipient": {
+                    "id": "rec1",
+                    "name": "recname",
+                    "aadObjectId": "rec-aadId-1"
+                }
+            }
+            """);
+        var teamsActivity = TeamsActivity.FromActivity(coreActivity);
+        string json = teamsActivity.ToJson();
+        string[] found = json.Split("aadObjectId");
+        Assert.Equal(1, found.Length - 1); // only one occurrence
+    }
+
+
     private const string jsonInvoke = """
           {
           "type": "invoke",
@@ -446,4 +466,24 @@ public class TeamsActivityTests
         Assert.Equal(typeof(TeamsActivity), activity.GetType());
         Assert.Equal("unknownType", activity.Type);
     }
+
+    [Fact]
+    public void FromActivity_Overrides_Recipient()
+    {
+       var coreActivity = CoreActivity.FromJsonString("""
+            {
+                "type": "message",
+                "recipient": {
+                    "id": "rec1",
+                    "name": "recname",
+                    "aadObjectId": "rec-aadId-1"
+                }
+            }
+            """);
+        var teamsActivity = TeamsActivity.FromActivity(coreActivity);
+        Assert.Equal("rec1", teamsActivity.Recipient?.Id);
+        Assert.Equal("recname", teamsActivity.Recipient?.Name);
+        Assert.Equal("rec-aadId-1", teamsActivity.Recipient?.AadObjectId);
+    }
+
 }


### PR DESCRIPTION
Removed the ConversationAccount property from TeamsConversationAccount to simplify inheritance and avoid redundant nesting. Updated constructors to directly initialize Id, Name, and Teams-specific properties. Added unit tests to ensure aadObjectId is not duplicated in JSON serialization and that recipient properties are correctly set when converting from CoreActivity.