### PR TITLE
Add sovereign cloud support to next/core (GCCH, DoD, China)

### DIFF
--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -422,6 +422,7 @@ public partial class App
         {
             AppId = @event.Token.AppId ?? Id ?? string.Empty,
             TenantId = @event.Token.TenantId ?? string.Empty,
+            Cloud = _cloud,
             Log = Logger.Child(path),
             Storage = Storage,
             Api = api,

--- a/Libraries/Microsoft.Teams.Apps/Contexts/Context.cs
+++ b/Libraries/Microsoft.Teams.Apps/Contexts/Context.cs
@@ -39,6 +39,11 @@ public partial interface IContext<TActivity> where TActivity : IActivity
     public string TenantId { get; set; }
 
     /// <summary>
+    /// the cloud environment configured on the app; drives per-cloud endpoint routing
+    /// </summary>
+    public CloudEnvironment Cloud { get; set; }
+
+    /// <summary>
     /// the app logger instance
     /// </summary>
     public ILogger Log { get; set; }
@@ -130,6 +135,7 @@ public partial class Context<TActivity>(ISenderPlugin sender, IStreamer stream) 
 
     public required string AppId { get; set; }
     public required string TenantId { get; set; }
+    public required CloudEnvironment Cloud { get; set; }
     public required ILogger Log { get; set; }
     public required IStorage<string, object> Storage { get; set; }
     public required ApiClient Api { get; set; }
@@ -176,6 +182,7 @@ public partial class Context<TActivity>(ISenderPlugin sender, IStreamer stream) 
             Sender = Sender,
             AppId = AppId,
             TenantId = TenantId,
+            Cloud = Cloud,
             Log = Log,
             Storage = Storage,
             Api = Api,

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Graph/ContextExtensions.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Graph/ContextExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Graph;
+﻿using System.Text.RegularExpressions;
+
+using Microsoft.Graph;
 using Microsoft.Teams.Api.Activities;
 using Microsoft.Teams.Apps;
 
@@ -6,6 +8,10 @@ namespace Microsoft.Teams.Extensions.Graph;
 
 public static class ContextExtensions
 {
+    // Extracts scheme + host (+ optional port) from a URL-like scope such as
+    // "https://graph.microsoft.us/.default" -> "https://graph.microsoft.us".
+    private static readonly Regex _graphBaseUrlRegex = new(@"^(https?://[^/]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     /// <summary>
     /// Get user's graph client from the context.
     /// </summary>
@@ -32,7 +38,27 @@ public static class ContextExtensions
             return new Azure.Core.AccessToken(userToken.ToString(), userToken.Token.ValidTo);
         });
 
-        graphClient = new GraphServiceClient(userGraphTokenProvider);
+        // Derive per-cloud Graph base URL from the configured cloud's graphScope.
+        // Falls back to the public Graph endpoint if the scope isn't a URL.
+        var graphScope = context.Cloud?.GraphScope?.Trim();
+        string? baseUrl = null;
+        if (!string.IsNullOrEmpty(graphScope))
+        {
+            var match = _graphBaseUrlRegex.Match(graphScope);
+            if (match.Success)
+            {
+                baseUrl = match.Groups[1].Value;
+            }
+            else
+            {
+                context.Log.Warn($"graphScope \"{graphScope}\" is not a URL; Graph calls will route to the public cloud. " +
+                    "Set graphScope to an \"https://<host>/.default\" value to route to the correct Graph endpoint.");
+            }
+        }
+
+        graphClient = baseUrl is null
+            ? new GraphServiceClient(userGraphTokenProvider)
+            : new GraphServiceClient(userGraphTokenProvider, scopes: null, baseUrl: baseUrl);
         context.Extra["UserGraphClient"] = graphClient;
 
         return graphClient;

--- a/Tests/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Graph.Tests/ContextExtensionsTests.cs
+++ b/Tests/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Graph.Tests/ContextExtensionsTests.cs
@@ -89,7 +89,9 @@ public class ContextExtensionsTests
         var graphClient = context.Object.GetUserGraphClient();
 
         Assert.NotNull(graphClient);
-        Assert.StartsWith(expectedBaseUrl, graphClient.RequestAdapter.BaseUrl, StringComparison.OrdinalIgnoreCase);
+        // Full equality rather than StartsWith: avoids the incomplete-URL-substring-sanitization
+        // smell (a prefix check could match "<expected>.evil.com").
+        Assert.Equal(expectedBaseUrl, graphClient.RequestAdapter.BaseUrl, ignoreCase: true);
     }
 
     [Fact]
@@ -115,7 +117,10 @@ public class ContextExtensionsTests
 
         Assert.NotNull(graphClient);
         // Fallback: public base URL used (because scope didn't parse as URL)
-        Assert.StartsWith("https://graph.microsoft.com", graphClient.RequestAdapter.BaseUrl, StringComparison.OrdinalIgnoreCase);
+        // Fallback path uses the parameterless GraphServiceClient ctor, which the Microsoft.Graph
+        // SDK initializes with "https://graph.microsoft.com/v1.0" (adds /v1.0, unlike the
+        // explicit-baseUrl overload which stores the value verbatim).
+        Assert.Equal("https://graph.microsoft.com/v1.0", graphClient.RequestAdapter.BaseUrl, ignoreCase: true);
         logger.Verify(l => l.Warn(It.IsAny<object?[]>()), Times.Once);
     }
 }

--- a/Tests/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Graph.Tests/ContextExtensionsTests.cs
+++ b/Tests/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Graph.Tests/ContextExtensionsTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.Teams.Api.Activities;
 using Microsoft.Teams.Api.Auth;
 using Microsoft.Teams.Apps;
+using Microsoft.Teams.Common.Logging;
 
 using Moq;
 
@@ -58,5 +59,63 @@ public class ContextExtensionsTests
         // Assert
         Assert.NotNull(graphClient);
         Assert.Equal(graphClientMock, graphClient);
+    }
+
+    // --- Sovereign cloud Graph routing ---
+
+    private static Mock<IContext<IActivity>> MockContextWith(CloudEnvironment? cloud, Mock<ILogger>? logger = null)
+    {
+        var token = "eyJhbGciOiJIUzI1NiJ9.eyJSb2xlIjoiQWRtaW4iLCJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkphdmFJblVzZSIsImV4cCI6MTc1MzI1MjAzNSwiaWF0IjoxNzUzMjUyMDM1fQ.J-DWberQuMBSnAECP0jmK-zX6BzB4o-rMEshkR0mN-A";
+        var jwtToken = new JsonWebToken(token);
+        var context = new Mock<IContext<IActivity>>();
+        context.Setup(c => c.UserGraphToken).Returns(jwtToken);
+        context.Setup(c => c.Extra).Returns(new Dictionary<string, object?>());
+        context.Setup(c => c.Cloud).Returns(cloud!);
+        context.Setup(c => c.Log).Returns((logger ?? new Mock<ILogger>()).Object);
+        return context;
+    }
+
+    [Theory]
+    [InlineData("USGov")]
+    [InlineData("USGovDoD")]
+    [InlineData("China")]
+    [InlineData("Public")]
+    public void GetUserGraphClient_RoutesToCloudSpecificBaseUrl(string cloudName)
+    {
+        var cloud = CloudEnvironment.FromName(cloudName);
+        var expectedBaseUrl = cloud.GraphScope.Replace("/.default", string.Empty);
+        var context = MockContextWith(cloud);
+
+        var graphClient = context.Object.GetUserGraphClient();
+
+        Assert.NotNull(graphClient);
+        Assert.StartsWith(expectedBaseUrl, graphClient.RequestAdapter.BaseUrl, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetUserGraphClient_NullCloud_UsesPublicDefault_NoWarning()
+    {
+        var logger = new Mock<ILogger>();
+        var context = MockContextWith(cloud: null, logger: logger);
+
+        var graphClient = context.Object.GetUserGraphClient();
+
+        Assert.NotNull(graphClient);
+        logger.Verify(l => l.Warn(It.IsAny<object?[]>()), Times.Never);
+    }
+
+    [Fact]
+    public void GetUserGraphClient_NonUrlGraphScope_LogsWarningAndFallsBack()
+    {
+        var cloud = CloudEnvironment.Public.WithOverrides(graphScope: "user.read");
+        var logger = new Mock<ILogger>();
+        var context = MockContextWith(cloud, logger);
+
+        var graphClient = context.Object.GetUserGraphClient();
+
+        Assert.NotNull(graphClient);
+        // Fallback: public base URL used (because scope didn't parse as URL)
+        Assert.StartsWith("https://graph.microsoft.com", graphClient.RequestAdapter.BaseUrl, StringComparison.OrdinalIgnoreCase);
+        logger.Verify(l => l.Warn(It.IsAny<object?[]>()), Times.Once);
     }
 }

--- a/core/samples/PABot/SimpleGraphClient.cs
+++ b/core/samples/PABot/SimpleGraphClient.cs
@@ -16,12 +16,17 @@ namespace PABot
     public class SimpleGraphClient
     {
         private readonly string _token;
+        private readonly string? _baseUrl;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleGraphClient"/> class.
         /// </summary>
         /// <param name="token">The token issued to the user.</param>
-        public SimpleGraphClient(string token)
+        /// <param name="baseUrl">
+        /// Optional Graph API base URL override for sovereign clouds
+        /// (e.g. "https://graph.microsoft.us" for GCCH). When null, the public Graph endpoint is used.
+        /// </param>
+        public SimpleGraphClient(string token, string? baseUrl = null)
         {
             if (string.IsNullOrWhiteSpace(token))
             {
@@ -29,6 +34,7 @@ namespace PABot
             }
 
             _token = token;
+            _baseUrl = baseUrl;
         }
 
         /// <summary>
@@ -139,7 +145,9 @@ namespace PABot
 
             BaseBearerTokenAuthenticationProvider authProvider = new(tokenProvider);
 
-            return new GraphServiceClient(authProvider);
+            return _baseUrl is null
+                ? new GraphServiceClient(authProvider)
+                : new GraphServiceClient(authProvider, _baseUrl);
         }
 
         public class SimpleAccessTokenProvider : IAccessTokenProvider

--- a/core/src/Microsoft.Teams.Bot.Core/Hosting/AddBotApplicationExtensions.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Hosting/AddBotApplicationExtensions.cs
@@ -105,13 +105,10 @@ public static class AddBotApplicationExtensions
     /// <returns>The service collection for method chaining.</returns>
     internal static IServiceCollection AddBotApplication<TApp>(this IServiceCollection services, BotConfig botConfig) where TApp : BotApplication
     {
-        services.AddSingleton<BotApplicationOptions>(sp =>
+        services.AddSingleton<BotApplicationOptions>(_ => new BotApplicationOptions
         {
-            IConfiguration config = sp.GetRequiredService<IConfiguration>();
-            return new BotApplicationOptions
-            {
-                AppId = botConfig.ClientId
-            };
+            AppId = botConfig.ClientId,
+            Cloud = botConfig.Cloud
         });
         services.AddHttpContextAccessor();
         services.AddBotAuthorization(botConfig);
@@ -168,6 +165,7 @@ public static class AddBotApplicationExtensions
             {
                 options.Scope = botConfig.Scope;
                 options.SectionName = botConfig.SectionName;
+                options.Cloud = botConfig.Cloud;
             });
 
         // TODO: This shouldn't be called multiple times. It will being called once for each client we support.

--- a/core/src/Microsoft.Teams.Bot.Core/Hosting/BotApplicationOptions.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Hosting/BotApplicationOptions.cs
@@ -20,4 +20,9 @@ public sealed class BotApplicationOptions
     /// Defaults to 5 minutes. Set to <see cref="Timeout.InfiniteTimeSpan"/> to disable the timeout.
     /// </summary>
     public TimeSpan ProcessActivityTimeout { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Gets or sets the cloud environment. Defaults to <see cref="CloudEnvironment.Public"/>.
+    /// </summary>
+    public CloudEnvironment Cloud { get; set; } = CloudEnvironment.Public;
 }

--- a/core/src/Microsoft.Teams.Bot.Core/Hosting/BotClientOptions.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Hosting/BotClientOptions.cs
@@ -11,10 +11,15 @@ internal sealed class BotClientOptions
     /// <summary>
     /// Gets or sets the scope for bot authentication.
     /// </summary>
-    public string Scope { get; set; } = "https://api.botframework.com/.default";
+    public string Scope { get; set; } = CloudEnvironment.Public.BotScope;
 
     /// <summary>
     /// Gets or sets the configuration section name.
     /// </summary>
     public string SectionName { get; set; } = "AzureAd";
+
+    /// <summary>
+    /// Gets or sets the resolved cloud environment. Defaults to <see cref="CloudEnvironment.Public"/>.
+    /// </summary>
+    public CloudEnvironment Cloud { get; set; } = CloudEnvironment.Public;
 }

--- a/core/src/Microsoft.Teams.Bot.Core/Hosting/BotConfig.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Hosting/BotConfig.cs
@@ -25,8 +25,6 @@ internal sealed class BotConfig
     /// </summary>
     public const string SystemManagedIdentityIdentifier = "system";
 
-    private const string BotScope = "https://api.botframework.com/.default";
-
     private const string DefaultSectionName = "AzureAd";
 
     /// <summary>
@@ -57,10 +55,16 @@ internal sealed class BotConfig
     public string SectionName { get; set; } = DefaultSectionName;
 
     /// <summary>
-    /// Gets or sets the scope for token acquisition.
-    /// Defaults to "https://api.botframework.com/.default" if not specified.
+    /// Gets or sets the cloud environment for sovereign cloud support.
+    /// Defaults to <see cref="CloudEnvironment.Public"/> if not specified.
     /// </summary>
-    public string Scope { get; set; } = BotScope;
+    public CloudEnvironment Cloud { get; set; } = CloudEnvironment.Public;
+
+    /// <summary>
+    /// Gets or sets the scope for token acquisition.
+    /// Defaults to the cloud environment's <see cref="CloudEnvironment.BotScope"/>.
+    /// </summary>
+    public string Scope { get; set; } = CloudEnvironment.Public.BotScope;
 
     internal IConfigurationSection? MsalConfigurationSection { get; set; }
 
@@ -73,12 +77,14 @@ internal sealed class BotConfig
     public static BotConfig FromBFConfig(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
+        var cloud = ResolveCloud(configuration["Cloud"]);
         return new()
         {
             TenantId = configuration["MicrosoftAppTenantId"] ?? string.Empty,
             ClientId = configuration["MicrosoftAppId"] ?? string.Empty,
             ClientSecret = configuration["MicrosoftAppPassword"],
-            Scope = configuration["Scope"] ?? BotScope
+            Cloud = cloud,
+            Scope = configuration["Scope"] ?? cloud.BotScope
         };
     }
 
@@ -95,13 +101,15 @@ internal sealed class BotConfig
     public static BotConfig FromCoreConfig(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
+        var cloud = ResolveCloud(configuration["CLOUD"] ?? configuration["Cloud"]);
         return new()
         {
             TenantId = configuration["TENANT_ID"] ?? string.Empty,
             ClientId = configuration["CLIENT_ID"] ?? string.Empty,
             ClientSecret = configuration["CLIENT_SECRET"],
             FicClientId = configuration["MANAGED_IDENTITY_CLIENT_ID"],
-            Scope = configuration["Scope"] ?? BotScope,
+            Cloud = cloud,
+            Scope = configuration["Scope"] ?? cloud.BotScope,
         };
     }
 
@@ -120,12 +128,14 @@ internal sealed class BotConfig
     {
         ArgumentNullException.ThrowIfNull(configuration);
         IConfigurationSection section = configuration.GetSection(sectionName);
+        var cloud = ResolveCloud(section["Cloud"] ?? configuration["Cloud"]);
         return new()
         {
             TenantId = section["TenantId"] ?? string.Empty,
             ClientId = section["ClientId"] ?? string.Empty,
             ClientSecret = section["ClientSecret"],
-            Scope = section["Scope"] ?? BotScope,
+            Cloud = cloud,
+            Scope = section["Scope"] ?? cloud.BotScope,
             MsalConfigurationSection = section,
             SectionName = sectionName
         };
@@ -194,6 +204,9 @@ internal sealed class BotConfig
         _logNoConfigFound(logger, null);
         return new BotConfig { SectionName = sectionName };
     }
+
+    private static CloudEnvironment ResolveCloud(string? cloudName) =>
+        string.IsNullOrWhiteSpace(cloudName) ? CloudEnvironment.Public : CloudEnvironment.FromName(cloudName);
 
     private static readonly Action<ILogger, Exception?> _logUsingBFConfig =
         LoggerMessage.Define(LogLevel.Debug, new(1), "Resolved bot configuration from Bot Framework configuration keys");

--- a/core/src/Microsoft.Teams.Bot.Core/Hosting/BotConfig.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Hosting/BotConfig.cs
@@ -77,7 +77,7 @@ internal sealed class BotConfig
     public static BotConfig FromBFConfig(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
-        var cloud = ResolveCloud(configuration["Cloud"]);
+        var cloud = ResolveCloud(configuration["Cloud"], key => configuration[key]);
         return new()
         {
             TenantId = configuration["MicrosoftAppTenantId"] ?? string.Empty,
@@ -101,7 +101,7 @@ internal sealed class BotConfig
     public static BotConfig FromCoreConfig(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
-        var cloud = ResolveCloud(configuration["CLOUD"] ?? configuration["Cloud"]);
+        var cloud = ResolveCloud(configuration["CLOUD"] ?? configuration["Cloud"], key => configuration[key]);
         return new()
         {
             TenantId = configuration["TENANT_ID"] ?? string.Empty,
@@ -128,7 +128,7 @@ internal sealed class BotConfig
     {
         ArgumentNullException.ThrowIfNull(configuration);
         IConfigurationSection section = configuration.GetSection(sectionName);
-        var cloud = ResolveCloud(section["Cloud"] ?? configuration["Cloud"]);
+        var cloud = ResolveCloud(section["Cloud"] ?? configuration["Cloud"], key => section[key] ?? configuration[key]);
         return new()
         {
             TenantId = section["TenantId"] ?? string.Empty,
@@ -205,8 +205,26 @@ internal sealed class BotConfig
         return new BotConfig { SectionName = sectionName };
     }
 
-    private static CloudEnvironment ResolveCloud(string? cloudName) =>
-        string.IsNullOrWhiteSpace(cloudName) ? CloudEnvironment.Public : CloudEnvironment.FromName(cloudName);
+    /// <summary>
+    /// Resolves a base cloud from <paramref name="cloudName"/> (or Public if unset) and applies any
+    /// per-endpoint overrides read via <paramref name="readOverride"/>.
+    /// Override keys: LoginEndpoint, LoginTenant, BotScope, TokenServiceUrl, OpenIdMetadataUrl, TokenIssuer, GraphScope.
+    /// </summary>
+    private static CloudEnvironment ResolveCloud(string? cloudName, Func<string, string?> readOverride)
+    {
+        var baseCloud = string.IsNullOrWhiteSpace(cloudName)
+            ? CloudEnvironment.Public
+            : CloudEnvironment.FromName(cloudName);
+
+        return baseCloud.WithOverrides(
+            loginEndpoint: readOverride("LoginEndpoint"),
+            loginTenant: readOverride("LoginTenant"),
+            botScope: readOverride("BotScope"),
+            tokenServiceUrl: readOverride("TokenServiceUrl"),
+            openIdMetadataUrl: readOverride("OpenIdMetadataUrl"),
+            tokenIssuer: readOverride("TokenIssuer"),
+            graphScope: readOverride("GraphScope"));
+    }
 
     private static readonly Action<ILogger, Exception?> _logUsingBFConfig =
         LoggerMessage.Define(LogLevel.Debug, new(1), "Resolved bot configuration from Bot Framework configuration keys");

--- a/core/src/Microsoft.Teams.Bot.Core/Hosting/CloudEnvironment.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Hosting/CloudEnvironment.cs
@@ -127,8 +127,9 @@ public class CloudEnvironment
     );
 
     /// <summary>
-    /// Creates a new <see cref="CloudEnvironment"/> by applying non-null overrides on top of this instance.
-    /// Returns the same instance if all overrides are null (no allocation).
+    /// Creates a new <see cref="CloudEnvironment"/> by applying non-null, non-whitespace overrides on top of this instance.
+    /// Returns the same instance if all overrides are effectively unset (no allocation).
+    /// Blank/whitespace inputs are treated as unset so empty config values don't override valid defaults.
     /// </summary>
     public CloudEnvironment WithOverrides(
         string? loginEndpoint = null,
@@ -139,6 +140,14 @@ public class CloudEnvironment
         string? tokenIssuer = null,
         string? graphScope = null)
     {
+        loginEndpoint = NullIfWhiteSpace(loginEndpoint);
+        loginTenant = NullIfWhiteSpace(loginTenant);
+        botScope = NullIfWhiteSpace(botScope);
+        tokenServiceUrl = NullIfWhiteSpace(tokenServiceUrl);
+        openIdMetadataUrl = NullIfWhiteSpace(openIdMetadataUrl);
+        tokenIssuer = NullIfWhiteSpace(tokenIssuer);
+        graphScope = NullIfWhiteSpace(graphScope);
+
         if (loginEndpoint is null && loginTenant is null && botScope is null &&
             tokenServiceUrl is null && openIdMetadataUrl is null && tokenIssuer is null &&
             graphScope is null)
@@ -156,6 +165,9 @@ public class CloudEnvironment
             graphScope ?? GraphScope
         );
     }
+
+    private static string? NullIfWhiteSpace(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
 
     /// <summary>
     /// Resolves a cloud environment name (case-insensitive) to its corresponding instance.

--- a/core/src/Microsoft.Teams.Bot.Core/Hosting/CloudEnvironment.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Hosting/CloudEnvironment.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Teams.Bot.Core.Hosting;
+
+/// <summary>
+/// Bundles all cloud-specific service endpoints for a given Azure environment.
+/// Use predefined instances (<see cref="Public"/>, <see cref="USGov"/>, <see cref="USGovDoD"/>, <see cref="China"/>)
+/// or construct a custom one.
+/// </summary>
+[SuppressMessage("Design", "CA1054:URI-like parameters should not be strings",
+    Justification = "Endpoints are stored and compared as strings to stay compatible with existing config binding and Libraries/CloudEnvironment.")]
+[SuppressMessage("Design", "CA1056:URI-like properties should not be strings",
+    Justification = "Endpoints are stored and compared as strings to stay compatible with existing config binding and Libraries/CloudEnvironment.")]
+public class CloudEnvironment
+{
+    /// <summary>
+    /// The Azure AD login endpoint (e.g. "https://login.microsoftonline.com").
+    /// </summary>
+    public string LoginEndpoint { get; }
+
+    /// <summary>
+    /// The default multi-tenant login tenant (e.g. "botframework.com").
+    /// </summary>
+    public string LoginTenant { get; }
+
+    /// <summary>
+    /// The Bot Framework OAuth scope (e.g. "https://api.botframework.com/.default").
+    /// </summary>
+    public string BotScope { get; }
+
+    /// <summary>
+    /// The Bot Framework token service base URL (e.g. "https://token.botframework.com").
+    /// </summary>
+    public string TokenServiceUrl { get; }
+
+    /// <summary>
+    /// The OpenID metadata URL for token validation.
+    /// </summary>
+    public string OpenIdMetadataUrl { get; }
+
+    /// <summary>
+    /// The token issuer for Bot Framework tokens (e.g. "https://api.botframework.com").
+    /// </summary>
+    public string TokenIssuer { get; }
+
+    /// <summary>
+    /// The Microsoft Graph token scope (e.g. "https://graph.microsoft.com/.default").
+    /// </summary>
+    public string GraphScope { get; }
+
+    /// <summary>
+    /// Creates a <see cref="CloudEnvironment"/> with the given per-cloud endpoints.
+    /// Prefer the predefined presets (<see cref="Public"/>, <see cref="USGov"/>, <see cref="USGovDoD"/>, <see cref="China"/>)
+    /// unless you need custom values.
+    /// </summary>
+    public CloudEnvironment(
+        string loginEndpoint,
+        string loginTenant,
+        string botScope,
+        string tokenServiceUrl,
+        string openIdMetadataUrl,
+        string tokenIssuer,
+        string graphScope)
+    {
+        ArgumentNullException.ThrowIfNull(loginEndpoint);
+        ArgumentNullException.ThrowIfNull(loginTenant);
+        ArgumentNullException.ThrowIfNull(botScope);
+        ArgumentNullException.ThrowIfNull(tokenServiceUrl);
+        ArgumentNullException.ThrowIfNull(openIdMetadataUrl);
+        ArgumentNullException.ThrowIfNull(tokenIssuer);
+        ArgumentNullException.ThrowIfNull(graphScope);
+
+        LoginEndpoint = loginEndpoint.TrimEnd('/');
+        LoginTenant = loginTenant;
+        BotScope = botScope;
+        TokenServiceUrl = tokenServiceUrl.TrimEnd('/');
+        OpenIdMetadataUrl = openIdMetadataUrl;
+        TokenIssuer = tokenIssuer;
+        GraphScope = graphScope;
+    }
+
+    /// <summary>Microsoft public (commercial) cloud.</summary>
+    public static readonly CloudEnvironment Public = new(
+        loginEndpoint: "https://login.microsoftonline.com",
+        loginTenant: "botframework.com",
+        botScope: "https://api.botframework.com/.default",
+        tokenServiceUrl: "https://token.botframework.com",
+        openIdMetadataUrl: "https://login.botframework.com/v1/.well-known/openidconfiguration",
+        tokenIssuer: "https://api.botframework.com",
+        graphScope: "https://graph.microsoft.com/.default"
+    );
+
+    /// <summary>US Government Community Cloud High (GCCH).</summary>
+    public static readonly CloudEnvironment USGov = new(
+        loginEndpoint: "https://login.microsoftonline.us",
+        loginTenant: "MicrosoftServices.onmicrosoft.us",
+        botScope: "https://api.botframework.us/.default",
+        tokenServiceUrl: "https://tokengcch.botframework.azure.us",
+        openIdMetadataUrl: "https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
+        tokenIssuer: "https://api.botframework.us",
+        graphScope: "https://graph.microsoft.us/.default"
+    );
+
+    /// <summary>US Government Department of Defense (DoD).</summary>
+    public static readonly CloudEnvironment USGovDoD = new(
+        loginEndpoint: "https://login.microsoftonline.us",
+        loginTenant: "MicrosoftServices.onmicrosoft.us",
+        botScope: "https://api.botframework.us/.default",
+        tokenServiceUrl: "https://apiDoD.botframework.azure.us",
+        openIdMetadataUrl: "https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
+        tokenIssuer: "https://api.botframework.us",
+        graphScope: "https://dod-graph.microsoft.us/.default"
+    );
+
+    /// <summary>China cloud (21Vianet).</summary>
+    public static readonly CloudEnvironment China = new(
+        loginEndpoint: "https://login.partner.microsoftonline.cn",
+        loginTenant: "microsoftservices.partner.onmschina.cn",
+        botScope: "https://api.botframework.azure.cn/.default",
+        tokenServiceUrl: "https://token.botframework.azure.cn",
+        openIdMetadataUrl: "https://login.botframework.azure.cn/v1/.well-known/openidconfiguration",
+        tokenIssuer: "https://api.botframework.azure.cn",
+        graphScope: "https://microsoftgraph.chinacloudapi.cn/.default"
+    );
+
+    /// <summary>
+    /// Creates a new <see cref="CloudEnvironment"/> by applying non-null overrides on top of this instance.
+    /// Returns the same instance if all overrides are null (no allocation).
+    /// </summary>
+    public CloudEnvironment WithOverrides(
+        string? loginEndpoint = null,
+        string? loginTenant = null,
+        string? botScope = null,
+        string? tokenServiceUrl = null,
+        string? openIdMetadataUrl = null,
+        string? tokenIssuer = null,
+        string? graphScope = null)
+    {
+        if (loginEndpoint is null && loginTenant is null && botScope is null &&
+            tokenServiceUrl is null && openIdMetadataUrl is null && tokenIssuer is null &&
+            graphScope is null)
+        {
+            return this;
+        }
+
+        return new CloudEnvironment(
+            loginEndpoint ?? LoginEndpoint,
+            loginTenant ?? LoginTenant,
+            botScope ?? BotScope,
+            tokenServiceUrl ?? TokenServiceUrl,
+            openIdMetadataUrl ?? OpenIdMetadataUrl,
+            tokenIssuer ?? TokenIssuer,
+            graphScope ?? GraphScope
+        );
+    }
+
+    /// <summary>
+    /// Resolves a cloud environment name (case-insensitive) to its corresponding instance.
+    /// Valid names: "Public", "USGov", "USGovDoD", "China".
+    /// </summary>
+    public static CloudEnvironment FromName(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Cloud environment name cannot be empty or whitespace.", nameof(name));
+        }
+
+        return name.ToUpperInvariant() switch
+        {
+            "PUBLIC" => Public,
+            "USGOV" => USGov,
+            "USGOVDOD" => USGovDoD,
+            "CHINA" => China,
+            _ => throw new ArgumentException($"Unknown cloud environment: '{name}'. Valid values are: Public, USGov, USGovDoD, China.", nameof(name))
+        };
+    }
+}

--- a/core/src/Microsoft.Teams.Bot.Core/Hosting/JwtExtensions.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Hosting/JwtExtensions.cs
@@ -24,9 +24,6 @@ namespace Microsoft.Teams.Bot.Core.Hosting
     /// </summary>
     public static class JwtExtensions
     {
-        internal const string BotOIDC = "https://login.botframework.com/v1/.well-known/openid-configuration";
-        internal const string EntraOIDC = "https://login.microsoftonline.com/";
-
         /// <summary>
         /// Adds JWT authentication for bots and agents using configuration from appsettings.
         /// </summary>
@@ -37,7 +34,7 @@ namespace Microsoft.Teams.Bot.Core.Hosting
         public static AuthenticationBuilder AddBotAuthentication(this IServiceCollection services, string aadSectionName = "AzureAd", ILogger? logger = null)
         {
             BotConfig botConfig = ResolveBotConfig(services, aadSectionName);
-            return services.AddBotAuthentication(botConfig.ClientId, botConfig.TenantId, aadSectionName, logger);
+            return services.AddBotAuthentication(botConfig.ClientId, botConfig.TenantId, aadSectionName, logger, botConfig.Cloud);
         }
 
         /// <summary>
@@ -48,16 +45,18 @@ namespace Microsoft.Teams.Bot.Core.Hosting
         /// <param name="tenantId">The Azure AD tenant ID. Can be empty for multi-tenant scenarios.</param>
         /// <param name="schemeName">The authentication scheme name. Defaults to "AzureAd".</param>
         /// <param name="logger">Optional logger instance for logging. If null, a NullLogger will be used.</param>
+        /// <param name="cloud">The cloud environment for sovereign cloud support. Defaults to <see cref="CloudEnvironment.Public"/>.</param>
         /// <returns>An <see cref="AuthenticationBuilder"/> for further authentication configuration.</returns>
         public static AuthenticationBuilder AddBotAuthentication(
             this IServiceCollection services,
             string clientId,
             string tenantId = "",
             string schemeName = "AzureAd",
-            ILogger? logger = null)
+            ILogger? logger = null,
+            CloudEnvironment? cloud = null)
         {
             AuthenticationBuilder builder = services.AddAuthentication();
-            builder.AddBotAuthentication(clientId, tenantId, schemeName, logger);
+            builder.AddBotAuthentication(clientId, tenantId, schemeName, logger, cloud);
             return builder;
         }
 
@@ -70,13 +69,15 @@ namespace Microsoft.Teams.Bot.Core.Hosting
         /// <param name="tenantId">The Azure AD tenant ID. Can be empty for multi-tenant scenarios.</param>
         /// <param name="schemeName">The authentication scheme name.</param>
         /// <param name="logger">Optional logger instance for logging. If null, a NullLogger will be used.</param>
+        /// <param name="cloud">The cloud environment for sovereign cloud support. Defaults to <see cref="CloudEnvironment.Public"/>.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/> for chaining.</returns>
         public static AuthenticationBuilder AddBotAuthentication(
             this AuthenticationBuilder builder,
             string clientId,
             string tenantId = "",
             string schemeName = "AzureAd",
-            ILogger? logger = null)
+            ILogger? logger = null,
+            CloudEnvironment? cloud = null)
         {
             if (string.IsNullOrWhiteSpace(clientId))
             {
@@ -84,7 +85,7 @@ namespace Microsoft.Teams.Bot.Core.Hosting
             }
             else
             {
-                builder.AddTeamsJwtBearer(schemeName, clientId, tenantId, logger);
+                builder.AddTeamsJwtBearer(schemeName, clientId, tenantId, cloud ?? CloudEnvironment.Public, logger);
             }
             return builder;
         }
@@ -115,7 +116,7 @@ namespace Microsoft.Teams.Bot.Core.Hosting
         {
             logger ??= NullLogger.Instance;
 
-            return services.AddBotAuthorization(botConfig.ClientId, botConfig.TenantId, botConfig.SectionName, logger);
+            return services.AddBotAuthorization(botConfig.ClientId, botConfig.TenantId, botConfig.SectionName, logger, botConfig.Cloud);
         }
 
         /// <summary>
@@ -126,15 +127,17 @@ namespace Microsoft.Teams.Bot.Core.Hosting
         /// <param name="tenantId">The Azure AD tenant ID. Can be empty for multi-tenant scenarios.</param>
         /// <param name="schemeName">The authentication scheme name. Defaults to "AzureAd".</param>
         /// <param name="logger">Optional logger instance for logging. If null, a NullLogger will be used.</param>
+        /// <param name="cloud">The cloud environment for sovereign cloud support. Defaults to <see cref="CloudEnvironment.Public"/>.</param>
         /// <returns>An <see cref="AuthorizationBuilder"/> for further authorization configuration.</returns>
         public static AuthorizationBuilder AddBotAuthorization(
             this IServiceCollection services,
             string clientId,
             string tenantId = "",
             string schemeName = "AzureAd",
-            ILogger? logger = null)
+            ILogger? logger = null,
+            CloudEnvironment? cloud = null)
         {
-            services.AddBotAuthentication(clientId, tenantId, schemeName, logger);
+            services.AddBotAuthentication(clientId, tenantId, schemeName, logger, cloud);
 
             return services
                 .AddAuthorizationBuilder()
@@ -145,19 +148,19 @@ namespace Microsoft.Teams.Bot.Core.Hosting
                 });
         }
 
-        private static string ValidateTeamsIssuer(string issuer, SecurityToken token, string configuredTenantId)
+        internal static string ValidateTeamsIssuer(string issuer, SecurityToken token, string configuredTenantId, CloudEnvironment cloud)
         {
             // Bot Framework tokens
-            if (issuer.Equals("https://api.botframework.com", StringComparison.OrdinalIgnoreCase))
+            if (issuer.Equals(cloud.TokenIssuer, StringComparison.OrdinalIgnoreCase))
                 return issuer;
 
-            // Entra tokens � bot-to-bot (agent) and user (tab/API)
+            // Entra tokens - bot-to-bot (agent) and user (tab/API)
             // Use the token's own tid claim for multi-tenant; fall back to configured tenant
             (_, string? tid) = GetTokenClaims(token);
             string? effectiveTenant = string.IsNullOrEmpty(configuredTenantId) ? tid : configuredTenantId;
 
             if (effectiveTenant is not null &&
-                (issuer == $"https://login.microsoftonline.com/{effectiveTenant}/v2.0" ||
+                (issuer == $"{cloud.LoginEndpoint}/{effectiveTenant}/v2.0" ||
                  issuer == $"https://sts.windows.net/{effectiveTenant}/"))
                 return issuer;
 
@@ -176,18 +179,19 @@ namespace Microsoft.Teams.Bot.Core.Hosting
         /// <param name="schemeName">The authentication scheme name.</param>
         /// <param name="audience">The application (client) ID used to validate the audience of tokens.</param>
         /// <param name="tenantId">The Azure AD tenant ID.</param>
+        /// <param name="cloud">The cloud environment providing per-cloud endpoints (issuer, OIDC metadata, login).</param>
         /// <param name="logger">Optional logger for authentication events.</param>
         /// <returns>The authentication builder for chaining.</returns>
         /// <remarks>
         /// This method configures authentication to support both types of tokens:
         /// <list type="bullet">
-        /// <item><description>Bot Framework tokens: Issued by the Bot Connector service when channels send activities to your bot (issuer: https://api.botframework.com).</description></item>
-        /// <item><description>Entra ID tokens: Issued by Azure AD when the bot is registered as an agentic application (issuer: https://login.microsoftonline.com). See https://learn.microsoft.com/en-us/microsoft-agent-365/developer/identity#understanding-agent-identity-components</description></item>
+        /// <item><description>Bot Framework tokens: Issued by the Bot Connector service when channels send activities to your bot. The expected issuer is <see cref="CloudEnvironment.TokenIssuer"/>.</description></item>
+        /// <item><description>Entra ID tokens: Issued by Azure AD when the bot is registered as an agentic application. The expected issuer is derived from <see cref="CloudEnvironment.LoginEndpoint"/>. See https://learn.microsoft.com/en-us/microsoft-agent-365/developer/identity#understanding-agent-identity-components</description></item>
         /// </list>
         /// The signing keys for both token types are dynamically resolved at runtime using OpenID Connect discovery,
         /// allowing the same authentication configuration to validate tokens from multiple issuers.
         /// </remarks>
-        private static AuthenticationBuilder AddTeamsJwtBearer(this AuthenticationBuilder builder, string schemeName, string audience, string tenantId, ILogger? logger = null)
+        private static AuthenticationBuilder AddTeamsJwtBearer(this AuthenticationBuilder builder, string schemeName, string audience, string tenantId, CloudEnvironment cloud, ILogger? logger = null)
         {
             // One ConfigurationManager per OIDC authority, shared safely across all requests.
             ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> configManagerCache = new(StringComparer.OrdinalIgnoreCase);
@@ -203,15 +207,15 @@ namespace Microsoft.Teams.Bot.Core.Hosting
                     ValidateIssuer = true,
                     ValidateAudience = true,
                     ValidAudiences = [audience, $"api://{audience}"],
-                    IssuerValidator = (issuer, token, _) => ValidateTeamsIssuer(issuer, token, tenantId),
+                    IssuerValidator = (issuer, token, _) => ValidateTeamsIssuer(issuer, token, tenantId, cloud),
                     IssuerSigningKeyResolver = (_, securityToken, _, _) =>
                     {
                         (string? iss, string? tid) = GetTokenClaims(securityToken);
                         if (iss is null) return [];
 
-                        string authority = iss.Equals("https://api.botframework.com", StringComparison.OrdinalIgnoreCase)
-                            ? BotOIDC
-                            : $"{EntraOIDC}{tid ?? "botframework.com"}/v2.0/.well-known/openid-configuration";
+                        string authority = iss.Equals(cloud.TokenIssuer, StringComparison.OrdinalIgnoreCase)
+                            ? cloud.OpenIdMetadataUrl
+                            : $"{cloud.LoginEndpoint}/{tid ?? cloud.LoginTenant}/v2.0/.well-known/openid-configuration";
 
                         logger.LogTraceGuarded("Resolving signing keys from OIDC authority '{Authority}' for issuer '{Issuer}'.", authority, iss);
 

--- a/core/src/Microsoft.Teams.Bot.Core/Hosting/MsalConfigurationExtensions.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/Hosting/MsalConfigurationExtensions.cs
@@ -33,7 +33,7 @@ internal static class MsalConfigurationExtensions
         }
         else if (botConfig.MsalConfigurationSection != null)
         {
-            services.ConfigureMSALFromConfig(botConfig.MsalConfigurationSection);
+            services.ConfigureMSALFromConfig(botConfig.MsalConfigurationSection, botConfig.Cloud);
         }
         else
         {
@@ -43,14 +43,54 @@ internal static class MsalConfigurationExtensions
         return true;
     }
 
-    private static IServiceCollection ConfigureMSALFromConfig(this IServiceCollection services, IConfigurationSection msalConfigSection)
+    private static IServiceCollection ConfigureMSALFromConfig(this IServiceCollection services, IConfigurationSection msalConfigSection, CloudEnvironment cloud)
     {
         ArgumentNullException.ThrowIfNull(msalConfigSection);
+
+        string? sectionInstance = msalConfigSection["Instance"];
+        string? sectionAuthority = msalConfigSection["Authority"];
+        ValidateSectionMatchesCloud(msalConfigSection.Path, sectionInstance, sectionAuthority, cloud);
+
         services.Configure<MicrosoftIdentityApplicationOptions>(MsalConfigKey, msalConfigSection);
+
+        // Fall back to Cloud's login endpoint when the section didn't set Instance or Authority.
+        // Lets `Cloud: "USGov"` alone configure sovereign correctly; honors the section when it's explicit.
+        if (string.IsNullOrWhiteSpace(sectionInstance) && string.IsNullOrWhiteSpace(sectionAuthority))
+        {
+            services.Configure<MicrosoftIdentityApplicationOptions>(MsalConfigKey, options =>
+            {
+                options.Instance = cloud.LoginEndpoint + "/";
+            });
+        }
         return services;
     }
 
-    private static IServiceCollection ConfigureMSALWithSecret(this IServiceCollection services, string tenantId, string clientId, string clientSecret)
+    private static void ValidateSectionMatchesCloud(string sectionPath, string? sectionInstance, string? sectionAuthority, CloudEnvironment cloud)
+    {
+        string expected = NormalizeEndpoint(cloud.LoginEndpoint);
+
+        if (!string.IsNullOrWhiteSpace(sectionInstance) &&
+            !NormalizeEndpoint(sectionInstance).Equals(expected, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"MSAL configuration conflict: '{sectionPath}:Instance' is '{sectionInstance}' " +
+                $"but Cloud resolves login endpoint to '{cloud.LoginEndpoint}'. " +
+                $"Either remove Instance from the MSAL section (Cloud will set it) or change Cloud to match.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(sectionAuthority) &&
+            !NormalizeEndpoint(sectionAuthority).StartsWith(expected, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"MSAL configuration conflict: '{sectionPath}:Authority' is '{sectionAuthority}' " +
+                $"but Cloud resolves login endpoint to '{cloud.LoginEndpoint}'. " +
+                $"Either remove Authority from the MSAL section (Cloud will set Instance) or change Cloud to match.");
+        }
+    }
+
+    private static string NormalizeEndpoint(string value) => value.TrimEnd('/');
+
+    private static IServiceCollection ConfigureMSALWithSecret(this IServiceCollection services, string tenantId, string clientId, string clientSecret, CloudEnvironment cloud)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
         ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
@@ -58,7 +98,7 @@ internal static class MsalConfigurationExtensions
 
         services.Configure<MicrosoftIdentityApplicationOptions>(MsalConfigKey, options =>
         {
-            options.Instance = "https://login.microsoftonline.com/";
+            options.Instance = cloud.LoginEndpoint + "/";
             options.TenantId = tenantId;
             options.ClientId = clientId;
             options.ClientCredentials = [
@@ -72,7 +112,7 @@ internal static class MsalConfigurationExtensions
         return services;
     }
 
-    private static IServiceCollection ConfigureMSALWithFIC(this IServiceCollection services, string tenantId, string clientId, string? ficClientId)
+    private static IServiceCollection ConfigureMSALWithFIC(this IServiceCollection services, string tenantId, string clientId, string? ficClientId, CloudEnvironment cloud)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
         ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
@@ -88,7 +128,7 @@ internal static class MsalConfigurationExtensions
 
         services.Configure<MicrosoftIdentityApplicationOptions>(MsalConfigKey, options =>
         {
-            options.Instance = "https://login.microsoftonline.com/";
+            options.Instance = cloud.LoginEndpoint + "/";
             options.TenantId = tenantId;
             options.ClientId = clientId;
             options.ClientCredentials = [
@@ -98,7 +138,7 @@ internal static class MsalConfigurationExtensions
         return services;
     }
 
-    private static IServiceCollection ConfigureMSALWithUMI(this IServiceCollection services, string tenantId, string clientId, string? managedIdentityClientId = null)
+    private static IServiceCollection ConfigureMSALWithUMI(this IServiceCollection services, string tenantId, string clientId, CloudEnvironment cloud, string? managedIdentityClientId = null)
     {
         ArgumentNullException.ThrowIfNullOrWhiteSpace(tenantId);
         ArgumentNullException.ThrowIfNullOrWhiteSpace(clientId);
@@ -114,7 +154,7 @@ internal static class MsalConfigurationExtensions
 
         services.Configure<MicrosoftIdentityApplicationOptions>(MsalConfigKey, options =>
         {
-            options.Instance = "https://login.microsoftonline.com/";
+            options.Instance = cloud.LoginEndpoint + "/";
             options.TenantId = tenantId;
             options.ClientId = clientId;
         });
@@ -127,18 +167,18 @@ internal static class MsalConfigurationExtensions
         if (!string.IsNullOrEmpty(botConfig.ClientSecret))
         {
             _logUsingClientSecret(logger, null);
-            services.ConfigureMSALWithSecret(botConfig.TenantId, botConfig.ClientId, botConfig.ClientSecret);
+            services.ConfigureMSALWithSecret(botConfig.TenantId, botConfig.ClientId, botConfig.ClientSecret, botConfig.Cloud);
         }
         else if (string.IsNullOrEmpty(botConfig.FicClientId) || botConfig.FicClientId == botConfig.ClientId)
         {
             _logUsingUMI(logger, null);
-            services.ConfigureMSALWithUMI(botConfig.TenantId, botConfig.ClientId, botConfig.FicClientId);
+            services.ConfigureMSALWithUMI(botConfig.TenantId, botConfig.ClientId, botConfig.Cloud, botConfig.FicClientId);
         }
         else
         {
             bool isSystemAssigned = IsSystemAssignedManagedIdentity(botConfig.FicClientId);
             _logUsingFIC(logger, isSystemAssigned ? "System-Assigned" : "User-Assigned", null);
-            services.ConfigureMSALWithFIC(botConfig.TenantId, botConfig.ClientId, botConfig.FicClientId);
+            services.ConfigureMSALWithFIC(botConfig.TenantId, botConfig.ClientId, botConfig.FicClientId, botConfig.Cloud);
         }
         return services;
     }

--- a/core/src/Microsoft.Teams.Bot.Core/UserTokenClient.cs
+++ b/core/src/Microsoft.Teams.Bot.Core/UserTokenClient.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Teams.Bot.Core.Hosting;
 using Microsoft.Teams.Bot.Core.Http;
 using Microsoft.Teams.Bot.Core.Schema;
 
@@ -15,8 +16,10 @@ namespace Microsoft.Teams.Bot.Core;
 /// </summary>
 /// <remarks>
 /// This client provides methods for OAuth token management including retrieving tokens, exchanging tokens,
-/// signing out users, and managing AAD tokens. The client communicates with the Bot Framework Token Service
-/// API endpoint (defaults to https://token.botframework.com but can be configured via UserTokenApiEndpoint).
+/// signing out users, and managing AAD tokens. The token service base URL is resolved (in priority order)
+/// from <c>UserTokenApiEndpoint</c>, from the <c>TokenServiceUrl</c> override (under <c>AzureAd</c> or root),
+/// or from the cloud preset chosen by <c>AzureAd:Cloud</c> / <c>Cloud</c> / <c>CLOUD</c>. Defaults to
+/// <see cref="CloudEnvironment.Public"/>'s token service if nothing is configured.
 /// </remarks>
 /// <param name="httpClient">The HTTP client for making requests to the token service.</param>
 /// <param name="configuration">Configuration containing the UserTokenApiEndpoint setting and other bot configuration.</param>
@@ -25,8 +28,31 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
 {
     internal const string UserTokenHttpClientName = "BotUserTokenClient";
     private readonly BotHttpClient _botHttpClient = new(httpClient, logger);
-    private readonly string _apiEndpoint = configuration["UserTokenApiEndpoint"] ?? "https://token.botframework.com";
+    private readonly string _apiEndpoint = ResolveApiEndpoint(configuration);
     private readonly JsonSerializerOptions _defaultOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    internal static string ResolveApiEndpoint(IConfiguration configuration)
+    {
+        // Explicit override: preserved for backward compatibility.
+        string? explicitEndpoint = configuration["UserTokenApiEndpoint"];
+        if (!string.IsNullOrWhiteSpace(explicitEndpoint))
+        {
+            return explicitEndpoint;
+        }
+
+        string? cloudName = configuration["AzureAd:Cloud"]
+            ?? configuration["Cloud"]
+            ?? configuration["CLOUD"];
+        CloudEnvironment baseCloud = string.IsNullOrWhiteSpace(cloudName)
+            ? CloudEnvironment.Public
+            : CloudEnvironment.FromName(cloudName);
+
+        // Apply per-endpoint override (section-scoped wins over root), matching BotConfig.ResolveCloud.
+        string? tokenServiceUrlOverride = configuration["AzureAd:TokenServiceUrl"]
+            ?? configuration["TokenServiceUrl"];
+
+        return baseCloud.WithOverrides(tokenServiceUrl: tokenServiceUrlOverride).TokenServiceUrl;
+    }
 
     internal AgenticIdentity? AgenticIdentity { get; set; }
 

--- a/core/test/Microsoft.Teams.Bot.Core.UnitTests/Hosting/AddBotApplicationExtensionsTests.cs
+++ b/core/test/Microsoft.Teams.Bot.Core.UnitTests/Hosting/AddBotApplicationExtensionsTests.cs
@@ -323,4 +323,250 @@ public class AddBotApplicationExtensionsTests
         // Assert
         Assert.Equal("core-client-id", GetAppId(serviceProvider));
     }
+
+    // --- MSAL Instance / Authority validation + Cloud fallback ---
+
+    [Fact]
+    public void AddConversationClient_SectionInstanceMatchesCloud_Succeeds()
+    {
+        Dictionary<string, string?> configData = new()
+        {
+            ["AzureAd:ClientId"] = "cid",
+            ["AzureAd:TenantId"] = "tid",
+            ["AzureAd:Cloud"] = "USGov",
+            ["AzureAd:Instance"] = "https://login.microsoftonline.us/"
+        };
+
+        ServiceProvider serviceProvider = BuildServiceProvider(configData);
+
+        AssertMsalOptions(serviceProvider, "cid", "tid", "https://login.microsoftonline.us/");
+    }
+
+    [Fact]
+    public void AddConversationClient_SectionInstanceConflictsWithCloud_Throws()
+    {
+        Dictionary<string, string?> configData = new()
+        {
+            ["AzureAd:ClientId"] = "cid",
+            ["AzureAd:TenantId"] = "tid",
+            ["AzureAd:Cloud"] = "USGov",
+            ["AzureAd:Instance"] = "https://login.microsoftonline.com/"
+        };
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => BuildServiceProvider(configData));
+        Assert.Contains("AzureAd:Instance", ex.Message);
+        Assert.Contains("https://login.microsoftonline.com/", ex.Message);
+        Assert.Contains("https://login.microsoftonline.us", ex.Message);
+    }
+
+    [Fact]
+    public void AddConversationClient_SectionInstanceMissing_FallsBackToCloud()
+    {
+        Dictionary<string, string?> configData = new()
+        {
+            ["AzureAd:ClientId"] = "cid",
+            ["AzureAd:TenantId"] = "tid",
+            ["AzureAd:Cloud"] = "USGov"
+        };
+
+        ServiceProvider serviceProvider = BuildServiceProvider(configData);
+
+        AssertMsalOptions(serviceProvider, "cid", "tid", "https://login.microsoftonline.us/");
+    }
+
+    [Fact]
+    public void AddConversationClient_SectionAuthorityMatchesCloud_Succeeds()
+    {
+        Dictionary<string, string?> configData = new()
+        {
+            ["AzureAd:ClientId"] = "cid",
+            ["AzureAd:TenantId"] = "tid",
+            ["AzureAd:Cloud"] = "USGov",
+            ["AzureAd:Authority"] = "https://login.microsoftonline.us/tid/v2.0"
+        };
+
+        ServiceProvider serviceProvider = BuildServiceProvider(configData);
+
+        MicrosoftIdentityApplicationOptions msalOptions = serviceProvider
+            .GetRequiredService<IOptionsMonitor<MicrosoftIdentityApplicationOptions>>()
+            .Get(MsalConfigurationExtensions.MsalConfigKey);
+        Assert.Equal("cid", msalOptions.ClientId);
+    }
+
+    [Fact]
+    public void AddConversationClient_SectionAuthorityConflictsWithCloud_Throws()
+    {
+        Dictionary<string, string?> configData = new()
+        {
+            ["AzureAd:ClientId"] = "cid",
+            ["AzureAd:TenantId"] = "tid",
+            ["AzureAd:Cloud"] = "USGov",
+            ["AzureAd:Authority"] = "https://login.microsoftonline.com/tid/v2.0"
+        };
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => BuildServiceProvider(configData));
+        Assert.Contains("AzureAd:Authority", ex.Message);
+        Assert.Contains("https://login.microsoftonline.com/tid/v2.0", ex.Message);
+    }
+
+    [Fact]
+    public void AddConversationClient_DefaultCloud_InstanceDefaultsToPublic()
+    {
+        Dictionary<string, string?> configData = new()
+        {
+            ["AzureAd:ClientId"] = "cid",
+            ["AzureAd:TenantId"] = "tid"
+        };
+
+        ServiceProvider serviceProvider = BuildServiceProvider(configData);
+
+        AssertMsalOptions(serviceProvider, "cid", "tid", "https://login.microsoftonline.com/");
+    }
+
+    [Fact]
+    public void AddConversationClient_RawCredentials_ConfiguresCloudAwareInstance()
+    {
+        // Core-config path (no MSAL section) should set MSAL Instance from Cloud.
+        Dictionary<string, string?> configData = new()
+        {
+            ["CLIENT_ID"] = "cid",
+            ["TENANT_ID"] = "tid",
+            ["CLIENT_SECRET"] = "secret",
+            ["CLOUD"] = "USGov"
+        };
+
+        ServiceProvider serviceProvider = BuildServiceProvider(configData);
+
+        AssertMsalOptions(serviceProvider, "cid", "tid", "https://login.microsoftonline.us/");
+    }
+
+    // --- Per-endpoint override binding (BotConfig.ResolveCloud) ---
+
+    [Fact]
+    public void BotConfig_FromMsalConfig_AppliesTokenIssuerOverrideFromSection()
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AzureAd:ClientId"] = "cid",
+                ["AzureAd:Cloud"] = "USGov",
+                ["AzureAd:TokenIssuer"] = "https://custom.issuer"
+            })
+            .Build();
+
+        BotConfig result = BotConfig.FromMsalConfig(config);
+
+        Assert.Equal("https://custom.issuer", result.Cloud.TokenIssuer);
+        Assert.Equal(CloudEnvironment.USGov.LoginEndpoint, result.Cloud.LoginEndpoint);
+    }
+
+    [Fact]
+    public void BotConfig_FromMsalConfig_AppliesMultipleEndpointOverrides()
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AzureAd:ClientId"] = "cid",
+                ["AzureAd:Cloud"] = "USGov",
+                ["AzureAd:TokenIssuer"] = "https://iss",
+                ["AzureAd:TokenServiceUrl"] = "https://tsu",
+                ["AzureAd:GraphScope"] = "https://graph.override/.default"
+            })
+            .Build();
+
+        BotConfig result = BotConfig.FromMsalConfig(config);
+
+        Assert.Equal("https://iss", result.Cloud.TokenIssuer);
+        Assert.Equal("https://tsu", result.Cloud.TokenServiceUrl);
+        Assert.Equal("https://graph.override/.default", result.Cloud.GraphScope);
+    }
+
+    [Fact]
+    public void BotConfig_FromMsalConfig_SectionOverrideWinsOverRoot()
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AzureAd:ClientId"] = "cid",
+                ["AzureAd:Cloud"] = "USGov",
+                ["AzureAd:TokenIssuer"] = "https://section",
+                ["TokenIssuer"] = "https://root"
+            })
+            .Build();
+
+        BotConfig result = BotConfig.FromMsalConfig(config);
+
+        Assert.Equal("https://section", result.Cloud.TokenIssuer);
+    }
+
+    [Fact]
+    public void BotConfig_FromMsalConfig_FallsBackToRootOverride()
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AzureAd:ClientId"] = "cid",
+                ["AzureAd:Cloud"] = "USGov",
+                ["TokenIssuer"] = "https://root"
+            })
+            .Build();
+
+        BotConfig result = BotConfig.FromMsalConfig(config);
+
+        Assert.Equal("https://root", result.Cloud.TokenIssuer);
+    }
+
+    [Fact]
+    public void BotConfig_FromMsalConfig_WhitespaceOverrideIgnored()
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AzureAd:ClientId"] = "cid",
+                ["AzureAd:Cloud"] = "USGov",
+                ["AzureAd:TokenIssuer"] = "   "
+            })
+            .Build();
+
+        BotConfig result = BotConfig.FromMsalConfig(config);
+
+        Assert.Equal(CloudEnvironment.USGov.TokenIssuer, result.Cloud.TokenIssuer);
+    }
+
+    [Fact]
+    public void BotConfig_FromBFConfig_AppliesEndpointOverrides()
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["MicrosoftAppId"] = "cid",
+                ["Cloud"] = "USGov",
+                ["TokenIssuer"] = "https://bf-custom"
+            })
+            .Build();
+
+        BotConfig result = BotConfig.FromBFConfig(config);
+
+        Assert.Equal("https://bf-custom", result.Cloud.TokenIssuer);
+    }
+
+    [Fact]
+    public void BotConfig_FromCoreConfig_AppliesEndpointOverrides()
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["CLIENT_ID"] = "cid",
+                ["CLOUD"] = "China",
+                ["TokenIssuer"] = "https://core-custom"
+            })
+            .Build();
+
+        BotConfig result = BotConfig.FromCoreConfig(config);
+
+        Assert.Equal("https://core-custom", result.Cloud.TokenIssuer);
+        Assert.Equal(CloudEnvironment.China.LoginEndpoint, result.Cloud.LoginEndpoint);
+    }
 }

--- a/core/test/Microsoft.Teams.Bot.Core.UnitTests/Hosting/CloudEnvironmentTests.cs
+++ b/core/test/Microsoft.Teams.Bot.Core.UnitTests/Hosting/CloudEnvironmentTests.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Teams.Bot.Core.Hosting;
+
+namespace Microsoft.Teams.Bot.Core.UnitTests.Hosting;
+
+public class CloudEnvironmentTests
+{
+    [Fact]
+    public void Public_HasCorrectEndpoints()
+    {
+        var env = CloudEnvironment.Public;
+
+        Assert.Equal("https://login.microsoftonline.com", env.LoginEndpoint);
+        Assert.Equal("botframework.com", env.LoginTenant);
+        Assert.Equal("https://api.botframework.com/.default", env.BotScope);
+        Assert.Equal("https://token.botframework.com", env.TokenServiceUrl);
+        Assert.Equal("https://login.botframework.com/v1/.well-known/openidconfiguration", env.OpenIdMetadataUrl);
+        Assert.Equal("https://api.botframework.com", env.TokenIssuer);
+        Assert.Equal("https://graph.microsoft.com/.default", env.GraphScope);
+    }
+
+    [Fact]
+    public void USGov_HasCorrectEndpoints()
+    {
+        var env = CloudEnvironment.USGov;
+
+        Assert.Equal("https://login.microsoftonline.us", env.LoginEndpoint);
+        Assert.Equal("MicrosoftServices.onmicrosoft.us", env.LoginTenant);
+        Assert.Equal("https://api.botframework.us/.default", env.BotScope);
+        Assert.Equal("https://tokengcch.botframework.azure.us", env.TokenServiceUrl);
+        Assert.Equal("https://login.botframework.azure.us/v1/.well-known/openidconfiguration", env.OpenIdMetadataUrl);
+        Assert.Equal("https://api.botframework.us", env.TokenIssuer);
+        Assert.Equal("https://graph.microsoft.us/.default", env.GraphScope);
+    }
+
+    [Fact]
+    public void USGovDoD_HasCorrectEndpoints()
+    {
+        var env = CloudEnvironment.USGovDoD;
+
+        Assert.Equal("https://login.microsoftonline.us", env.LoginEndpoint);
+        Assert.Equal("MicrosoftServices.onmicrosoft.us", env.LoginTenant);
+        Assert.Equal("https://api.botframework.us/.default", env.BotScope);
+        Assert.Equal("https://apiDoD.botframework.azure.us", env.TokenServiceUrl);
+        Assert.Equal("https://api.botframework.us", env.TokenIssuer);
+        Assert.Equal("https://dod-graph.microsoft.us/.default", env.GraphScope);
+    }
+
+    [Fact]
+    public void China_HasCorrectEndpoints()
+    {
+        var env = CloudEnvironment.China;
+
+        Assert.Equal("https://login.partner.microsoftonline.cn", env.LoginEndpoint);
+        Assert.Equal("microsoftservices.partner.onmschina.cn", env.LoginTenant);
+        Assert.Equal("https://api.botframework.azure.cn/.default", env.BotScope);
+        Assert.Equal("https://token.botframework.azure.cn", env.TokenServiceUrl);
+        Assert.Equal("https://api.botframework.azure.cn", env.TokenIssuer);
+        Assert.Equal("https://microsoftgraph.chinacloudapi.cn/.default", env.GraphScope);
+    }
+
+    [Theory]
+    [InlineData("Public", "https://login.microsoftonline.com")]
+    [InlineData("public", "https://login.microsoftonline.com")]
+    [InlineData("PUBLIC", "https://login.microsoftonline.com")]
+    [InlineData("USGov", "https://login.microsoftonline.us")]
+    [InlineData("usgov", "https://login.microsoftonline.us")]
+    [InlineData("USGovDoD", "https://login.microsoftonline.us")]
+    [InlineData("usgovdod", "https://login.microsoftonline.us")]
+    [InlineData("China", "https://login.partner.microsoftonline.cn")]
+    [InlineData("china", "https://login.partner.microsoftonline.cn")]
+    public void FromName_ResolvesCorrectly(string name, string expectedLoginEndpoint)
+    {
+        var env = CloudEnvironment.FromName(name);
+        Assert.Equal(expectedLoginEndpoint, env.LoginEndpoint);
+    }
+
+    [Fact]
+    public void FromName_ReturnsStaticInstances()
+    {
+        Assert.Same(CloudEnvironment.Public, CloudEnvironment.FromName("Public"));
+        Assert.Same(CloudEnvironment.USGov, CloudEnvironment.FromName("USGov"));
+        Assert.Same(CloudEnvironment.USGovDoD, CloudEnvironment.FromName("USGovDoD"));
+        Assert.Same(CloudEnvironment.China, CloudEnvironment.FromName("China"));
+    }
+
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("Azure")]
+    public void FromName_ThrowsForUnknownName(string name)
+    {
+        Assert.Throws<ArgumentException>(() => CloudEnvironment.FromName(name));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FromName_ThrowsForEmptyOrWhitespace(string name)
+    {
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => CloudEnvironment.FromName(name));
+        Assert.Contains("empty or whitespace", ex.Message);
+    }
+
+    [Fact]
+    public void FromName_ThrowsForNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => CloudEnvironment.FromName(null!));
+    }
+
+    [Fact]
+    public void Constructor_TrimsTrailingSlashOnLoginEndpointAndTokenServiceUrl()
+    {
+        var env = new CloudEnvironment(
+            loginEndpoint: "https://example.com/",
+            loginTenant: "tenant",
+            botScope: "scope",
+            tokenServiceUrl: "https://token.example.com/",
+            openIdMetadataUrl: "https://oidc.example.com",
+            tokenIssuer: "issuer",
+            graphScope: "graph");
+
+        Assert.Equal("https://example.com", env.LoginEndpoint);
+        Assert.Equal("https://token.example.com", env.TokenServiceUrl);
+    }
+
+    [Fact]
+    public void WithOverrides_AllNulls_ReturnsSameInstance()
+    {
+        var env = CloudEnvironment.Public;
+
+        var result = env.WithOverrides();
+
+        Assert.Same(env, result);
+    }
+
+    [Fact]
+    public void WithOverrides_SingleOverride_ReplacesOnlyThatProperty()
+    {
+        var env = CloudEnvironment.Public;
+
+        var result = env.WithOverrides(tokenIssuer: "https://custom.issuer");
+
+        Assert.NotSame(env, result);
+        Assert.Equal("https://custom.issuer", result.TokenIssuer);
+        Assert.Equal(env.LoginEndpoint, result.LoginEndpoint);
+        Assert.Equal(env.BotScope, result.BotScope);
+        Assert.Equal(env.TokenServiceUrl, result.TokenServiceUrl);
+        Assert.Equal(env.OpenIdMetadataUrl, result.OpenIdMetadataUrl);
+        Assert.Equal(env.GraphScope, result.GraphScope);
+    }
+
+    [Fact]
+    public void WithOverrides_AllOverrides_ReplacesAllProperties()
+    {
+        var env = CloudEnvironment.Public;
+
+        var result = env.WithOverrides(
+            loginEndpoint: "https://a",
+            loginTenant: "b",
+            botScope: "c",
+            tokenServiceUrl: "https://d",
+            openIdMetadataUrl: "e",
+            tokenIssuer: "f",
+            graphScope: "g");
+
+        Assert.Equal("https://a", result.LoginEndpoint);
+        Assert.Equal("b", result.LoginTenant);
+        Assert.Equal("c", result.BotScope);
+        Assert.Equal("https://d", result.TokenServiceUrl);
+        Assert.Equal("e", result.OpenIdMetadataUrl);
+        Assert.Equal("f", result.TokenIssuer);
+        Assert.Equal("g", result.GraphScope);
+    }
+}

--- a/core/test/Microsoft.Teams.Bot.Core.UnitTests/Hosting/JwtExtensionsTests.cs
+++ b/core/test/Microsoft.Teams.Bot.Core.UnitTests/Hosting/JwtExtensionsTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.Teams.Bot.Core.Hosting;
+
+namespace Microsoft.Teams.Bot.Core.UnitTests.Hosting;
+
+public class JwtExtensionsTests
+{
+    private const string Tenant = "00000000-0000-0000-0000-000000000001";
+
+    private static SecurityToken MakeToken(string? tid = null)
+    {
+        JwtSecurityTokenHandler handler = new();
+        JwtSecurityToken jwt = new(
+            claims: tid is null ? [] : [new Claim("tid", tid)]);
+        return new JsonWebToken(handler.WriteToken(jwt));
+    }
+
+    [Fact]
+    public void ValidateTeamsIssuer_AcceptsBotFrameworkIssuerForPublic()
+    {
+        string result = JwtExtensions.ValidateTeamsIssuer(
+            "https://api.botframework.com",
+            MakeToken(),
+            configuredTenantId: "",
+            CloudEnvironment.Public);
+
+        Assert.Equal("https://api.botframework.com", result);
+    }
+
+    [Fact]
+    public void ValidateTeamsIssuer_AcceptsBotFrameworkIssuerForUSGov()
+    {
+        string result = JwtExtensions.ValidateTeamsIssuer(
+            "https://api.botframework.us",
+            MakeToken(),
+            configuredTenantId: "",
+            CloudEnvironment.USGov);
+
+        Assert.Equal("https://api.botframework.us", result);
+    }
+
+    [Fact]
+    public void ValidateTeamsIssuer_RejectsPublicBotIssuerWhenCloudIsUSGov()
+    {
+        Assert.Throws<SecurityTokenInvalidIssuerException>(() =>
+            JwtExtensions.ValidateTeamsIssuer(
+                "https://api.botframework.com",
+                MakeToken(),
+                configuredTenantId: "",
+                CloudEnvironment.USGov));
+    }
+
+    [Fact]
+    public void ValidateTeamsIssuer_AcceptsEntraV2IssuerForUSGov()
+    {
+        string result = JwtExtensions.ValidateTeamsIssuer(
+            $"https://login.microsoftonline.us/{Tenant}/v2.0",
+            MakeToken(tid: Tenant),
+            configuredTenantId: Tenant,
+            CloudEnvironment.USGov);
+
+        Assert.Equal($"https://login.microsoftonline.us/{Tenant}/v2.0", result);
+    }
+
+    [Fact]
+    public void ValidateTeamsIssuer_RejectsPublicEntraV2IssuerWhenCloudIsUSGov()
+    {
+        Assert.Throws<SecurityTokenInvalidIssuerException>(() =>
+            JwtExtensions.ValidateTeamsIssuer(
+                $"https://login.microsoftonline.com/{Tenant}/v2.0",
+                MakeToken(tid: Tenant),
+                configuredTenantId: Tenant,
+                CloudEnvironment.USGov));
+    }
+
+    [Fact]
+    public void ValidateTeamsIssuer_AcceptsEntraV2IssuerForChina()
+    {
+        string result = JwtExtensions.ValidateTeamsIssuer(
+            $"https://login.partner.microsoftonline.cn/{Tenant}/v2.0",
+            MakeToken(tid: Tenant),
+            configuredTenantId: Tenant,
+            CloudEnvironment.China);
+
+        Assert.Equal($"https://login.partner.microsoftonline.cn/{Tenant}/v2.0", result);
+    }
+
+    [Fact]
+    public void ValidateTeamsIssuer_UsesTokenTidWhenConfiguredTenantEmpty()
+    {
+        string result = JwtExtensions.ValidateTeamsIssuer(
+            $"https://login.microsoftonline.com/{Tenant}/v2.0",
+            MakeToken(tid: Tenant),
+            configuredTenantId: "",
+            CloudEnvironment.Public);
+
+        Assert.Equal($"https://login.microsoftonline.com/{Tenant}/v2.0", result);
+    }
+
+    [Fact]
+    public void ValidateTeamsIssuer_AcceptsStsV1IssuerForPublic()
+    {
+        // v1.0 STS issuer: kept as hardcoded sts.windows.net. This is a known limitation
+        // for sovereign clouds that use a different STS (e.g. China: sts.chinacloudapi.cn).
+        string result = JwtExtensions.ValidateTeamsIssuer(
+            $"https://sts.windows.net/{Tenant}/",
+            MakeToken(tid: Tenant),
+            configuredTenantId: Tenant,
+            CloudEnvironment.Public);
+
+        Assert.Equal($"https://sts.windows.net/{Tenant}/", result);
+    }
+
+    [Fact]
+    public void ValidateTeamsIssuer_RejectsUnknownIssuer()
+    {
+        Assert.Throws<SecurityTokenInvalidIssuerException>(() =>
+            JwtExtensions.ValidateTeamsIssuer(
+                "https://evil.example.com",
+                MakeToken(tid: Tenant),
+                configuredTenantId: Tenant,
+                CloudEnvironment.Public));
+    }
+}

--- a/core/test/Microsoft.Teams.Bot.Core.UnitTests/UserTokenClientTests.cs
+++ b/core/test/Microsoft.Teams.Bot.Core.UnitTests/UserTokenClientTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Teams.Bot.Core;
+
+namespace Microsoft.Teams.Bot.Core.UnitTests;
+
+public class UserTokenClientTests
+{
+    private static IConfiguration Config(Dictionary<string, string?> data) =>
+        new ConfigurationBuilder().AddInMemoryCollection(data).Build();
+
+    [Fact]
+    public void ResolveApiEndpoint_NoConfiguration_DefaultsToPublicTokenService()
+    {
+        Assert.Equal("https://token.botframework.com", UserTokenClient.ResolveApiEndpoint(Config([])));
+    }
+
+    [Fact]
+    public void ResolveApiEndpoint_ExplicitUserTokenApiEndpoint_WinsOverEverything()
+    {
+        IConfiguration config = Config(new()
+        {
+            ["UserTokenApiEndpoint"] = "https://my.explicit.endpoint",
+            ["AzureAd:Cloud"] = "USGov",
+            ["AzureAd:TokenServiceUrl"] = "https://should-be-ignored"
+        });
+
+        Assert.Equal("https://my.explicit.endpoint", UserTokenClient.ResolveApiEndpoint(config));
+    }
+
+    [Theory]
+    [InlineData("USGov", "https://tokengcch.botframework.azure.us")]
+    [InlineData("USGovDoD", "https://apiDoD.botframework.azure.us")]
+    [InlineData("China", "https://token.botframework.azure.cn")]
+    [InlineData("Public", "https://token.botframework.com")]
+    public void ResolveApiEndpoint_CloudPresetAzureAdSection_ResolvesSovereignEndpoint(string cloudName, string expected)
+    {
+        IConfiguration config = Config(new() { ["AzureAd:Cloud"] = cloudName });
+        Assert.Equal(expected, UserTokenClient.ResolveApiEndpoint(config));
+    }
+
+    [Fact]
+    public void ResolveApiEndpoint_RootCloudKey_Works()
+    {
+        Assert.Equal("https://tokengcch.botframework.azure.us",
+            UserTokenClient.ResolveApiEndpoint(Config(new() { ["Cloud"] = "USGov" })));
+    }
+
+    [Fact]
+    public void ResolveApiEndpoint_UppercaseCloudKey_Works()
+    {
+        Assert.Equal("https://token.botframework.azure.cn",
+            UserTokenClient.ResolveApiEndpoint(Config(new() { ["CLOUD"] = "China" })));
+    }
+
+    [Fact]
+    public void ResolveApiEndpoint_SectionTokenServiceUrlOverride_AppliesOnTopOfCloud()
+    {
+        IConfiguration config = Config(new()
+        {
+            ["AzureAd:Cloud"] = "USGov",
+            ["AzureAd:TokenServiceUrl"] = "https://custom.token.service"
+        });
+
+        Assert.Equal("https://custom.token.service", UserTokenClient.ResolveApiEndpoint(config));
+    }
+
+    [Fact]
+    public void ResolveApiEndpoint_RootTokenServiceUrlOverride_AppliesWhenNoCloudSet()
+    {
+        IConfiguration config = Config(new() { ["TokenServiceUrl"] = "https://root-override" });
+
+        Assert.Equal("https://root-override", UserTokenClient.ResolveApiEndpoint(config));
+    }
+
+    [Fact]
+    public void ResolveApiEndpoint_SectionOverrideBeatsRootOverride()
+    {
+        IConfiguration config = Config(new()
+        {
+            ["AzureAd:TokenServiceUrl"] = "https://section",
+            ["TokenServiceUrl"] = "https://root"
+        });
+
+        Assert.Equal("https://section", UserTokenClient.ResolveApiEndpoint(config));
+    }
+
+    [Fact]
+    public void ResolveApiEndpoint_WhitespaceOverrideIgnored_FallsBackToCloud()
+    {
+        IConfiguration config = Config(new()
+        {
+            ["AzureAd:Cloud"] = "USGov",
+            ["AzureAd:TokenServiceUrl"] = "   "
+        });
+
+        Assert.Equal("https://tokengcch.botframework.azure.us", UserTokenClient.ResolveApiEndpoint(config));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveApiEndpoint_EmptyOrWhitespaceCloud_DefaultsToPublic(string cloudValue)
+    {
+        IConfiguration config = Config(new() { ["AzureAd:Cloud"] = cloudValue });
+        Assert.Equal("https://token.botframework.com", UserTokenClient.ResolveApiEndpoint(config));
+    }
+}


### PR DESCRIPTION
## Summary
- Cherry-picks Libraries-layer sovereign cloud changes from #352
- Adds core/ package support: `BotConfig` cloud resolution, MSAL Instance from `CloudEnvironment.LoginEndpoint`, cloud-aware default scope, cloud-aware `UserTokenClient` endpoint

## core/ changes
| File | Change |
|---|---|
| `core/src/.../Hosting/BotConfig.cs` | `Cloud` property, resolved from config key in all 3 formats (BF, Core, AzureAd) |
| `core/src/.../Hosting/BotClientOptions.cs` | `Cloud` property, scope defaults from cloud |
| `core/src/.../Hosting/AddBotApplicationExtensions.cs` | Cloud-aware MSAL `Instance`, resolves cloud from config, threads through all auth methods |
| `core/src/.../UserTokenClient.cs` | Cloud-aware default token service endpoint |

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 42 sovereign cloud tests pass (24 CloudEnv + 9 BotTokenClient + 9 TeamsValidationSettings)

## Depends on
- #352 (Libraries layer changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)