### PR TITLE
Security hardening: token validation and service URL improvements

### DIFF
--- a/Libraries/Microsoft.Teams.Api/Auth/CloudEnvironment.cs
+++ b/Libraries/Microsoft.Teams.Api/Auth/CloudEnvironment.cs
@@ -67,7 +67,7 @@ public class CloudEnvironment
         OpenIdMetadataUrl = openIdMetadataUrl;
         TokenIssuer = tokenIssuer;
         GraphScope = graphScope;
-        AllowedServiceUrls = allowedServiceUrls ?? [];
+        AllowedServiceUrls = allowedServiceUrls is not null ? Array.AsReadOnly(allowedServiceUrls) : [];
     }
 
     /// <summary>

--- a/Libraries/Microsoft.Teams.Api/Auth/CloudEnvironment.cs
+++ b/Libraries/Microsoft.Teams.Api/Auth/CloudEnvironment.cs
@@ -45,6 +45,11 @@ public class CloudEnvironment
     /// </summary>
     public string GraphScope { get; }
 
+    /// <summary>
+    /// Allowed service URL hostnames for this cloud environment.
+    /// </summary>
+    public IReadOnlyList<string> AllowedServiceUrls { get; }
+
     public CloudEnvironment(
         string loginEndpoint,
         string loginTenant,
@@ -52,7 +57,8 @@ public class CloudEnvironment
         string tokenServiceUrl,
         string openIdMetadataUrl,
         string tokenIssuer,
-        string graphScope)
+        string graphScope,
+        string[]? allowedServiceUrls = null)
     {
         LoginEndpoint = loginEndpoint.TrimEnd('/');
         LoginTenant = loginTenant;
@@ -61,6 +67,7 @@ public class CloudEnvironment
         OpenIdMetadataUrl = openIdMetadataUrl;
         TokenIssuer = tokenIssuer;
         GraphScope = graphScope;
+        AllowedServiceUrls = allowedServiceUrls ?? [];
     }
 
     /// <summary>
@@ -73,7 +80,8 @@ public class CloudEnvironment
         tokenServiceUrl: "https://token.botframework.com",
         openIdMetadataUrl: "https://login.botframework.com/v1/.well-known/openidconfiguration",
         tokenIssuer: "https://api.botframework.com",
-        graphScope: "https://graph.microsoft.com/.default"
+        graphScope: "https://graph.microsoft.com/.default",
+        allowedServiceUrls: ["smba.trafficmanager.net", "smba.onyx.prod.teams.trafficmanager.net", "smba.infra.gcc.teams.microsoft.com"]
     );
 
     /// <summary>
@@ -86,7 +94,8 @@ public class CloudEnvironment
         tokenServiceUrl: "https://tokengcch.botframework.azure.us",
         openIdMetadataUrl: "https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
         tokenIssuer: "https://api.botframework.us",
-        graphScope: "https://graph.microsoft.us/.default"
+        graphScope: "https://graph.microsoft.us/.default",
+        allowedServiceUrls: ["smba.infra.gov.teams.microsoft.us"]
     );
 
     /// <summary>
@@ -99,7 +108,8 @@ public class CloudEnvironment
         tokenServiceUrl: "https://apiDoD.botframework.azure.us",
         openIdMetadataUrl: "https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
         tokenIssuer: "https://api.botframework.us",
-        graphScope: "https://dod-graph.microsoft.us/.default"
+        graphScope: "https://dod-graph.microsoft.us/.default",
+        allowedServiceUrls: ["smba.infra.dod.teams.microsoft.us"]
     );
 
     /// <summary>
@@ -112,7 +122,8 @@ public class CloudEnvironment
         tokenServiceUrl: "https://token.botframework.azure.cn",
         openIdMetadataUrl: "https://login.botframework.azure.cn/v1/.well-known/openidconfiguration",
         tokenIssuer: "https://api.botframework.azure.cn",
-        graphScope: "https://microsoftgraph.chinacloudapi.cn/.default"
+        graphScope: "https://microsoftgraph.chinacloudapi.cn/.default",
+        allowedServiceUrls: ["frontend.botapi.msg.infra.teams.microsoftonline.cn"]
     );
 
     /// <summary>
@@ -126,11 +137,12 @@ public class CloudEnvironment
         string? tokenServiceUrl = null,
         string? openIdMetadataUrl = null,
         string? tokenIssuer = null,
-        string? graphScope = null)
+        string? graphScope = null,
+        string[]? allowedServiceUrls = null)
     {
         if (loginEndpoint is null && loginTenant is null && botScope is null &&
             tokenServiceUrl is null && openIdMetadataUrl is null && tokenIssuer is null &&
-            graphScope is null)
+            graphScope is null && allowedServiceUrls is null)
         {
             return this;
         }
@@ -142,7 +154,8 @@ public class CloudEnvironment
             tokenServiceUrl ?? TokenServiceUrl,
             openIdMetadataUrl ?? OpenIdMetadataUrl,
             tokenIssuer ?? TokenIssuer,
-            graphScope ?? GraphScope
+            graphScope ?? GraphScope,
+            allowedServiceUrls ?? [.. AllowedServiceUrls]
         );
     }
 

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -65,6 +65,11 @@ public partial class App
         Provider = options?.Provider;
         _additionalAllowedDomains = options?.AdditionalAllowedDomains;
 
+        if (_additionalAllowedDomains?.Contains("*") == true)
+        {
+            Logger.Warn("Service URL validation is disabled via wildcard in AdditionalAllowedDomains");
+        }
+
         TokenClient = new Common.Http.HttpClient();
         Client = options?.Client ?? options?.ClientFactory?.CreateClient() ?? new Common.Http.HttpClient();
         Client.Options.AddUserAgent(UserAgent);

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -41,7 +41,6 @@ public partial class App
     internal IServiceProvider? Provider { get; set; }
     internal IContainer Container { get; set; }
 
-    private readonly bool _skipServiceUrlValidation;
     private readonly IEnumerable<string>? _additionalAllowedDomains;
     internal string UserAgent
     {
@@ -62,7 +61,6 @@ public partial class App
         Plugins = options?.Plugins ?? [];
         OAuth = options?.OAuth ?? new OAuthSettings();
         Provider = options?.Provider;
-        _skipServiceUrlValidation = options?.SkipServiceUrlValidation ?? false;
         _additionalAllowedDomains = options?.AdditionalAllowedDomains;
 
         TokenClient = new Common.Http.HttpClient();
@@ -388,7 +386,7 @@ public partial class App
         Logger.Debug(path);
 
         var serviceUrl = @event.Activity.ServiceUrl ?? @event.Token.ServiceUrl;
-        if (!_skipServiceUrlValidation && !ServiceUrlValidator.IsAllowed(serviceUrl, _additionalAllowedDomains))
+        if (!ServiceUrlValidator.IsAllowed(serviceUrl, _additionalAllowedDomains))
         {
             throw new InvalidOperationException($"Service URL '{serviceUrl}' is not from an allowed domain");
         }

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -390,7 +390,8 @@ public partial class App
         var serviceUrl = @event.Activity.ServiceUrl ?? @event.Token.ServiceUrl;
         if (!ServiceUrlValidator.IsAllowed(serviceUrl, _cloud, _additionalAllowedDomains))
         {
-            throw new InvalidOperationException($"Service URL '{serviceUrl}' is not from an allowed domain");
+            Logger.Warn($"Rejected service URL: {serviceUrl}");
+            throw new InvalidOperationException("Service URL is not from an allowed domain");
         }
 
         var reference = new ConversationReference()

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -42,6 +42,7 @@ public partial class App
     internal IContainer Container { get; set; }
 
     private readonly IEnumerable<string>? _additionalAllowedDomains;
+    private readonly CloudEnvironment _cloud;
     internal string UserAgent
     {
         get
@@ -54,6 +55,7 @@ public partial class App
     public App(AppOptions? options = null)
     {
         var cloud = options?.Cloud ?? CloudEnvironment.Public;
+        _cloud = cloud;
 
         Logger = options?.Logger ?? new ConsoleLogger();
         Storage = options?.Storage ?? new LocalStorage<object>();
@@ -386,7 +388,7 @@ public partial class App
         Logger.Debug(path);
 
         var serviceUrl = @event.Activity.ServiceUrl ?? @event.Token.ServiceUrl;
-        if (!ServiceUrlValidator.IsAllowed(serviceUrl, _additionalAllowedDomains))
+        if (!ServiceUrlValidator.IsAllowed(serviceUrl, _cloud, _additionalAllowedDomains))
         {
             throw new InvalidOperationException($"Service URL '{serviceUrl}' is not from an allowed domain");
         }

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -40,6 +40,9 @@ public partial class App
     internal IHttpClient TokenClient { get; set; }
     internal IServiceProvider? Provider { get; set; }
     internal IContainer Container { get; set; }
+
+    private readonly bool _skipServiceUrlValidation;
+    private readonly IEnumerable<string>? _additionalAllowedDomains;
     internal string UserAgent
     {
         get
@@ -59,6 +62,8 @@ public partial class App
         Plugins = options?.Plugins ?? [];
         OAuth = options?.OAuth ?? new OAuthSettings();
         Provider = options?.Provider;
+        _skipServiceUrlValidation = options?.SkipServiceUrlValidation ?? false;
+        _additionalAllowedDomains = options?.AdditionalAllowedDomains;
 
         TokenClient = new Common.Http.HttpClient();
         Client = options?.Client ?? options?.ClientFactory?.CreateClient() ?? new Common.Http.HttpClient();
@@ -382,9 +387,15 @@ public partial class App
         var path = @event.Activity.GetPath();
         Logger.Debug(path);
 
+        var serviceUrl = @event.Activity.ServiceUrl ?? @event.Token.ServiceUrl;
+        if (!_skipServiceUrlValidation && !ServiceUrlValidator.IsAllowed(serviceUrl, _additionalAllowedDomains))
+        {
+            throw new InvalidOperationException($"Service URL '{serviceUrl}' is not from an allowed domain");
+        }
+
         var reference = new ConversationReference()
         {
-            ServiceUrl = @event.Activity.ServiceUrl ?? @event.Token.ServiceUrl,
+            ServiceUrl = serviceUrl,
             ChannelId = @event.Activity.ChannelId,
             Bot = @event.Activity.Recipient,
             User = @event.Activity.From,

--- a/Libraries/Microsoft.Teams.Apps/AppOptions.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppOptions.cs
@@ -19,11 +19,6 @@ public class AppOptions
     public CloudEnvironment? Cloud { get; set; }
 
     /// <summary>
-    /// Skip service URL domain validation. Not recommended for production.
-    /// </summary>
-    public bool SkipServiceUrlValidation { get; set; } = false;
-
-    /// <summary>
     /// Additional allowed service URL domain suffixes beyond the built-in defaults.
     /// Use this if your bot receives activities from non-standard channels.
     /// </summary>

--- a/Libraries/Microsoft.Teams.Apps/AppOptions.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppOptions.cs
@@ -18,6 +18,17 @@ public class AppOptions
     public OAuthSettings OAuth { get; set; } = new OAuthSettings();
     public CloudEnvironment? Cloud { get; set; }
 
+    /// <summary>
+    /// Skip service URL domain validation. Not recommended for production.
+    /// </summary>
+    public bool SkipServiceUrlValidation { get; set; } = false;
+
+    /// <summary>
+    /// Additional allowed service URL domain suffixes beyond the built-in defaults.
+    /// Use this if your bot receives activities from non-standard channels.
+    /// </summary>
+    public IEnumerable<string>? AdditionalAllowedDomains { get; set; }
+
     public AppOptions()
     {
 

--- a/Libraries/Microsoft.Teams.Apps/AppOptions.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppOptions.cs
@@ -19,7 +19,7 @@ public class AppOptions
     public CloudEnvironment? Cloud { get; set; }
 
     /// <summary>
-    /// Additional allowed service URL domain suffixes beyond the built-in defaults.
+    /// Additional allowed service URL hostnames beyond the built-in defaults.
     /// Use this if your bot receives activities from non-standard channels.
     /// </summary>
     public IEnumerable<string>? AdditionalAllowedDomains { get; set; }

--- a/Libraries/Microsoft.Teams.Apps/ServiceUrlValidator.cs
+++ b/Libraries/Microsoft.Teams.Apps/ServiceUrlValidator.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Teams.Api.Auth;
+
 namespace Microsoft.Teams.Apps;
 
 /// <summary>
@@ -9,28 +11,12 @@ namespace Microsoft.Teams.Apps;
 public static class ServiceUrlValidator
 {
     /// <summary>
-    /// Default allowed service URL domain suffixes for Bot Framework.
-    /// Covers public, government, sovereign, and regional clouds.
+    /// Validates that a service URL hostname is allowed.
+    /// Checks against the cloud environment's allowed service URLs,
+    /// plus any additional domains provided by the caller.
+    /// Localhost is always allowed for local development.
     /// </summary>
-    private static readonly string[] DefaultAllowedDomains =
-    [
-        // Public cloud
-        ".botframework.com",
-        // US Government
-        ".botframework.azure.us",
-        ".teams.microsoft.com",
-        ".teams.microsoft.us",
-        // China (21Vianet)
-        ".botframework.azure.cn",
-        ".teams.microsoftonline.cn",
-    ];
-
-    /// <summary>
-    /// Validates that a service URL belongs to a known allowed domain.
-    /// Returns true if the URL's hostname ends with one of the allowed domain suffixes,
-    /// or if the hostname is localhost (for local development).
-    /// </summary>
-    public static bool IsAllowed(string serviceUrl, IEnumerable<string>? additionalDomains = null)
+    public static bool IsAllowed(string serviceUrl, CloudEnvironment cloud, IEnumerable<string>? additionalDomains = null)
     {
         if (string.IsNullOrEmpty(serviceUrl))
             return true; // No URL to validate
@@ -43,14 +29,15 @@ public static class ServiceUrlValidator
         if (hostname is "localhost" or "127.0.0.1")
             return true;
 
-        // trafficmanager.net is a shared Azure service; only allow smba-prefixed hostnames
-        if (hostname.EndsWith(".trafficmanager.net") || hostname == "trafficmanager.net")
-            return hostname.StartsWith("smba");
+        var additional = additionalDomains?.ToList() ?? [];
+        if (additional.Contains("*"))
+            return true;
 
-        var allDomains = additionalDomains is not null
-            ? DefaultAllowedDomains.Concat(additionalDomains)
-            : DefaultAllowedDomains;
+        // Check against cloud environment's allowed FQDNs
+        if (cloud.AllowedServiceUrls.Any(allowed => hostname == allowed.ToLowerInvariant()))
+            return true;
 
-        return allDomains.Any(domain => domain == "*" || hostname.EndsWith(domain.ToLowerInvariant()));
+        // Check against additional domains (suffix match)
+        return additional.Any(domain => hostname.EndsWith(domain.ToLowerInvariant()));
     }
 }

--- a/Libraries/Microsoft.Teams.Apps/ServiceUrlValidator.cs
+++ b/Libraries/Microsoft.Teams.Apps/ServiceUrlValidator.cs
@@ -16,7 +16,7 @@ public static class ServiceUrlValidator
     /// plus any additional domains provided by the caller.
     /// Localhost is always allowed for local development.
     /// </summary>
-    public static bool IsAllowed(string serviceUrl, CloudEnvironment cloud, IEnumerable<string>? additionalDomains = null)
+    public static bool IsAllowed(string? serviceUrl, CloudEnvironment cloud, IEnumerable<string>? additionalDomains = null)
     {
         if (string.IsNullOrEmpty(serviceUrl))
             return true; // No URL to validate
@@ -29,15 +29,13 @@ public static class ServiceUrlValidator
         if (hostname is "localhost" or "127.0.0.1")
             return true;
 
-        var additional = additionalDomains?.ToList() ?? [];
-        if (additional.Contains("*"))
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var allowed = cloud.AllowedServiceUrls.Concat(additionalDomains ?? []).Select(d => d.ToLowerInvariant()).ToList();
+        if (allowed.Contains("*"))
             return true;
 
-        // Check against cloud environment's allowed FQDNs
-        if (cloud.AllowedServiceUrls.Any(allowed => hostname == allowed.ToLowerInvariant()))
-            return true;
-
-        // Check against additional domains (suffix match)
-        return additional.Any(domain => hostname.EndsWith(domain.ToLowerInvariant()));
+        return allowed.Contains(hostname);
     }
 }

--- a/Libraries/Microsoft.Teams.Apps/ServiceUrlValidator.cs
+++ b/Libraries/Microsoft.Teams.Apps/ServiceUrlValidator.cs
@@ -16,7 +16,6 @@ public static class ServiceUrlValidator
     [
         // Public cloud
         ".botframework.com",
-        ".trafficmanager.net",
         // US Government
         ".botframework.azure.us",
         ".teams.microsoft.com",
@@ -43,6 +42,10 @@ public static class ServiceUrlValidator
 
         if (hostname is "localhost" or "127.0.0.1")
             return true;
+
+        // trafficmanager.net is a shared Azure service; only allow smba-prefixed hostnames
+        if (hostname.EndsWith(".trafficmanager.net") || hostname == "trafficmanager.net")
+            return hostname.StartsWith("smba");
 
         var allDomains = additionalDomains is not null
             ? DefaultAllowedDomains.Concat(additionalDomains)

--- a/Libraries/Microsoft.Teams.Apps/ServiceUrlValidator.cs
+++ b/Libraries/Microsoft.Teams.Apps/ServiceUrlValidator.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Teams.Apps;
+
+/// <summary>
+/// Validates service URLs against known allowed domains.
+/// </summary>
+public static class ServiceUrlValidator
+{
+    /// <summary>
+    /// Default allowed service URL domain suffixes for Bot Framework.
+    /// Covers public, government, sovereign, and regional clouds.
+    /// </summary>
+    private static readonly string[] DefaultAllowedDomains =
+    [
+        // Public cloud
+        ".botframework.com",
+        ".trafficmanager.net",
+        // US Government
+        ".botframework.azure.us",
+        ".teams.microsoft.com",
+        ".teams.microsoft.us",
+        // China (21Vianet)
+        ".botframework.azure.cn",
+        ".teams.microsoftonline.cn",
+    ];
+
+    /// <summary>
+    /// Validates that a service URL belongs to a known allowed domain.
+    /// Returns true if the URL's hostname ends with one of the allowed domain suffixes,
+    /// or if the hostname is localhost (for local development).
+    /// </summary>
+    public static bool IsAllowed(string serviceUrl, IEnumerable<string>? additionalDomains = null)
+    {
+        if (string.IsNullOrEmpty(serviceUrl))
+            return true; // No URL to validate
+
+        if (!Uri.TryCreate(serviceUrl, UriKind.Absolute, out var uri))
+            return false;
+
+        var hostname = uri.Host.ToLowerInvariant();
+
+        if (hostname is "localhost" or "127.0.0.1")
+            return true;
+
+        var allDomains = additionalDomains is not null
+            ? DefaultAllowedDomains.Concat(additionalDomains)
+            : DefaultAllowedDomains;
+
+        return allDomains.Any(domain => hostname.EndsWith(domain.ToLowerInvariant()));
+    }
+}

--- a/Libraries/Microsoft.Teams.Apps/ServiceUrlValidator.cs
+++ b/Libraries/Microsoft.Teams.Apps/ServiceUrlValidator.cs
@@ -51,6 +51,6 @@ public static class ServiceUrlValidator
             ? DefaultAllowedDomains.Concat(additionalDomains)
             : DefaultAllowedDomains;
 
-        return allDomains.Any(domain => hostname.EndsWith(domain.ToLowerInvariant()));
+        return allDomains.Any(domain => domain == "*" || hostname.EndsWith(domain.ToLowerInvariant()));
     }
 }

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
@@ -11,6 +11,7 @@ public class TeamsSettings
     public string? ClientSecret { get; set; }
     public string? TenantId { get; set; }
     public string? Cloud { get; set; }
+    public string[]? AdditionalAllowedDomains { get; set; }
 
     /// <summary>Override the Azure AD login endpoint.</summary>
     public string? LoginEndpoint { get; set; }
@@ -78,6 +79,11 @@ public class TeamsSettings
         else if (options.Credentials is ClientCredentials existingCredentials)
         {
             existingCredentials.Cloud = cloud;
+        }
+
+        if (AdditionalAllowedDomains is { Length: > 0 })
+        {
+            options.AdditionalAllowedDomains = AdditionalAllowedDomains;
         }
 
         return options;

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore.DevTools/DevToolsPlugin.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore.DevTools/DevToolsPlugin.cs
@@ -92,7 +92,9 @@ public class DevToolsPlugin : IAspNetCorePlugin
     public Task OnInit(App app, CancellationToken cancellationToken = default)
     {
         var hostEnvironment = _services.GetService<IHostEnvironment>();
-        if (hostEnvironment?.IsProduction() == true)
+        var isProduction = hostEnvironment?.IsProduction()
+            ?? string.Equals(Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"), "Production", StringComparison.OrdinalIgnoreCase);
+        if (isProduction)
         {
             throw new InvalidOperationException(
                 "Devtools plugin cannot be used in production environments. " +

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore.DevTools/DevToolsPlugin.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore.DevTools/DevToolsPlugin.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Events;
 using Microsoft.Teams.Apps.Plugins;
@@ -90,6 +91,14 @@ public class DevToolsPlugin : IAspNetCorePlugin
 
     public Task OnInit(App app, CancellationToken cancellationToken = default)
     {
+        var hostEnvironment = _services.GetService<IHostEnvironment>();
+        if (hostEnvironment?.IsProduction() == true)
+        {
+            throw new InvalidOperationException(
+                "Devtools plugin cannot be used in production environments. " +
+                "Remove the devtools plugin from your app configuration.");
+        }
+
         foreach (var page in _settings.Pages)
         {
             AddPage(page);

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/TeamsValidationSettings.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/TeamsValidationSettings.cs
@@ -48,6 +48,14 @@ public class TeamsValidationSettings
         {
             validIssuers.Add($"{LoginEndpoint}/{tenantId}/");
         }
+        else
+        {
+            // When no tenant ID is configured, issuer validation will be skipped.
+            // This accepts tokens from any Azure AD tenant.
+            System.Diagnostics.Trace.TraceWarning(
+                "No tenant ID provided for Entra token validation. " +
+                "Issuer validation will be skipped, accepting tokens from any tenant.");
+        }
         return validIssuers;
     }
 

--- a/Tests/Microsoft.Teams.Apps.Tests/ServiceUrlValidatorTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/ServiceUrlValidatorTests.cs
@@ -36,9 +36,21 @@ public class ServiceUrlValidatorTests
     [InlineData("https://evil.com")]
     [InlineData("https://botframework.com.evil.com")]
     [InlineData("https://attacker.net/api")]
+    [InlineData("https://attacker.trafficmanager.net")]
     public void IsAllowed_RejectsUnknownDomains(string serviceUrl)
     {
         Assert.False(ServiceUrlValidator.IsAllowed(serviceUrl));
+    }
+
+    // --- Trafficmanager narrowing ---
+
+    [Theory]
+    [InlineData("https://smba.trafficmanager.net/teams/")]
+    [InlineData("https://smba.trafficmanager.net/amer/")]
+    [InlineData("https://smba.onyx.prod.teams.trafficmanager.net")]
+    public void IsAllowed_AcceptsSmbaTrafficManager(string serviceUrl)
+    {
+        Assert.True(ServiceUrlValidator.IsAllowed(serviceUrl));
     }
 
     // --- Empty / null ---

--- a/Tests/Microsoft.Teams.Apps.Tests/ServiceUrlValidatorTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/ServiceUrlValidatorTests.cs
@@ -1,22 +1,46 @@
+using Microsoft.Teams.Api.Auth;
+
 namespace Microsoft.Teams.Apps.Tests;
 
 public class ServiceUrlValidatorTests
 {
-    // --- Default allowed domains ---
+    // --- Public cloud ---
 
     [Theory]
     [InlineData("https://smba.trafficmanager.net/teams/")]
     [InlineData("https://smba.trafficmanager.net/amer/")]
-    [InlineData("https://webchat.botframework.com")]
-    [InlineData("https://directline.botframework.com")]
-    [InlineData("https://smba.infra.gcc.teams.microsoft.com/")]
-    [InlineData("https://smba.infra.gov.teams.microsoft.us/gcch/")]
-    [InlineData("https://directline.botframework.azure.us")]
-    [InlineData("https://frontend.botapi.msg.infra.teams.microsoftonline.cn")]
-    [InlineData("https://directline.botframework.azure.cn")]
-    public void IsAllowed_AcceptsKnownBotFrameworkDomains(string serviceUrl)
+    [InlineData("https://smba.onyx.prod.teams.trafficmanager.net")]
+    public void IsAllowed_AcceptsPublicCloudDomains(string serviceUrl)
     {
-        Assert.True(ServiceUrlValidator.IsAllowed(serviceUrl));
+        Assert.True(ServiceUrlValidator.IsAllowed(serviceUrl, CloudEnvironment.Public));
+    }
+
+    // --- Government clouds ---
+
+    [Fact]
+    public void IsAllowed_AcceptsUSGovDomain()
+    {
+        Assert.True(ServiceUrlValidator.IsAllowed("https://smba.infra.gov.teams.microsoft.us/gcch/", CloudEnvironment.USGov));
+    }
+
+    [Fact]
+    public void IsAllowed_AcceptsDoDDomain()
+    {
+        Assert.True(ServiceUrlValidator.IsAllowed("https://smba.infra.dod.teams.microsoft.us/", CloudEnvironment.USGovDoD));
+    }
+
+    [Fact]
+    public void IsAllowed_AcceptsChinaDomain()
+    {
+        Assert.True(ServiceUrlValidator.IsAllowed("https://frontend.botapi.msg.infra.teams.microsoftonline.cn", CloudEnvironment.China));
+    }
+
+    // --- Cross-cloud rejection ---
+
+    [Fact]
+    public void IsAllowed_RejectsGovDomainWithPublicCloud()
+    {
+        Assert.False(ServiceUrlValidator.IsAllowed("https://smba.infra.gov.teams.microsoft.us/", CloudEnvironment.Public));
     }
 
     // --- Localhost ---
@@ -27,7 +51,7 @@ public class ServiceUrlValidatorTests
     [InlineData("http://127.0.0.1:3978")]
     public void IsAllowed_AcceptsLocalhost(string serviceUrl)
     {
-        Assert.True(ServiceUrlValidator.IsAllowed(serviceUrl));
+        Assert.True(ServiceUrlValidator.IsAllowed(serviceUrl, CloudEnvironment.Public));
     }
 
     // --- Rejected domains ---
@@ -39,18 +63,7 @@ public class ServiceUrlValidatorTests
     [InlineData("https://attacker.trafficmanager.net")]
     public void IsAllowed_RejectsUnknownDomains(string serviceUrl)
     {
-        Assert.False(ServiceUrlValidator.IsAllowed(serviceUrl));
-    }
-
-    // --- Trafficmanager narrowing ---
-
-    [Theory]
-    [InlineData("https://smba.trafficmanager.net/teams/")]
-    [InlineData("https://smba.trafficmanager.net/amer/")]
-    [InlineData("https://smba.onyx.prod.teams.trafficmanager.net")]
-    public void IsAllowed_AcceptsSmbaTrafficManager(string serviceUrl)
-    {
-        Assert.True(ServiceUrlValidator.IsAllowed(serviceUrl));
+        Assert.False(ServiceUrlValidator.IsAllowed(serviceUrl, CloudEnvironment.Public));
     }
 
     // --- Empty / null ---
@@ -60,7 +73,7 @@ public class ServiceUrlValidatorTests
     [InlineData(null)]
     public void IsAllowed_AcceptsEmptyOrNull(string? serviceUrl)
     {
-        Assert.True(ServiceUrlValidator.IsAllowed(serviceUrl!));
+        Assert.True(ServiceUrlValidator.IsAllowed(serviceUrl!, CloudEnvironment.Public));
     }
 
     // --- Invalid URLs ---
@@ -68,7 +81,7 @@ public class ServiceUrlValidatorTests
     [Fact]
     public void IsAllowed_RejectsInvalidUrl()
     {
-        Assert.False(ServiceUrlValidator.IsAllowed("not-a-url"));
+        Assert.False(ServiceUrlValidator.IsAllowed("not-a-url", CloudEnvironment.Public));
     }
 
     // --- Additional domains ---
@@ -77,13 +90,32 @@ public class ServiceUrlValidatorTests
     public void IsAllowed_AcceptsAdditionalDomains()
     {
         var additional = new[] { ".custom-channel.com" };
-        Assert.True(ServiceUrlValidator.IsAllowed("https://api.custom-channel.com", additional));
+        Assert.True(ServiceUrlValidator.IsAllowed("https://api.custom-channel.com", CloudEnvironment.Public, additional));
     }
 
     [Fact]
     public void IsAllowed_RejectsWhenNotInAdditionalDomains()
     {
         var additional = new[] { ".custom-channel.com" };
-        Assert.False(ServiceUrlValidator.IsAllowed("https://evil.com", additional));
+        Assert.False(ServiceUrlValidator.IsAllowed("https://evil.com", CloudEnvironment.Public, additional));
+    }
+
+    // --- Wildcard ---
+
+    [Fact]
+    public void IsAllowed_AcceptsAnyDomainWithWildcard()
+    {
+        var additional = new[] { "*" };
+        Assert.True(ServiceUrlValidator.IsAllowed("https://anything.example.com", CloudEnvironment.Public, additional));
+    }
+
+    // --- botframework.com not in default ---
+
+    [Theory]
+    [InlineData("https://webchat.botframework.com")]
+    [InlineData("https://directline.botframework.com")]
+    public void IsAllowed_RejectsBotframeworkByDefault(string serviceUrl)
+    {
+        Assert.False(ServiceUrlValidator.IsAllowed(serviceUrl, CloudEnvironment.Public));
     }
 }

--- a/Tests/Microsoft.Teams.Apps.Tests/ServiceUrlValidatorTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/ServiceUrlValidatorTests.cs
@@ -89,14 +89,14 @@ public class ServiceUrlValidatorTests
     [Fact]
     public void IsAllowed_AcceptsAdditionalDomains()
     {
-        var additional = new[] { ".custom-channel.com" };
+        var additional = new[] { "api.custom-channel.com" };
         Assert.True(ServiceUrlValidator.IsAllowed("https://api.custom-channel.com", CloudEnvironment.Public, additional));
     }
 
     [Fact]
     public void IsAllowed_RejectsWhenNotInAdditionalDomains()
     {
-        var additional = new[] { ".custom-channel.com" };
+        var additional = new[] { "api.custom-channel.com" };
         Assert.False(ServiceUrlValidator.IsAllowed("https://evil.com", CloudEnvironment.Public, additional));
     }
 

--- a/Tests/Microsoft.Teams.Apps.Tests/ServiceUrlValidatorTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/ServiceUrlValidatorTests.cs
@@ -1,0 +1,77 @@
+namespace Microsoft.Teams.Apps.Tests;
+
+public class ServiceUrlValidatorTests
+{
+    // --- Default allowed domains ---
+
+    [Theory]
+    [InlineData("https://smba.trafficmanager.net/teams/")]
+    [InlineData("https://smba.trafficmanager.net/amer/")]
+    [InlineData("https://webchat.botframework.com")]
+    [InlineData("https://directline.botframework.com")]
+    [InlineData("https://smba.infra.gcc.teams.microsoft.com/")]
+    [InlineData("https://smba.infra.gov.teams.microsoft.us/gcch/")]
+    [InlineData("https://directline.botframework.azure.us")]
+    [InlineData("https://frontend.botapi.msg.infra.teams.microsoftonline.cn")]
+    [InlineData("https://directline.botframework.azure.cn")]
+    public void IsAllowed_AcceptsKnownBotFrameworkDomains(string serviceUrl)
+    {
+        Assert.True(ServiceUrlValidator.IsAllowed(serviceUrl));
+    }
+
+    // --- Localhost ---
+
+    [Theory]
+    [InlineData("http://localhost:3978")]
+    [InlineData("https://localhost:443")]
+    [InlineData("http://127.0.0.1:3978")]
+    public void IsAllowed_AcceptsLocalhost(string serviceUrl)
+    {
+        Assert.True(ServiceUrlValidator.IsAllowed(serviceUrl));
+    }
+
+    // --- Rejected domains ---
+
+    [Theory]
+    [InlineData("https://evil.com")]
+    [InlineData("https://botframework.com.evil.com")]
+    [InlineData("https://attacker.net/api")]
+    public void IsAllowed_RejectsUnknownDomains(string serviceUrl)
+    {
+        Assert.False(ServiceUrlValidator.IsAllowed(serviceUrl));
+    }
+
+    // --- Empty / null ---
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void IsAllowed_AcceptsEmptyOrNull(string? serviceUrl)
+    {
+        Assert.True(ServiceUrlValidator.IsAllowed(serviceUrl!));
+    }
+
+    // --- Invalid URLs ---
+
+    [Fact]
+    public void IsAllowed_RejectsInvalidUrl()
+    {
+        Assert.False(ServiceUrlValidator.IsAllowed("not-a-url"));
+    }
+
+    // --- Additional domains ---
+
+    [Fact]
+    public void IsAllowed_AcceptsAdditionalDomains()
+    {
+        var additional = new[] { ".custom-channel.com" };
+        Assert.True(ServiceUrlValidator.IsAllowed("https://api.custom-channel.com", additional));
+    }
+
+    [Fact]
+    public void IsAllowed_RejectsWhenNotInAdditionalDomains()
+    {
+        var additional = new[] { ".custom-channel.com" };
+        Assert.False(ServiceUrlValidator.IsAllowed("https://evil.com", additional));
+    }
+}


### PR DESCRIPTION
## Summary

Security hardening for token validation, service URL handling, and development tooling.

- **Service URL validation**: Validate inbound `ServiceUrl` against allowed hostnames from the configured `CloudEnvironment` preset. Configurable via `AdditionalAllowedDomains` on `AppOptions` (also settable in `appsettings.json`).
- **Issuer validation**: Log a warning when Entra token validation is configured without a tenant ID, making the silent issuer validation skip visible.
- **DevTools**: Prevent the DevTools plugin from starting in production environments.

## Test plan

- Unit tests for `ServiceUrlValidator` (cloud preset FQDNs, rejected domains, localhost, empty/null, invalid URLs, additional domains, wildcard, cross-cloud rejection, botframework.com rejected by default)
- E2E validated in Teams -- no regressions
- E2E validated DevTools blocked on `ASPNETCORE_ENVIRONMENT=Production`