### PR TITLE
Activity specific builders for outgoing activities

### DIFF
--- a/core/samples/AllFeatures/Program.cs
+++ b/core/samples/AllFeatures/Program.cs
@@ -14,8 +14,7 @@ teamsApp.OnMessage = async (messageArgs, context, cancellationToken) =>
 
     await context.SendTypingActivityAsync(cancellationToken);
 
-    TeamsActivity reply = TeamsActivity.CreateBuilder()
-        .WithType(TeamsActivityType.Message)
+    MessageActivity reply = MessageActivity.CreateBuilder()
         .WithConversationReference(context.Activity)
         .WithText(replyText)
         .Build();

--- a/core/samples/CompatBot/EchoBot.cs
+++ b/core/samples/CompatBot/EchoBot.cs
@@ -44,7 +44,7 @@ internal class EchoBot(TeamsBotApplication teamsBotApp, ConversationState conver
         // await turnContext.SendActivityAsync(MessageFactory.Text($"Send a proactive message `/api/notify/{turnContext.Activity.Conversation.Id}`"), cancellationToken);
 
         var incomingCoreActivity = ((Activity)turnContext.Activity).FromCompatActivity();
-        TeamsActivity tm = TeamsActivity.CreateBuilder()
+        MessageActivity tm = MessageActivity.CreateBuilder()
             .WithConversation(new Conversation { Id = incomingCoreActivity.Conversation?.Id! })
             .WithText("Hello TM !")
             .WithRecipient(incomingCoreActivity.From, true)

--- a/core/samples/TabApp/Program.cs
+++ b/core/samples/TabApp/Program.cs
@@ -78,8 +78,7 @@ app.MapPost("/functions/post-to-chat", async (
         conversationId = cached!;
     }
 
-    TeamsActivity activity = TeamsActivity.CreateBuilder()
-        .WithType(TeamsActivityType.Message)
+    MessageActivity activity = MessageActivity.CreateBuilder()
         .WithText("Hello from the tab!")
         .WithServiceUrl(serviceUrl)
         .WithConversation(new TeamsConversation { Id = conversationId! })

--- a/core/samples/TeamsBot/Program.cs
+++ b/core/samples/TeamsBot/Program.cs
@@ -32,8 +32,7 @@ teamsApp.OnMessage("(?i)^help$", async (context, cancellationToken) =>
         }, cancellationToken);
 
 
-    var helpActivity = TeamsActivity.CreateBuilder()
-        .WithType(TeamsActivityType.Message)
+    var helpActivity = MessageActivity.CreateBuilder()
         .WithText(WelcomeMessageMiddleware.WelcomeMessage, TextFormats.Markdown)
         .WithSuggestedActions(new SuggestedActions()
          {
@@ -57,8 +56,7 @@ teamsApp.OnMessage("(?i)hello", async (context, cancellationToken) =>
 
     string replyText = $"You sent: `{context.Activity.Text}`. Type `help` to see available commands.";
 
-    TeamsActivity ta = TeamsActivity.CreateBuilder()
-        .WithType(TeamsActivityType.Message)
+    MessageActivity ta = MessageActivity.CreateBuilder()
         .WithText(replyText)
         .AddMention(context.Activity.From)
         .Build();
@@ -144,8 +142,7 @@ teamsApp.OnMessage("(?i)targeted", async (context, cancellationToken) =>
     ArgumentNullException.ThrowIfNull(context.Activity.ServiceUrl);
 
     // Send a targeted message visible only to the sender
-    TeamsActivity targeted = TeamsActivity.CreateBuilder()
-        .WithType(TeamsActivityType.Message)
+    MessageActivity targeted = MessageActivity.CreateBuilder()
         .WithText("This is a targeted message only you can see!")
         .WithRecipient(context.Activity.From, isTargeted: true)
         .Build();
@@ -155,8 +152,7 @@ teamsApp.OnMessage("(?i)targeted", async (context, cancellationToken) =>
     await Task.Delay(2000, cancellationToken);
 
     // Update the targeted message (must use UpdateTargetedAsync to avoid setting Recipient on the update payload)
-    TeamsActivity updated = TeamsActivity.CreateBuilder()
-        .WithType(TeamsActivityType.Message)
+    MessageActivity updated = MessageActivity.CreateBuilder()
         .WithText("This targeted message was updated!")
         .WithServiceUrl(context.Activity.ServiceUrl)
         .Build();
@@ -183,8 +179,7 @@ teamsApp.OnMessage("(?i)^react$", async (context, cancellationToken) =>
     ArgumentNullException.ThrowIfNull(context.Activity.Conversation);
     ArgumentNullException.ThrowIfNull(context.Activity.ServiceUrl);
 
-    var tmMsgToReact = TeamsActivity.CreateBuilder()
-        .WithType(TeamsActivityType.Message)
+    var tmMsgToReact = MessageActivity.CreateBuilder()
         .WithText("I'm going to add and remove reactions to this message.")
         .WithRecipient(context.Activity.From, false)
         .WithServiceUrl(context.Activity.ServiceUrl)
@@ -264,8 +259,7 @@ teamsApp.OnMessage("(?i)^suggested$", async (context, cancellationToken) =>
         ]
     };
 
-    var reply = TeamsActivity.CreateBuilder()
-        .WithType(TeamsActivityType.Message)
+    var reply = MessageActivity.CreateBuilder()
         .WithText("Here are some suggested actions for you:")
         .WithSuggestedActions(suggestedActions)
         .Build();
@@ -329,7 +323,7 @@ teamsApp.OnAdaptiveCardAction(async (context, cancellationToken) =>
     string? feedbackValue = context.Activity.Value?.Action?.Data?["feedback"]?.ToString();
 
     TeamsActivity reply = TeamsActivity.CreateBuilder()
-        .WithAttachment(TeamsAttachment.CreateBuilder()
+        .AddAttachment(TeamsAttachment.CreateBuilder()
             .WithAdaptiveCard(Cards.ResponseCard(feedbackValue))
             .Build()
         )
@@ -366,8 +360,7 @@ teamsApp.OnTaskSubmit(async (context, cancellationToken) =>
     string? name = data?["userName"]?.ToString();
     string? comment = data?["userComment"]?.ToString();
 
-    TeamsActivity reply = TeamsActivity.CreateBuilder()
-        .WithType(TeamsActivityType.Message)
+    MessageActivity reply = MessageActivity.CreateBuilder()
         .WithText($"**Task module submitted!**\n- Name: {name ?? "(empty)"}\n- Comment: {comment ?? "(empty)"}")
         .Build();
 

--- a/core/samples/TeamsBot/WelcomeMessageMiddleware.cs
+++ b/core/samples/TeamsBot/WelcomeMessageMiddleware.cs
@@ -39,10 +39,10 @@ internal class WelcomeMessageMiddleware : ITurnMiddleware
     {
         if (!_hasSentWelcomeMessage)
         {
-            var welcomeActivity = TeamsActivity.CreateBuilder()
+            var welcomeActivity = MessageActivity.CreateBuilder()
                 .WithType("message")
                 .WithText(WelcomeMessage, TextFormats.Markdown)
-                .WithConversationReference(TeamsActivity.FromActivity(activity))
+                .WithConversationReference(activity)
                 .Build();
 
             await botApplication.SendActivityAsync(welcomeActivity, cancellationToken);

--- a/core/src/Microsoft.Teams.Bot.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Context.cs
@@ -32,7 +32,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <returns></returns>
     public Task<SendActivityResponse?> SendActivityAsync(string text, CancellationToken cancellationToken = default)
         => TeamsBotApplication.SendActivityAsync(
-            new TeamsActivityBuilder()
+            MessageActivity.CreateBuilder()
                 .WithConversationReference(Activity)
                 .WithText(text)
                 .Build(), cancellationToken);

--- a/core/src/Microsoft.Teams.Bot.Apps/Handlers/InvokeHandler.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Handlers/InvokeHandler.cs
@@ -23,8 +23,7 @@ public static class InvokeExtensions
 {
     /// <summary>
     /// Registers a catch-all handler for all invoke activities.
-    /// Cannot be combined with specific invoke handlers such as <see cref="AdaptiveCardExtensions.OnAdaptiveCardAction"/>,
-    /// <see cref="TaskExtensions.OnTaskFetch"/>, etc.
+    /// Cannot be combined with specific invoke handlers such as <see cref="AdaptiveCardExtensions.OnAdaptiveCardAction"/>
     /// </summary>
     /// <remarks>
     /// Breaking change: previously a catch-all invoke handler could be registered alongside specific invoke handlers. This combination now throws at registration time.

--- a/core/src/Microsoft.Teams.Bot.Apps/Handlers/TaskModules/TaskHandler.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Handlers/TaskModules/TaskHandler.cs
@@ -5,7 +5,7 @@ using Microsoft.Teams.Bot.Apps.Handlers.TaskModules;
 using Microsoft.Teams.Bot.Apps.Routing;
 using Microsoft.Teams.Bot.Apps.Schema;
 
-namespace Microsoft.Teams.Bot.Apps.Handlers;
+namespace Microsoft.Teams.Bot.Apps.Handlers.TaskModules;
 
 /// <summary>
 /// Delegate for handling task module invoke activities.

--- a/core/src/Microsoft.Teams.Bot.Apps/Schema/Entities/ProductInfoEntity.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Schema/Entities/ProductInfoEntity.cs
@@ -2,8 +2,42 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
+using Microsoft.Teams.Bot.Apps.Schema;
 
 namespace Microsoft.Teams.Bot.Apps.Schema.Entities;
+
+/// <summary>
+/// Extension methods for activity product info.
+/// </summary>
+public static class ActivityProductInfoExtensions
+{
+    /// <summary>
+    /// Adds a product info entity to the activity.
+    /// </summary>
+    /// <param name="activity">The activity to add product info to. Cannot be null.</param>
+    /// <param name="id">The product identifier.</param>
+    /// <returns>The created ProductInfoEntity that was added to the activity.</returns>
+    public static ProductInfoEntity AddProductInfo(this TeamsActivity activity, string id)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        ProductInfoEntity productInfo = new() { Id = id };
+        activity.Entities ??= [];
+        activity.Entities.Add(productInfo);
+        activity.Rebase();
+        return productInfo;
+    }
+
+    /// <summary>
+    /// Gets the product info entity from the activity's entity collection, if present.
+    /// </summary>
+    /// <param name="activity">The activity to read from. Cannot be null.</param>
+    /// <returns>The ProductInfoEntity if found; otherwise, null.</returns>
+    public static ProductInfoEntity? GetProductInfo(this TeamsActivity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        return activity.Entities?.FirstOrDefault(e => e is ProductInfoEntity) as ProductInfoEntity;
+    }
+}
 
 
 

--- a/core/src/Microsoft.Teams.Bot.Apps/Schema/Entities/StreamInfoEntity.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Schema/Entities/StreamInfoEntity.cs
@@ -2,8 +2,49 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
+using Microsoft.Teams.Bot.Apps.Schema;
 
 namespace Microsoft.Teams.Bot.Apps.Schema.Entities;
+
+/// <summary>
+/// Extension methods for activity stream info.
+/// </summary>
+public static class ActivityStreamInfoExtensions
+{
+    /// <summary>
+    /// Adds a stream info entity to the activity.
+    /// </summary>
+    /// <param name="activity">The activity to add stream info to. Cannot be null.</param>
+    /// <param name="streamType">The stream type. See <see cref="StreamType"/> for possible values.</param>
+    /// <param name="streamId">Optional stream identifier.</param>
+    /// <param name="streamSequence">Optional stream sequence number.</param>
+    /// <returns>The created StreamInfoEntity that was added to the activity.</returns>
+    public static StreamInfoEntity AddStreamInfo(this TeamsActivity activity, string streamType, string? streamId = null, int? streamSequence = null)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        StreamInfoEntity streamInfo = new()
+        {
+            StreamType = streamType,
+            StreamId = streamId,
+            StreamSequence = streamSequence
+        };
+        activity.Entities ??= [];
+        activity.Entities.Add(streamInfo);
+        activity.Rebase();
+        return streamInfo;
+    }
+
+    /// <summary>
+    /// Gets the stream info entity from the activity's entity collection, if present.
+    /// </summary>
+    /// <param name="activity">The activity to read from. Cannot be null.</param>
+    /// <returns>The StreamInfoEntity if found; otherwise, null.</returns>
+    public static StreamInfoEntity? GetStreamInfo(this TeamsActivity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        return activity.Entities?.FirstOrDefault(e => e is StreamInfoEntity) as StreamInfoEntity;
+    }
+}
 
 /// <summary>
 /// Stream info entity.

--- a/core/src/Microsoft.Teams.Bot.Apps/Schema/MessageActivity.Builder.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Schema/MessageActivity.Builder.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Teams.Bot.Apps.Schema.Entities;
+using Microsoft.Teams.Bot.Core.Schema;
+
+namespace Microsoft.Teams.Bot.Apps.Schema;
+
+/// <summary>
+/// Provides a fluent API for building <see cref="MessageActivity"/> instances.
+/// Uses typed property setters for first-class message fields (Text, TextFormat, SuggestedActions).
+/// </summary>
+public class MessageActivityBuilder : TeamsActivityBuilder<MessageActivity, MessageActivityBuilder>
+{
+    /// <summary>
+    /// Initializes a new instance of the MessageActivityBuilder class.
+    /// </summary>
+    internal MessageActivityBuilder() : base(new MessageActivity())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the MessageActivityBuilder class with an existing activity.
+    /// </summary>
+    /// <param name="activity">The activity to build upon.</param>
+    internal MessageActivityBuilder(MessageActivity activity) : base(activity)
+    {
+    }
+
+    /// <summary>
+    /// Sets the text content and text format of the message.
+    /// </summary>
+    public MessageActivityBuilder WithText(string text, string textFormat = "plain")
+    {
+        _activity.Text = text;
+        _activity.TextFormat = textFormat;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the suggested actions for the message.
+    /// </summary>
+    public MessageActivityBuilder WithSuggestedActions(SuggestedActions suggestedActions)
+    {
+        _activity.SuggestedActions = suggestedActions;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a mention to the activity.
+    /// </summary>
+    /// <param name="account">The account to mention.</param>
+    /// <param name="text">Optional custom text for the mention. If null, uses the account name.</param>
+    /// <param name="addText">Whether to prepend the mention text to the activity's text content.</param>
+    public MessageActivityBuilder AddMention(ConversationAccount account, string? text = null, bool addText = true)
+    {
+        ArgumentNullException.ThrowIfNull(account);
+        string? mentionText = text ?? account.Name;
+
+        if (addText)
+        {
+            _activity.Text = $"<at>{mentionText}</at> {_activity.Text}";
+        }
+
+        _activity.Entities ??= [];
+        _activity.Entities.Add(new MentionEntity(account, $"<at>{mentionText}</at>"));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Builds and returns the configured MessageActivity instance.
+    /// </summary>
+    public override MessageActivity Build()
+    {
+        _activity.Rebase();
+        return _activity;
+    }
+}

--- a/core/src/Microsoft.Teams.Bot.Apps/Schema/MessageActivity.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Schema/MessageActivity.cs
@@ -78,10 +78,6 @@ public class MessageActivity : TeamsActivity
             {
                 SuggestedActions = JsonSerializer.Deserialize<SuggestedActions>(je.GetRawText());
             }
-            else
-            {
-                SuggestedActions = suggestedActions as SuggestedActions;
-            }
             activity.Properties.Remove("suggestedActions");
         }
         /*
@@ -135,7 +131,21 @@ public class MessageActivity : TeamsActivity
     [JsonPropertyName("attachmentLayout")]
     public string? AttachmentLayout { get; set; }
 
-    
+    /// <summary>
+    /// Gets or sets the suggested actions for the message.
+    /// </summary>
+    [JsonPropertyName("suggestedActions")]
+    public SuggestedActions? SuggestedActions { get; set; }
+
+    /// <summary>
+    /// Creates a new <see cref="MessageActivityBuilder"/> instance.
+    /// </summary>
+    public static new MessageActivityBuilder CreateBuilder() => new();
+
+    /// <summary>
+    /// Creates a new <see cref="MessageActivityBuilder"/> initialized with an existing activity.
+    /// </summary>
+    public static MessageActivityBuilder CreateBuilder(MessageActivity activity) => new(activity);
 
     //TODO : Review properties
     /*

--- a/core/src/Microsoft.Teams.Bot.Apps/Schema/StreamingActivity.Builder.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Schema/StreamingActivity.Builder.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Teams.Bot.Apps.Schema;
+
+/// <summary>
+/// Provides a fluent API for building <see cref="StreamingActivity"/> instances.
+/// </summary>
+public class StreamingActivityBuilder : TeamsActivityBuilder<StreamingActivity, StreamingActivityBuilder>
+{
+    /// <summary>
+    /// Initializes a new instance of the StreamingActivityBuilder class with an initial text chunk.
+    /// </summary>
+    /// <param name="text">The initial text content of the streaming chunk.</param>
+    internal StreamingActivityBuilder(string text = "") : base(new StreamingActivity(text))
+    {
+    }
+
+    /// <summary>
+    /// Sets the text content of the streaming chunk.
+    /// </summary>
+    public StreamingActivityBuilder WithText(string text)
+    {
+        _activity.Text = text;
+        return this;
+    }
+
+    /// <summary>
+    /// Builds and returns the configured StreamingActivity instance.
+    /// </summary>
+    public override StreamingActivity Build()
+    {
+        _activity.Rebase();
+        return _activity;
+    }
+}

--- a/core/src/Microsoft.Teams.Bot.Apps/Schema/StreamingActivity.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Schema/StreamingActivity.cs
@@ -21,7 +21,8 @@ public class StreamingActivity : TeamsActivity
     {
         Text = text;
         StreamInfo = new StreamInfoEntity();
-        AddEntity(StreamInfo);
+        Entities ??= [];
+        Entities.Add(StreamInfo);
     }
 
     /// <summary>
@@ -34,4 +35,9 @@ public class StreamingActivity : TeamsActivity
     /// Gets the stream info entity for this streaming activity.
     /// </summary>
     public StreamInfoEntity StreamInfo { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="StreamingActivityBuilder"/> with an initial text chunk.
+    /// </summary>
+    public static StreamingActivityBuilder CreateBuilder(string text = "") => new(text);
 }

--- a/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsActivity.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsActivity.cs
@@ -65,7 +65,7 @@ public class TeamsActivity : CoreActivity
         // Convert base types to Teams-specific types
         if (activity.ChannelData is not null)
         {
-            ChannelData = new TeamsChannelData(activity.ChannelData);
+            ChannelData = TeamsChannelData.FromChannelData(activity.ChannelData);
         }
 
         if (activity.From is not null)
@@ -146,6 +146,7 @@ public class TeamsActivity : CoreActivity
     /// </summary>
     [JsonPropertyName("entities")] public new EntityList? Entities { get; set; }
 
+    // TODO : mv attachments to MessageActivity if it's only used for messages.
     /// <summary>
     /// Attachments specific to Teams.
     /// </summary>
@@ -174,27 +175,6 @@ public class TeamsActivity : CoreActivity
     /// </summary>
     [JsonPropertyName("localTimezone")]
     public string? LocalTimezone { get; set; }
-
-    /// <summary>
-    /// Gets or sets the suggested actions for the message.
-    /// </summary>
-    [JsonPropertyName("suggestedActions")]
-    public SuggestedActions? SuggestedActions { get; set; }
-
-
-    /// <summary>
-    /// Adds an entity to the activity's Entities collection.
-    /// </summary>
-    /// <param name="entity"></param>
-    /// <returns></returns>
-    public TeamsActivity AddEntity(Entity entity)
-    {
-        // TODO: Pick up nuances about entities.
-        // For eg, there can only be 1 single MessageEntity
-        Entities ??= [];
-        Entities.Add(entity);
-        return this;
-    }
 
     /// <summary>
     /// Creates a new TeamsActivityBuilder instance for building a TeamsActivity with a fluent API.

--- a/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsActivityBuilder.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsActivityBuilder.cs
@@ -7,9 +7,121 @@ using Microsoft.Teams.Bot.Core.Schema;
 namespace Microsoft.Teams.Bot.Apps.Schema;
 
 /// <summary>
-/// Provides a fluent API for building TeamsActivity instances.
+/// Abstract generic base for Teams activity builders.
+/// Provides Teams-specific overrides and fluent methods common to all Teams activity types.
 /// </summary>
-public class TeamsActivityBuilder : CoreActivityBuilder<TeamsActivity, TeamsActivityBuilder>
+/// <typeparam name="TActivity">The concrete Teams activity type being built.</typeparam>
+/// <typeparam name="TBuilder">The concrete builder type (for fluent chaining).</typeparam>
+public abstract class TeamsActivityBuilder<TActivity, TBuilder> : CoreActivityBuilder<TActivity, TBuilder>
+    where TActivity : TeamsActivity
+    where TBuilder : TeamsActivityBuilder<TActivity, TBuilder>
+{
+    /// <summary>
+    /// Initializes a new instance with the given activity.
+    /// </summary>
+    protected TeamsActivityBuilder(TActivity activity) : base(activity)
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override void SetConversation(Conversation? conversation)
+    {
+        _activity.Conversation = conversation is TeamsConversation teamsConv
+            ? teamsConv
+            : TeamsConversation.FromConversation(conversation);
+    }
+
+    /// <inheritdoc/>
+    protected override void SetFrom(ConversationAccount? from)
+    {
+        _activity.From = from is TeamsConversationAccount teamsAccount
+            ? teamsAccount
+            : TeamsConversationAccount.FromConversationAccount(from);
+    }
+
+    /// <inheritdoc/>
+    protected override void SetRecipient(ConversationAccount? recipient)
+    {
+        _activity.Recipient = recipient is TeamsConversationAccount teamsAccount
+            ? teamsAccount
+            : TeamsConversationAccount.FromConversationAccount(recipient);
+    }
+
+    /// <summary>
+    /// Sets the Teams-specific channel data.
+    /// </summary>
+    public TBuilder WithChannelData(TeamsChannelData? channelData)
+    {
+        _activity.ChannelData = channelData;
+        return (TBuilder)this;
+    }
+
+    /// <summary>
+    /// Sets the entities collection.
+    /// </summary>
+    public TBuilder WithEntities(EntityList entities)
+    {
+        _activity.Entities = entities;
+        return (TBuilder)this;
+    }
+
+    /// <summary>
+    /// Adds an entity to the activity's Entities collection.
+    /// </summary>
+    public TBuilder AddEntity(Entity entity)
+    {
+        _activity.Entities ??= [];
+        _activity.Entities.Add(entity);
+        return (TBuilder)this;
+    }
+
+    /// <summary>
+    /// Sets the attachments collection.
+    /// </summary>
+    public TBuilder WithAttachments(IList<TeamsAttachment> attachments)
+    {
+        _activity.Attachments = attachments;
+        return (TBuilder)this;
+    }
+
+
+    /// <summary>
+    /// Adds an attachment to the activity's Attachments collection.
+    /// </summary>
+    public TBuilder AddAttachment(TeamsAttachment attachment)
+    {
+        _activity.Attachments ??= [];
+        _activity.Attachments.Add(attachment);
+        return (TBuilder)this;
+    }
+
+    /// <summary>
+    /// Adds an Adaptive Card attachment to the activity.
+    /// </summary>
+    /// <param name="adaptiveCard">The Adaptive Card payload.</param>
+    /// <param name="configure">Optional callback to further configure the attachment.</param>
+    public TBuilder AddAdaptiveCardAttachment(object adaptiveCard, Action<TeamsAttachmentBuilder>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(adaptiveCard);
+        return AddAttachment(BuildAdaptiveCardAttachment(adaptiveCard, configure));
+    }
+
+    private static TeamsAttachment BuildAdaptiveCardAttachment(object adaptiveCard, Action<TeamsAttachmentBuilder>? configure)
+    {
+        TeamsAttachmentBuilder attachmentBuilder = TeamsAttachment
+            .CreateBuilder()
+            .WithAdaptiveCard(adaptiveCard);
+
+        configure?.Invoke(attachmentBuilder);
+
+        return attachmentBuilder.Build();
+    }
+}
+
+/// <summary>
+/// Provides a fluent API for building <see cref="TeamsActivity"/> instances.
+/// </summary>
+public class TeamsActivityBuilder : TeamsActivityBuilder<TeamsActivity, TeamsActivityBuilder>
 {
     /// <summary>
     /// Initializes a new instance of the TeamsActivityBuilder class.
@@ -27,204 +139,11 @@ public class TeamsActivityBuilder : CoreActivityBuilder<TeamsActivity, TeamsActi
     }
 
     /// <summary>
-    /// Sets the conversation (override for Teams-specific type).
-    /// </summary>
-    protected override void SetConversation(Conversation? conversation)
-    {
-        _activity.Conversation = conversation is TeamsConversation teamsConv
-            ? teamsConv
-            : TeamsConversation.FromConversation(conversation);
-    }
-
-    /// <summary>
-    /// Sets the From account (override for Teams-specific type).
-    /// </summary>
-    protected override void SetFrom(ConversationAccount? from)
-    {
-        _activity.From = from is TeamsConversationAccount teamsAccount
-            ? teamsAccount
-            : TeamsConversationAccount.FromConversationAccount(from);
-    }
-
-    /// <summary>
-    /// Sets the Recipient account (override for Teams-specific type).
-    /// </summary>
-    protected override void SetRecipient(ConversationAccount? recipient)
-    {
-        _activity.Recipient = recipient is TeamsConversationAccount teamsAccount
-            ? teamsAccount
-            : TeamsConversationAccount.FromConversationAccount(recipient);
-    }
-
-    /// <summary>
-    /// Sets the Teams-specific channel data.
-    /// </summary>
-    /// <param name="channelData">The channel data.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    public TeamsActivityBuilder WithChannelData(TeamsChannelData? channelData)
-    {
-        _activity.ChannelData = channelData;
-        return this;
-    }
-
-    /// <summary>
-    /// Sets the entities collection.
-    /// </summary>
-    /// <param name="entities">The entities collection.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    public TeamsActivityBuilder WithEntities(EntityList entities)
-    {
-        _activity.Entities = entities;
-        return this;
-    }
-
-    /// <summary>
-    /// Sets the attachments collection.
-    /// </summary>
-    /// <param name="attachments">The attachments collection.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    public TeamsActivityBuilder WithAttachments(IList<TeamsAttachment> attachments)
-    {
-        _activity.Attachments = attachments;
-        return this;
-    }
-
-    // TODO: Builders should only have "With" methods, not "Add" methods.
-    /// <summary>
-    /// Replaces the attachments collection with a single attachment.
-    /// </summary>
-    /// <param name="attachment">The attachment to set. Passing null clears the attachments.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    public TeamsActivityBuilder WithAttachment(TeamsAttachment? attachment)
-    {
-        _activity.Attachments = attachment is null
-            ? null
-            : [attachment];
-
-        return this;
-    }
-
-    /// <summary>
-    /// Adds an entity to the activity's Entities collection.
-    /// </summary>
-    /// <param name="entity">The entity to add.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    public TeamsActivityBuilder AddEntity(Entity entity)
-    {
-        _activity.Entities ??= [];
-        _activity.Entities.Add(entity);
-        return this;
-    }
-
-    /// <summary>
-    /// Adds an attachment to the activity's Attachments collection.
-    /// </summary>
-    /// <param name="attachment">The attachment to add.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    public TeamsActivityBuilder AddAttachment(TeamsAttachment attachment)
-    {
-        _activity.Attachments ??= [];
-        _activity.Attachments.Add(attachment);
-        return this;
-    }
-
-    /// <summary>
-    /// Adds an Adaptive Card attachment to the activity.
-    /// </summary>
-    /// <param name="adaptiveCard">The Adaptive Card payload.</param>
-    /// <param name="configure">Optional callback to further configure the attachment before it is added.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    public TeamsActivityBuilder AddAdaptiveCardAttachment(object adaptiveCard, Action<TeamsAttachmentBuilder>? configure = null)
-    {
-        TeamsAttachment attachment = BuildAdaptiveCardAttachment(adaptiveCard, configure);
-        return AddAttachment(attachment);
-    }
-
-    /// <summary>
-    /// Sets the activity attachments collection to a single Adaptive Card attachment.
-    /// </summary>
-    /// <param name="adaptiveCard">The Adaptive Card payload.</param>
-    /// <param name="configure">Optional callback to further configure the attachment.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    public TeamsActivityBuilder WithAdaptiveCardAttachment(object adaptiveCard, Action<TeamsAttachmentBuilder>? configure = null)
-    {
-        TeamsAttachment attachment = BuildAdaptiveCardAttachment(adaptiveCard, configure);
-        return WithAttachment(attachment);
-    }
-
-    /// <summary>
-    /// Adds or sets the text content of the activity.
-    /// </summary>
-    /// <param name="text"></param>
-    /// <param name="textFormat"></param>
-    /// <returns></returns>
-    public TeamsActivityBuilder WithText(string text, string textFormat = "plain")
-    {
-        WithProperty("text", text);
-        WithProperty("textFormat", textFormat);
-        return this;
-    }
-
-    /// <summary>
-    /// With Suggested Actions
-    /// </summary>
-    /// <param name="suggestedActions"></param>
-    /// <returns></returns>
-    public TeamsActivityBuilder WithSuggestedActions(SuggestedActions suggestedActions)
-    {
-        ArgumentNullException.ThrowIfNull(_activity);
-        _activity.SuggestedActions = suggestedActions;
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a mention to the activity.
-    /// </summary>
-    /// <param name="account">The account to mention.</param>
-    /// <param name="text">Optional custom text for the mention. If null, uses the account name.</param>
-    /// <param name="addText">Whether to prepend the mention text to the activity's text content.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    public TeamsActivityBuilder AddMention(ConversationAccount account, string? text = null, bool addText = true)
-    {
-        ArgumentNullException.ThrowIfNull(account);
-        string? mentionText = text ?? account.Name;
-
-        if (addText)
-        {
-            string? currentText = _activity.Properties.TryGetValue("text", out object? value) ? value?.ToString() : null;
-            WithProperty("text", $"<at>{mentionText}</at> {currentText}");
-        }
-
-        _activity.Entities ??= [];
-        _activity.Entities.Add(new MentionEntity(account, $"<at>{mentionText}</at>"));
-
-        CoreActivity baseActivity = _activity;
-        baseActivity.Entities = _activity.Entities.ToJsonArray();
-
-        return this;
-    }
-
-    /// <summary>
     /// Builds and returns the configured TeamsActivity instance.
     /// </summary>
-    /// <returns>The configured TeamsActivity.</returns>
     public override TeamsActivity Build()
     {
         _activity.Rebase();
-
         return _activity;
-    }
-
-    private static TeamsAttachment BuildAdaptiveCardAttachment(object adaptiveCard, Action<TeamsAttachmentBuilder>? configure)
-    {
-        ArgumentNullException.ThrowIfNull(adaptiveCard);
-
-        TeamsAttachmentBuilder attachmentBuilder = TeamsAttachment
-            .CreateBuilder()
-            .WithAdaptiveCard(adaptiveCard);
-
-        configure?.Invoke(attachmentBuilder);
-
-        return attachmentBuilder.Build();
     }
 }

--- a/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsChannelData.cs
+++ b/core/src/Microsoft.Teams.Bot.Apps/Schema/TeamsChannelData.cs
@@ -65,74 +65,79 @@ public class TeamsChannelData : ChannelData
     /// Creates a new instance of the <see cref="TeamsChannelData"/> class from the specified <see cref="ChannelData"/> object.
     /// </summary>
     /// <param name="cd"></param>
-    public TeamsChannelData(ChannelData? cd)
+    public static TeamsChannelData? FromChannelData(ChannelData? cd)
     {
-        if (cd is not null)
+        if (cd is null)
         {
-            //TODO : is channel id needed ? what is teamschannleid and teamsteamid ?
-            if (cd.Properties.TryGetValue("teamsChannelId", out object? channelIdObj)
-                && channelIdObj is JsonElement jeChannelId
-                && jeChannelId.ValueKind == JsonValueKind.String)
-            {
-                TeamsChannelId = jeChannelId.GetString();
-            }
-
-            if (cd.Properties.TryGetValue("teamsTeamId", out object? teamIdObj)
-                && teamIdObj is JsonElement jeTeamId
-                && jeTeamId.ValueKind == JsonValueKind.String)
-            {
-                TeamsTeamId = jeTeamId.GetString();
-            }
-
-            if (cd.Properties.TryGetValue("settings", out object? settingsObj)
-                && settingsObj is JsonElement settingsObjJE
-                && settingsObjJE.ValueKind == JsonValueKind.Object)
-            {
-                Settings = JsonSerializer.Deserialize<TeamsChannelDataSettings?>(settingsObjJE.GetRawText());
-            }
-
-            if (cd.Properties.TryGetValue("channel", out object? channelObj)
-                && channelObj is JsonElement channelObjJE
-                && channelObjJE.ValueKind == JsonValueKind.Object)
-            {
-                Channel = JsonSerializer.Deserialize<TeamsChannel?>(channelObjJE.GetRawText());
-            }
-
-            if (cd.Properties.TryGetValue("tenant", out object? tenantObj)
-                && tenantObj is JsonElement je
-                && je.ValueKind == JsonValueKind.Object)
-            {
-                Tenant = JsonSerializer.Deserialize<TeamsChannelDataTenant>(je.GetRawText());
-            }
-
-            if (cd.Properties.TryGetValue("eventType", out object? eventTypeObj)
-                && eventTypeObj is JsonElement jeEventType
-                && jeEventType.ValueKind == JsonValueKind.String)
-            {
-                EventType = jeEventType.GetString();
-            }
-
-            if (cd.Properties.TryGetValue("team", out object? teamObj)
-                && teamObj is JsonElement teamObjJE
-                && teamObjJE.ValueKind == JsonValueKind.Object)
-            {
-                Team = JsonSerializer.Deserialize<Team?>(teamObjJE.GetRawText());
-            }
-
-            if (cd.Properties.TryGetValue("source", out object? sourceObj)
-                && sourceObj is JsonElement sourceObjJE
-                && sourceObjJE.ValueKind == JsonValueKind.Object)
-            {
-                Source = JsonSerializer.Deserialize<TeamsChannelDataSource?>(sourceObjJE.GetRawText());
-            }
-
-            if (cd.Properties.TryGetValue("feedbackLoopEnabled", out object? feedbackObj)
-                && feedbackObj is JsonElement jeFeedback
-                && jeFeedback.ValueKind is JsonValueKind.True or JsonValueKind.False)
-            {
-                FeedbackLoopEnabled = jeFeedback.GetBoolean();
-            }
+            return null;
         }
+
+        TeamsChannelData result = new();
+
+        //TODO : is channel id needed ? what is teamschannleid and teamsteamid ?
+        if (cd.Properties.TryGetValue("teamsChannelId", out object? channelIdObj)
+            && channelIdObj is JsonElement jeChannelId
+            && jeChannelId.ValueKind == JsonValueKind.String)
+        {
+            result.TeamsChannelId = jeChannelId.GetString();
+        }
+
+        if (cd.Properties.TryGetValue("teamsTeamId", out object? teamIdObj)
+            && teamIdObj is JsonElement jeTeamId
+            && jeTeamId.ValueKind == JsonValueKind.String)
+        {
+            result.TeamsTeamId = jeTeamId.GetString();
+        }
+
+        if (cd.Properties.TryGetValue("settings", out object? settingsObj)
+            && settingsObj is JsonElement settingsObjJE
+            && settingsObjJE.ValueKind == JsonValueKind.Object)
+        {
+            result.Settings = JsonSerializer.Deserialize<TeamsChannelDataSettings?>(settingsObjJE.GetRawText());
+        }
+
+        if (cd.Properties.TryGetValue("channel", out object? channelObj)
+            && channelObj is JsonElement channelObjJE
+            && channelObjJE.ValueKind == JsonValueKind.Object)
+        {
+            result.Channel = JsonSerializer.Deserialize<TeamsChannel?>(channelObjJE.GetRawText());
+        }
+
+        if (cd.Properties.TryGetValue("tenant", out object? tenantObj)
+            && tenantObj is JsonElement je
+            && je.ValueKind == JsonValueKind.Object)
+        {
+            result.Tenant = JsonSerializer.Deserialize<TeamsChannelDataTenant>(je.GetRawText());
+        }
+
+        if (cd.Properties.TryGetValue("eventType", out object? eventTypeObj)
+            && eventTypeObj is JsonElement jeEventType
+            && jeEventType.ValueKind == JsonValueKind.String)
+        {
+            result.EventType = jeEventType.GetString();
+        }
+
+        if (cd.Properties.TryGetValue("team", out object? teamObj)
+            && teamObj is JsonElement teamObjJE
+            && teamObjJE.ValueKind == JsonValueKind.Object)
+        {
+            result.Team = JsonSerializer.Deserialize<Team?>(teamObjJE.GetRawText());
+        }
+
+        if (cd.Properties.TryGetValue("source", out object? sourceObj)
+            && sourceObj is JsonElement sourceObjJE
+            && sourceObjJE.ValueKind == JsonValueKind.Object)
+        {
+            result.Source = JsonSerializer.Deserialize<TeamsChannelDataSource?>(sourceObjJE.GetRawText());
+        }
+
+        if (cd.Properties.TryGetValue("feedbackLoopEnabled", out object? feedbackObj)
+            && feedbackObj is JsonElement jeFeedback
+            && jeFeedback.ValueKind is JsonValueKind.True or JsonValueKind.False)
+        {
+            result.FeedbackLoopEnabled = jeFeedback.GetBoolean();
+        }
+        return result;
     }
 
 

--- a/core/src/Microsoft.Teams.Bot.Core/Schema/CoreActivityBuilder.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Schema/CoreActivityBuilder.cs
@@ -34,7 +34,7 @@ public abstract class CoreActivityBuilder<TActivity, TBuilder>
     /// </summary>
     /// <param name="activity">The source activity to copy conversation reference from.</param>
     /// <returns>The builder instance for chaining.</returns>
-    public TBuilder WithConversationReference(TActivity activity)
+    public TBuilder WithConversationReference(CoreActivity activity)
     {
         ArgumentNullException.ThrowIfNull(activity);
         ArgumentNullException.ThrowIfNull(activity.ChannelId);

--- a/core/test/Microsoft.Teams.Bot.Apps.UnitTests/MessageActivityBuilderTests.cs
+++ b/core/test/Microsoft.Teams.Bot.Apps.UnitTests/MessageActivityBuilderTests.cs
@@ -1,0 +1,261 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Teams.Bot.Apps.Schema;
+using Microsoft.Teams.Bot.Apps.Schema.Entities;
+using Microsoft.Teams.Bot.Core.Schema;
+
+namespace Microsoft.Teams.Bot.Apps.UnitTests;
+
+public class MessageActivityBuilderTests
+{
+    [Fact]
+    public void WithText_SetsTextAndFormat()
+    {
+        MessageActivity activity = MessageActivity.CreateBuilder()
+            .WithText("Hello, World!")
+            .Build();
+
+        Assert.Equal("Hello, World!", activity.Text);
+        Assert.Equal("plain", activity.TextFormat);
+    }
+
+    [Fact]
+    public void WithText_CustomFormat_SetsFormat()
+    {
+        MessageActivity activity = MessageActivity.CreateBuilder()
+            .WithText("**bold**", "markdown")
+            .Build();
+
+        Assert.Equal("**bold**", activity.Text);
+        Assert.Equal("markdown", activity.TextFormat);
+    }
+
+    [Fact]
+    public void WithSuggestedActions_SetsSuggestedActions()
+    {
+        SuggestedActions suggestedActions = new()
+        {
+            Actions = [new() { Title = "Yes", Type = "imBack", Value = "yes" }]
+        };
+
+        MessageActivity activity = MessageActivity.CreateBuilder()
+            .WithSuggestedActions(suggestedActions)
+            .Build();
+
+        Assert.NotNull(activity.SuggestedActions);
+        Assert.Single(activity.SuggestedActions.Actions!);
+        Assert.Equal("Yes", activity.SuggestedActions.Actions![0].Title);
+    }
+
+    [Fact]
+    public void AddMention_WithNullAccount_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => MessageActivity.CreateBuilder().AddMention(null!));
+    }
+
+    [Fact]
+    public void AddMention_WithAccountAndDefaultText_AddsMentionAndUpdatesText()
+    {
+        ConversationAccount account = new()
+        {
+            Id = "user-123",
+            Name = "John Doe"
+        };
+
+        MessageActivity activity = MessageActivity.CreateBuilder()
+            .WithText("said hello")
+            .AddMention(account)
+            .Build();
+
+        Assert.Equal("<at>John Doe</at> said hello", activity.Text);
+        Assert.NotNull(activity.Entities);
+        Assert.Single(activity.Entities);
+
+        MentionEntity? mention = activity.Entities[0] as MentionEntity;
+        Assert.NotNull(mention);
+        Assert.Equal("user-123", mention.Mentioned?.Id);
+        Assert.Equal("John Doe", mention.Mentioned?.Name);
+        Assert.Equal("<at>John Doe</at>", mention.Text);
+    }
+
+    [Fact]
+    public void AddMention_WithCustomText_UsesCustomText()
+    {
+        ConversationAccount account = new()
+        {
+            Id = "user-123",
+            Name = "John Doe"
+        };
+
+        MessageActivity activity = MessageActivity.CreateBuilder()
+            .WithText("replied")
+            .AddMention(account, "CustomName")
+            .Build();
+
+        Assert.Equal("<at>CustomName</at> replied", activity.Text);
+
+        MentionEntity? mention = activity.Entities![0] as MentionEntity;
+        Assert.NotNull(mention);
+        Assert.Equal("<at>CustomName</at>", mention.Text);
+    }
+
+    [Fact]
+    public void AddMention_WithAddTextFalse_DoesNotUpdateText()
+    {
+        ConversationAccount account = new()
+        {
+            Id = "user-123",
+            Name = "John Doe"
+        };
+
+        MessageActivity activity = MessageActivity.CreateBuilder()
+            .WithText("original text")
+            .AddMention(account, addText: false)
+            .Build();
+
+        Assert.Equal("original text", activity.Text);
+        Assert.NotNull(activity.Entities);
+        Assert.Single(activity.Entities);
+    }
+
+    [Fact]
+    public void AddMention_MultipleMentions_AddsAllMentions()
+    {
+        ConversationAccount account1 = new() { Id = "user-1", Name = "User One" };
+        ConversationAccount account2 = new() { Id = "user-2", Name = "User Two" };
+
+        MessageActivity activity = MessageActivity.CreateBuilder()
+            .WithText("message")
+            .AddMention(account1)
+            .AddMention(account2)
+            .Build();
+
+        Assert.Equal("<at>User Two</at> <at>User One</at> message", activity.Text);
+        Assert.NotNull(activity.Entities);
+        Assert.Equal(2, activity.Entities?.Count);
+    }
+
+    [Fact]
+    public void AddMention_EmptyText_PrependsMention()
+    {
+        ConversationAccount account = new() { Id = "user-123", Name = "User" };
+
+        MessageActivity activity = MessageActivity.CreateBuilder()
+            .AddMention(account)
+            .Build();
+
+        Assert.Equal("<at>User</at> ", activity.Text);
+    }
+
+    [Fact]
+    public void AddMention_WithAccountWithNullName_UsesNullText()
+    {
+        ConversationAccount account = new() { Id = "user-123", Name = null };
+
+        MessageActivity activity = MessageActivity.CreateBuilder()
+            .WithText("message")
+            .AddMention(account)
+            .Build();
+
+        Assert.Equal("<at></at> message", activity.Text);
+        Assert.NotNull(activity.Entities);
+        Assert.Single(activity.Entities);
+    }
+
+    [Fact]
+    public void AddMention_UpdatesBaseEntityCollection()
+    {
+        ConversationAccount account = new() { Id = "user-123", Name = "Test User" };
+
+        MessageActivity activity = MessageActivity.CreateBuilder()
+            .AddMention(account)
+            .Build();
+
+        CoreActivity baseActivity = activity;
+        Assert.NotNull(baseActivity.Entities);
+        Assert.NotEmpty(baseActivity.Entities);
+    }
+
+    [Fact]
+    public void MethodChaining_ReturnsBuilderInstance()
+    {
+        MessageActivityBuilder msgBuilder = MessageActivity.CreateBuilder();
+
+        MessageActivityBuilder result1 = msgBuilder.WithId("id");
+        MessageActivityBuilder result2 = msgBuilder.WithText("text");
+        MessageActivityBuilder result3 = msgBuilder.WithType(TeamsActivityType.Message);
+
+        Assert.Same(msgBuilder, result1);
+        Assert.Same(msgBuilder, result2);
+        Assert.Same(msgBuilder, result3);
+    }
+
+    [Fact]
+    public void CreateBuilder_WithExistingActivity_PreservesData()
+    {
+        MessageActivity original = new() { Id = "original-id", Text = "original text" };
+
+        MessageActivity modified = MessageActivity.CreateBuilder(original)
+            .WithText("modified text")
+            .Build();
+
+        Assert.Equal("original-id", modified.Id);
+        Assert.Equal("modified text", modified.Text);
+    }
+
+    [Fact]
+    public void IntegrationTest_CreateComplexMessageActivity()
+    {
+        Uri serviceUrl = new("https://smba.trafficmanager.net/amer/test/");
+        TeamsChannelData channelData = new()
+        {
+            TeamsChannelId = "19:channel@thread.tacv2",
+            TeamsTeamId = "19:team@thread.tacv2"
+        };
+
+        Conversation conv = new()
+        {
+            Id = "conv-001",
+            Properties =
+            {
+                { "tenantId", "tenant-001" },
+                { "conversationType", "channel" }
+            }
+        };
+
+        TeamsConversation? tc = TeamsConversation.FromConversation(conv);
+        Assert.NotNull(tc);
+
+        MessageActivity activity = MessageActivity.CreateBuilder()
+            .WithId("msg-001")
+            .WithServiceUrl(serviceUrl)
+            .WithChannelId("msteams")
+            .WithText("Please review this document")
+            .WithFrom(TeamsConversationAccount.FromConversationAccount(new ConversationAccount { Id = "bot-id", Name = "Bot" }))
+            .WithRecipient(TeamsConversationAccount.FromConversationAccount(new ConversationAccount { Id = "user-id", Name = "User" }))
+            .WithConversation(tc)
+            .WithChannelData(channelData)
+            .AddEntity(new ClientInfoEntity { Locale = "en-US", Country = "US", Platform = "Web" })
+            .AddAttachment(new TeamsAttachment { ContentType = "application/vnd.microsoft.card.adaptive", Name = "card.json" })
+            .AddMention(new ConversationAccount { Id = "manager-id", Name = "Manager" }, "Manager")
+            .Build();
+
+        Assert.Equal(TeamsActivityType.Message, activity.Type);
+        Assert.Equal("msg-001", activity.Id);
+        Assert.Equal(serviceUrl, activity.ServiceUrl);
+        Assert.Equal("msteams", activity.ChannelId);
+        Assert.Equal("<at>Manager</at> Please review this document", activity.Text);
+        Assert.Equal("bot-id", activity.From?.Id);
+        Assert.Equal("user-id", activity.Recipient?.Id);
+        Assert.Equal("conv-001", activity.Conversation?.Id);
+        Assert.Equal("tenant-001", activity.Conversation?.TenantId);
+        Assert.Equal("channel", activity.Conversation?.ConversationType);
+        Assert.NotNull(activity.ChannelData);
+        Assert.Equal("19:channel@thread.tacv2", activity.ChannelData?.TeamsChannelId);
+        Assert.NotNull(activity.Entities);
+        Assert.Equal(2, activity.Entities?.Count); // ClientInfo + Mention
+        Assert.NotNull(activity.Attachments);
+        Assert.Single(activity.Attachments);
+    }
+}

--- a/core/test/Microsoft.Teams.Bot.Apps.UnitTests/StreamingActivityBuilderTests.cs
+++ b/core/test/Microsoft.Teams.Bot.Apps.UnitTests/StreamingActivityBuilderTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Teams.Bot.Apps.Schema;
+using Microsoft.Teams.Bot.Apps.Schema.Entities;
+
+namespace Microsoft.Teams.Bot.Apps.UnitTests;
+
+public class StreamingActivityBuilderTests
+{
+    [Fact]
+    public void CreateBuilder_DefaultText_CreatesStreamingActivity()
+    {
+        StreamingActivity activity = StreamingActivity.CreateBuilder().Build();
+
+        Assert.NotNull(activity);
+        Assert.Equal(TeamsActivityType.Typing, activity.Type);
+        Assert.Equal("", activity.Text);
+    }
+
+    [Fact]
+    public void CreateBuilder_WithInitialText_SetsText()
+    {
+        StreamingActivity activity = StreamingActivity.CreateBuilder("Hello").Build();
+
+        Assert.Equal("Hello", activity.Text);
+    }
+
+    [Fact]
+    public void WithText_UpdatesText()
+    {
+        StreamingActivity activity = StreamingActivity.CreateBuilder("initial")
+            .WithText("updated text")
+            .Build();
+
+        Assert.Equal("updated text", activity.Text);
+    }
+
+    [Fact]
+    public void Build_ActivityHasStreamInfoEntity()
+    {
+        StreamingActivity activity = StreamingActivity.CreateBuilder("chunk").Build();
+
+        Assert.NotNull(activity.StreamInfo);
+        Assert.NotNull(activity.Entities);
+        Assert.Contains(activity.Entities, e => e is StreamInfoEntity);
+    }
+
+    [Fact]
+    public void MethodChaining_ReturnsBuilderInstance()
+    {
+        StreamingActivityBuilder streamBuilder = StreamingActivity.CreateBuilder();
+
+        StreamingActivityBuilder result1 = streamBuilder.WithId("id");
+        StreamingActivityBuilder result2 = streamBuilder.WithText("text");
+
+        Assert.Same(streamBuilder, result1);
+        Assert.Same(streamBuilder, result2);
+    }
+
+    [Fact]
+    public void Build_ReturnsStreamingActivity()
+    {
+        StreamingActivity activity = StreamingActivity.CreateBuilder("test").Build();
+
+        Assert.IsType<StreamingActivity>(activity);
+    }
+}

--- a/core/test/Microsoft.Teams.Bot.Apps.UnitTests/SuggestedActionsTests.cs
+++ b/core/test/Microsoft.Teams.Bot.Apps.UnitTests/SuggestedActionsTests.cs
@@ -191,8 +191,7 @@ public class SuggestedActionsTests
     {
         var suggestedActions = new SuggestedActions();
 
-        var activity = TeamsActivity.CreateBuilder()
-            .WithType(TeamsActivityType.Message)
+        MessageActivity activity = MessageActivity.CreateBuilder()
             .WithText("Choose an option")
             .WithSuggestedActions(suggestedActions)
             .Build();
@@ -202,7 +201,7 @@ public class SuggestedActionsTests
         Assert.Empty(activity.SuggestedActions.Actions);
     }
 
-    
+
 
     [Fact]
     public void MessageActivity_WithSuggestedActions()
@@ -210,8 +209,7 @@ public class SuggestedActionsTests
         var suggestedActions = new SuggestedActions()
             .AddAction(new SuggestedAction(ActionType.IMBack, "Option 1") { Value = "opt1" });
 
-        var activity = TeamsActivity.CreateBuilder()
-            .WithType(TeamsActivityType.Message)
+        MessageActivity activity = MessageActivity.CreateBuilder()
             .WithText("Choose an option")
             .WithSuggestedActions(suggestedActions)
             .Build();

--- a/core/test/Microsoft.Teams.Bot.Apps.UnitTests/TeamsActivityBuilderTests.cs
+++ b/core/test/Microsoft.Teams.Bot.Apps.UnitTests/TeamsActivityBuilderTests.cs
@@ -91,16 +91,6 @@ public class TeamsActivityBuilderTests
     }
 
     [Fact]
-    public void WithText_SetsTextContent()
-    {
-        TeamsActivity activity = builder
-            .WithText("Hello, World!")
-            .Build();
-
-        Assert.Equal("Hello, World!", activity.Properties["text"]);
-    }
-
-    [Fact]
     public void WithFrom_SetsSenderAccount()
     {
         TeamsConversationAccount? fromAccount = TeamsConversationAccount.FromConversationAccount(new ConversationAccount
@@ -138,8 +128,6 @@ public class TeamsActivityBuilderTests
     public void WithConversation_SetsConversationInfo()
     {
         Conversation baseConversation = new Conversation("conversation-id");
-
-        Assert.NotNull(baseConversation);
         baseConversation.Properties.Add("tenantId", "tenant-123");
         baseConversation.Properties.Add("conversationType", "channel");
         TeamsConversation? conversation = TeamsConversation.FromConversation(baseConversation);
@@ -211,24 +199,6 @@ public class TeamsActivityBuilderTests
         Assert.Single(activity.Attachments);
         Assert.Equal("application/json", activity.Attachments[0].ContentType);
         Assert.Equal("test-attachment", activity.Attachments[0].Name);
-    }
-
-    [Fact]
-    public void WithAttachment_SetsSingleAttachment()
-    {
-        TeamsAttachment attachment = new()
-        {
-            ContentType = "application/json",
-            Name = "single"
-        };
-
-        TeamsActivity activity = builder
-            .WithAttachment(attachment)
-            .Build();
-
-        Assert.NotNull(activity.Attachments);
-        Assert.Single(activity.Attachments);
-        Assert.Equal("single", activity.Attachments[0].Name);
     }
 
     [Fact]
@@ -307,12 +277,12 @@ public class TeamsActivityBuilderTests
     }
 
     [Fact]
-    public void WithAdaptiveCardAttachment_ConfigureActionAppliesChanges()
+    public void AddAdaptiveCardAttachment_WithConfigure_AppliesChanges()
     {
         var adaptiveCard = new { type = "AdaptiveCard" };
 
         TeamsActivity activity = builder
-            .WithAdaptiveCardAttachment(adaptiveCard, b => b.WithName("feedback"))
+            .AddAdaptiveCardAttachment(adaptiveCard, b => b.WithName("feedback"))
             .Build();
 
         Assert.NotNull(activity.Attachments);
@@ -327,194 +297,24 @@ public class TeamsActivityBuilderTests
     }
 
     [Fact]
-    public void AddMention_WithNullAccount_ThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => builder.AddMention(null!));
-    }
-
-    [Fact]
-    public void AddMention_WithAccountAndDefaultText_AddsMentionAndUpdatesText()
-    {
-        ConversationAccount account = new()
-        {
-            Id = "user-123",
-            Name = "John Doe"
-        };
-
-        TeamsActivity activity = builder
-            .WithText("said hello")
-            .AddMention(account)
-            .Build();
-
-        Assert.Equal("<at>John Doe</at> said hello", activity.Properties["text"]);
-        Assert.NotNull(activity.Entities);
-        Assert.Single(activity.Entities);
-
-        MentionEntity? mention = activity.Entities[0] as MentionEntity;
-        Assert.NotNull(mention);
-        Assert.Equal("user-123", mention.Mentioned?.Id);
-        Assert.Equal("John Doe", mention.Mentioned?.Name);
-        Assert.Equal("<at>John Doe</at>", mention.Text);
-    }
-
-    [Fact]
-    public void AddMention_WithCustomText_UsesCustomText()
-    {
-        ConversationAccount account = new()
-        {
-            Id = "user-123",
-            Name = "John Doe"
-        };
-
-        TeamsActivity activity = builder
-            .WithText("replied")
-            .AddMention(account, "CustomName")
-            .Build();
-
-        Assert.Equal("<at>CustomName</at> replied", activity.Properties["text"]);
-
-        MentionEntity? mention = activity.Entities![0] as MentionEntity;
-        Assert.NotNull(mention);
-        Assert.Equal("<at>CustomName</at>", mention.Text);
-    }
-
-    [Fact]
-    public void AddMention_WithAddTextFalse_DoesNotUpdateText()
-    {
-        ConversationAccount account = new()
-        {
-            Id = "user-123",
-            Name = "John Doe"
-        };
-
-        TeamsActivity activity = builder
-            .WithText("original text")
-            .AddMention(account, addText: false)
-            .Build();
-
-        Assert.Equal("original text", activity.Properties["text"]);
-        Assert.NotNull(activity.Entities);
-        Assert.Single(activity.Entities);
-    }
-
-    [Fact]
-    public void AddMention_MultipleMentions_AddsAllMentions()
-    {
-        ConversationAccount account1 = new() { Id = "user-1", Name = "User One" };
-        ConversationAccount account2 = new() { Id = "user-2", Name = "User Two" };
-
-        TeamsActivity activity = builder
-            .WithText("message")
-            .AddMention(account1)
-            .AddMention(account2)
-            .Build();
-
-        Assert.Equal("<at>User Two</at> <at>User One</at> message", activity.Properties["text"]);
-        Assert.NotNull(activity.Entities);
-        Assert.Equal(2, activity.Entities?.Count);
-    }
-
-    [Fact]
-    public void FluentAPI_CompleteActivity_BuildsCorrectly()
-    {
-        TeamsActivity activity = builder
-            .WithType(TeamsActivityType.Message)
-            .WithId("activity-123")
-            .WithChannelId("msteams")
-            .WithText("Test message")
-            .WithServiceUrl(new Uri("https://smba.trafficmanager.net/teams/"))
-            .WithFrom(TeamsConversationAccount.FromConversationAccount(new ConversationAccount
-            {
-                Id = "sender-id",
-                Name = "Sender"
-            }))
-            .WithRecipient(TeamsConversationAccount.FromConversationAccount(new ConversationAccount
-            {
-                Id = "recipient-id",
-                Name = "Recipient"
-            }))
-            .WithConversation(TeamsConversation.FromConversation(new Conversation
-            {
-                Id = "conv-id"
-            }))
-            .AddEntity(new ClientInfoEntity { Locale = "en-US" })
-            .AddAttachment(new TeamsAttachment { ContentType = "text/html" })
-            .AddMention(new ConversationAccount { Id = "user-1", Name = "User" })
-            .Build();
-
-        Assert.Equal(TeamsActivityType.Message, activity.Type);
-        Assert.Equal("activity-123", activity.Id);
-        Assert.Equal("msteams", activity.ChannelId);
-        Assert.Equal("<at>User</at> Test message", activity.Properties["text"]);
-        Assert.Equal("sender-id", activity.From?.Id);
-        Assert.Equal("recipient-id", activity.Recipient?.Id);
-        Assert.Equal("conv-id", activity.Conversation?.Id);
-        Assert.NotNull(activity.Entities);
-        Assert.Equal(2, activity.Entities?.Count); // ClientInfo + Mention
-        Assert.NotNull(activity.Attachments);
-        Assert.Single(activity.Attachments);
-    }
-
-    [Fact]
     public void FluentAPI_MethodChaining_ReturnsBuilderInstance()
     {
-
         TeamsActivityBuilder result1 = builder.WithId("id");
-        TeamsActivityBuilder result2 = builder.WithText("text");
-        TeamsActivityBuilder result3 = builder.WithType(TeamsActivityType.Message);
+        TeamsActivityBuilder result2 = builder.WithType(TeamsActivityType.Message);
 
         Assert.Same(builder, result1);
         Assert.Same(builder, result2);
-        Assert.Same(builder, result3);
     }
 
     [Fact]
     public void Build_CalledMultipleTimes_ReturnsSameInstance()
     {
-        builder
-            .WithId("test-id");
+        builder.WithId("test-id");
 
         TeamsActivity activity1 = builder.Build();
         TeamsActivity activity2 = builder.Build();
 
         Assert.Same(activity1, activity2);
-    }
-
-    [Fact]
-    public void Builder_ModifyingExistingActivity_PreservesOriginalData()
-    {
-        TeamsActivity original = new()
-        {
-            Id = "original-id",
-            Type = TeamsActivityType.Message
-        };
-        original.Properties["text"] = "original text";
-
-        TeamsActivity modified = TeamsActivity.CreateBuilder(original)
-            .WithText("modified text")
-            .Build();
-
-        Assert.Equal("original-id", modified.Id);
-        Assert.Equal("modified text", modified.Properties["text"]);
-        Assert.Equal(TeamsActivityType.Message, modified.Type);
-    }
-
-    [Fact]
-    public void AddMention_UpdatesBaseEntityCollection()
-    {
-        ConversationAccount account = new()
-        {
-            Id = "user-123",
-            Name = "Test User"
-        };
-
-        TeamsActivity activity = builder
-            .AddMention(account)
-            .Build();
-
-        CoreActivity baseActivity = activity;
-        Assert.NotNull(baseActivity.Entities);
-        Assert.NotEmpty(baseActivity.Entities);
     }
 
     [Fact]
@@ -531,7 +331,6 @@ public class TeamsActivityBuilderTests
     public void AddEntity_NullEntitiesCollection_InitializesCollection()
     {
         TeamsActivity activity = builder.Build();
-
         Assert.Null(activity.Entities);
 
         ClientInfoEntity entity = new() { Locale = "en-US" };
@@ -546,7 +345,6 @@ public class TeamsActivityBuilderTests
     public void AddAttachment_NullAttachmentsCollection_InitializesCollection()
     {
         TeamsActivity activity = builder.Build();
-
         Assert.Null(activity.Attachments);
 
         TeamsAttachment attachment = new() { ContentType = "text/html" };
@@ -558,22 +356,6 @@ public class TeamsActivityBuilderTests
     }
 
     [Fact]
-    public void Builder_EmptyText_AddMention_PrependsMention()
-    {
-        ConversationAccount account = new()
-        {
-            Id = "user-123",
-            Name = "User"
-        };
-
-        TeamsActivity activity = builder
-            .AddMention(account)
-            .Build();
-
-        Assert.Equal("<at>User</at> ", activity.Properties["text"]);
-    }
-
-    [Fact]
     public void WithConversationReference_WithNullActivity_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() => builder.WithConversationReference(null!));
@@ -582,7 +364,6 @@ public class TeamsActivityBuilderTests
     [Fact]
     public void WithConversationReference_WithNullChannelId_ThrowsArgumentNullException()
     {
-
         TeamsActivity sourceActivity = new()
         {
             ChannelId = null,
@@ -623,7 +404,6 @@ public class TeamsActivityBuilderTests
         };
 
         TeamsActivity result = builder.WithConversationReference(sourceActivity).Build();
-
         Assert.NotNull(result.Conversation);
     }
 
@@ -640,7 +420,6 @@ public class TeamsActivityBuilderTests
         };
 
         TeamsActivity result = builder.WithConversationReference(sourceActivity).Build();
-
         Assert.NotNull(result.From);
     }
 
@@ -657,7 +436,6 @@ public class TeamsActivityBuilderTests
         };
 
         TeamsActivity result = builder.WithConversationReference(sourceActivity).Build();
-
         Assert.NotNull(result.From);
     }
 
@@ -736,29 +514,9 @@ public class TeamsActivityBuilderTests
     }
 
     [Fact]
-    public void AddMention_WithAccountWithNullName_UsesNullText()
-    {
-        ConversationAccount account = new()
-        {
-            Id = "user-123",
-            Name = null
-        };
-
-        TeamsActivity activity = builder
-            .WithText("message")
-            .AddMention(account)
-            .Build();
-
-        Assert.Equal("<at></at> message", activity.Properties["text"]);
-        Assert.NotNull(activity.Entities);
-        Assert.Single(activity.Entities);
-    }
-
-    [Fact]
     public void Build_MultipleCalls_ReturnsRebasedActivity()
     {
-        builder
-            .AddEntity(new ClientInfoEntity { Locale = "en-US" });
+        builder.AddEntity(new ClientInfoEntity { Locale = "en-US" });
 
         TeamsActivity activity1 = builder.Build();
         CoreActivity baseActivity1 = activity1;
@@ -771,83 +529,5 @@ public class TeamsActivityBuilderTests
         Assert.Same(activity1, activity2);
         Assert.NotNull(baseActivity2.Entities);
         Assert.Equal(2, activity2.Entities!.Count);
-    }
-
-    [Fact]
-    public void IntegrationTest_CreateComplexActivity()
-    {
-        Uri serviceUrl = new("https://smba.trafficmanager.net/amer/test/");
-        TeamsChannelData channelData = new()
-        {
-            TeamsChannelId = "19:channel@thread.tacv2",
-            TeamsTeamId = "19:team@thread.tacv2"
-        };
-
-        Conversation conv = new()
-        {
-            Id = "conv-001",
-            Properties =
-            {
-                { "tenantId", "tenant-001" },
-                { "conversationType", "channel" }
-            }
-        };
-
-        TeamsConversation? tc = TeamsConversation.FromConversation(conv);
-        Assert.NotNull(tc);
-
-        TeamsActivity activity = builder
-            .WithType(TeamsActivityType.Message)
-            .WithId("msg-001")
-            .WithServiceUrl(serviceUrl)
-            .WithChannelId("msteams")
-            .WithText("Please review this document")
-            .WithFrom(TeamsConversationAccount.FromConversationAccount(new ConversationAccount
-            {
-                Id = "bot-id",
-                Name = "Bot"
-            }))
-            .WithRecipient(TeamsConversationAccount.FromConversationAccount(new ConversationAccount
-            {
-                Id = "user-id",
-                Name = "User"
-            }))
-            .WithConversation(tc)
-            .WithChannelData(channelData)
-            .AddEntity(new ClientInfoEntity
-            {
-                Locale = "en-US",
-                Country = "US",
-                Platform = "Web"
-            })
-            .AddAttachment(new TeamsAttachment
-            {
-                ContentType = "application/vnd.microsoft.card.adaptive",
-                Name = "adaptive-card.json"
-            })
-            .AddMention(new ConversationAccount
-            {
-                Id = "manager-id",
-                Name = "Manager"
-            }, "Manager")
-            .Build();
-
-        // Verify all properties
-        Assert.Equal(TeamsActivityType.Message, activity.Type);
-        Assert.Equal("msg-001", activity.Id);
-        Assert.Equal(serviceUrl, activity.ServiceUrl);
-        Assert.Equal("msteams", activity.ChannelId);
-        Assert.Equal("<at>Manager</at> Please review this document", activity.Properties["text"]);
-        Assert.Equal("bot-id", activity.From?.Id);
-        Assert.Equal("user-id", activity.Recipient?.Id);
-        Assert.Equal("conv-001", activity.Conversation?.Id);
-        Assert.Equal("tenant-001", activity.Conversation?.TenantId);
-        Assert.Equal("channel", activity.Conversation?.ConversationType);
-        Assert.NotNull(activity.ChannelData);
-        Assert.Equal("19:channel@thread.tacv2", activity.ChannelData?.TeamsChannelId);
-        Assert.NotNull(activity.Entities);
-        Assert.Equal(2, activity.Entities?.Count); // ClientInfo + Mention
-        Assert.NotNull(activity.Attachments);
-        Assert.Single(activity.Attachments);
     }
 }

--- a/core/test/Microsoft.Teams.Bot.Apps.UnitTests/TeamsActivityTests.cs
+++ b/core/test/Microsoft.Teams.Bot.Apps.UnitTests/TeamsActivityTests.cs
@@ -121,8 +121,7 @@ public class TeamsActivityTests
     [Fact]
     public void TeamsActivityBuilder_FluentAPI()
     {
-        TeamsActivity activity = TeamsActivity.CreateBuilder()
-            .WithType(TeamsActivityType.Message)
+        MessageActivity activity = MessageActivity.CreateBuilder()
             .WithText("Hello World")
             .WithChannelId("msteams")
             .AddMention(new ConversationAccount
@@ -133,7 +132,7 @@ public class TeamsActivityTests
             .Build();
 
         Assert.Equal(ActivityType.Message, activity.Type);
-        Assert.Equal("<at>TestUser</at> Hello World", activity.Properties["text"]);
+        Assert.Equal("<at>TestUser</at> Hello World", activity.Text);
         Assert.Equal("msteams", activity.ChannelId);
         Assert.NotNull(activity.Entities);
         Assert.Single(activity.Entities);
@@ -147,8 +146,7 @@ public class TeamsActivityTests
     [Fact]
     public void Serialize_TeamsActivity_WithEntities()
     {
-        TeamsActivity activity = TeamsActivity.CreateBuilder()
-            .WithType(ActivityType.Message)
+        MessageActivity activity = MessageActivity.CreateBuilder()
             .WithText("Hello World")
             .WithChannelId("msteams")
             .Build();


### PR DESCRIPTION
  What changed: Introduced type-specific activity builders alongside the existing TeamsActivityBuilder.                                        
  New types                                                                                                                                    
  - TeamsActivityBuilder<TActivity, TBuilder> — abstract generic base that all Teams builders inherit from. Holds shared methods: WithChannelData, WithEntities, AddEntity, WithAttachments, AddAttachment, AddAdaptiveCardAttachment, and the Teams-specific overrides for SetConversation/SetFrom/SetRecipient.
  - MessageActivityBuilder — concrete builder for MessageActivity with typed setters for WithText, WithSuggestedActions, and AddMention (reads/writes activity.Text directly).
  - StreamingActivityBuilder — concrete builder for StreamingActivity with typed WithText.
  - TeamsActivityBuilder — now just a thin concrete class with Build() only, backwards-compatible for non-message use cases.

---

  Why
- Previously TeamsActivityBuilder built all activity types but returned TeamsActivity. So you could do WithText("...") but not access activity.Text after building. This is a problem. Even if we internally cast, the user cannot access activity.Text without casting again
  With dedicated builders, MessageActivity.CreateBuilder().WithText(...).Build() returns a MessageActivity — activity.Text just works. Same for SuggestedActions, TextFormat, etc. 
- Since we have limited outgoing activities, this is a clean approach. Developers should directly be accessing Message Activity, and Teams Activity is more of an internal class to coordinate shared properties across outgoing/incoming activities and a bridge to core activity. 

---

  Ripple changes

  - CoreActivityBuilder.WithConversationReference parameter widened from TActivity to CoreActivity so any builder can accept any activity as a conversation reference source.
  - Context.cs and all samples updated to use MessageActivity.CreateBuilder() where they were building message replies.
  - Test suite split into TeamsActivityBuilderTests, MessageActivityBuilderTests, StreamingActivityBuilderTests to match the new structure.