### PR TITLE
Add proactive threading support

### DIFF
--- a/Libraries/Microsoft.Teams.Api/Conversation.cs
+++ b/Libraries/Microsoft.Teams.Api/Conversation.cs
@@ -64,6 +64,31 @@ public class Conversation
         }
     }
 
+    /// <summary>
+    /// Construct a threaded conversation ID by appending <c>;messageid={messageId}</c>
+    /// to the conversation ID. This is the format APX uses to route messages
+    /// to a specific thread in a channel.
+    /// </summary>
+    /// <param name="conversationId">the conversation to thread into (e.g. <c>19:abc@thread.skype</c>)</param>
+    /// <param name="messageId">the thread root message ID (must be a non-zero numeric string)</param>
+    /// <returns>the threaded conversation ID (e.g. <c>19:abc@thread.skype;messageid=123</c>)</returns>
+    public static string ToThreadId(string conversationId, string messageId)
+    {
+        if (string.IsNullOrEmpty(conversationId))
+        {
+            throw new ArgumentException("conversationId must be a non-empty string", nameof(conversationId));
+        }
+
+        if (string.IsNullOrEmpty(messageId) || !ulong.TryParse(messageId, out var parsed) || parsed == 0)
+        {
+            throw new ArgumentException($"Invalid messageId \"{messageId}\": must be a non-zero numeric value", nameof(messageId));
+        }
+
+        // Strip any existing ;messageid= suffix (mirrors APX's NormalizeConversationId)
+        var baseId = conversationId.Split(';')[0];
+        return $"{baseId};messageid={messageId}";
+    }
+
     public object Clone() => MemberwiseClone();
     public Conversation Copy() => (Conversation)Clone();
 }

--- a/Libraries/Microsoft.Teams.Api/Conversation.cs
+++ b/Libraries/Microsoft.Teams.Api/Conversation.cs
@@ -72,7 +72,7 @@ public class Conversation
     /// <param name="conversationId">the conversation to thread into (e.g. <c>19:abc@thread.skype</c>)</param>
     /// <param name="messageId">the thread root message ID (must be a non-zero numeric string)</param>
     /// <returns>the threaded conversation ID (e.g. <c>19:abc@thread.skype;messageid=123</c>)</returns>
-    public static string ToThreadId(string conversationId, string messageId)
+    public static string ToThreadedConversationId(string conversationId, string messageId)
     {
         if (string.IsNullOrEmpty(conversationId))
         {

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -176,7 +176,7 @@ public partial class App
     /// send an activity proactively to a conversation.
     /// Sends to the exact conversation ID provided. For channel threads,
     /// the conversation ID must include <c>;messageid=</c> -- use
-    /// <see cref="Conversation.ToThreadId"/> to construct it, or use
+    /// <see cref="Conversation.ToThreadedConversationId"/> to construct it, or use
     /// <see cref="Reply{T}(string, string, T, CancellationToken)"/> which handles this automatically.
     /// </summary>
     public async Task<T> Send<T>(string conversationId, T activity, ConversationType? conversationType = null, string? serviceUrl = null, CancellationToken cancellationToken = default) where T : IActivity
@@ -258,7 +258,7 @@ public partial class App
         // Group chats and meetings use @thread.v2 which does not support threading.
         var supportsThreading = baseId.EndsWith("@thread.tacv2") || baseId.EndsWith("@thread.skype") || baseId.EndsWith("@unq.gbl.spaces");
         var targetId = supportsThreading
-            ? Conversation.ToThreadId(conversationId, messageId)
+            ? Conversation.ToThreadedConversationId(conversationId, messageId)
             : conversationId;
         return Send(targetId, activity, cancellationToken: cancellationToken);
     }

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -256,7 +256,7 @@ public partial class App
         var baseId = conversationId.Split(';')[0];
         // Channels use @thread.tacv2 or @thread.skype, 1:1 chats use @unq.gbl.spaces.
         // Group chats and meetings use @thread.v2 which does not support threading.
-        var supportsThreading = baseId.EndsWith("@thread.tacv2") || baseId.EndsWith("@thread.skype") || baseId.EndsWith("@unq.gbl.spaces");
+        var supportsThreading = baseId.EndsWith("@thread.tacv2", StringComparison.Ordinal) || baseId.EndsWith("@thread.skype", StringComparison.Ordinal) || baseId.EndsWith("@unq.gbl.spaces", StringComparison.Ordinal);
         var targetId = supportsThreading
             ? Conversation.ToThreadedConversationId(conversationId, messageId)
             : conversationId;

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -173,9 +173,12 @@ public partial class App
     }
 
     /// <summary>
-    /// send an activity to the conversation
+    /// send an activity proactively to a conversation.
+    /// Sends to the exact conversation ID provided. For channel threads,
+    /// the conversation ID must include <c>;messageid=</c> -- use
+    /// <see cref="Conversation.ToThreadId"/> to construct it, or use
+    /// <see cref="Reply{T}(string, string, T, CancellationToken)"/> which handles this automatically.
     /// </summary>
-    /// <param name="activity">activity activity to send</param>
     public async Task<T> Send<T>(string conversationId, T activity, ConversationType? conversationType = null, string? serviceUrl = null, CancellationToken cancellationToken = default) where T : IActivity
     {
         if (Id is null)
@@ -196,7 +199,7 @@ public partial class App
             Conversation = new()
             {
                 Id = conversationId,
-                Type = conversationType ?? ConversationType.Personal
+                Type = conversationType
             }
         };
 
@@ -235,6 +238,74 @@ public partial class App
     public async Task<MessageActivity> Send(string conversationId, Cards.AdaptiveCard card, ConversationType? conversationType = null, string? serviceUrl = null, CancellationToken cancellationToken = default)
     {
         return await Send(conversationId, new MessageActivity().AddAttachment(card), conversationType, serviceUrl, cancellationToken);
+    }
+
+    /// <summary>
+    /// send an activity proactively to a channel thread.
+    /// In channels, constructs a threaded conversation ID from the conversation ID
+    /// and message ID, then sends to that thread.
+    /// In flat scopes (1:1, group chat, meetings), sends as a normal message -
+    /// the message ID is ignored.
+    /// </summary>
+    /// <param name="conversationId">the channel or conversation ID</param>
+    /// <param name="messageId">the thread root message ID</param>
+    /// <param name="activity">the activity to send</param>
+    /// <param name="cancellationToken">optional cancellation token</param>
+    public Task<T> Reply<T>(string conversationId, string messageId, T activity, CancellationToken cancellationToken = default) where T : IActivity
+    {
+        var baseId = conversationId.Split(';')[0];
+        // Channels use @thread.tacv2 or @thread.skype, 1:1 chats use @unq.gbl.spaces.
+        // Group chats and meetings use @thread.v2 which does not support threading.
+        var supportsThreading = baseId.EndsWith("@thread.tacv2") || baseId.EndsWith("@thread.skype") || baseId.EndsWith("@unq.gbl.spaces");
+        var targetId = supportsThreading
+            ? Conversation.ToThreadId(conversationId, messageId)
+            : conversationId;
+        return Send(targetId, activity, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// send an activity proactively to a conversation.
+    /// Sends to the exact conversation ID provided - threaded if
+    /// it contains <c>;messageid=</c>, flat otherwise.
+    /// </summary>
+    /// <param name="conversationId">the conversation to send to</param>
+    /// <param name="activity">the activity to send</param>
+    /// <param name="cancellationToken">optional cancellation token</param>
+    public Task<T> Reply<T>(string conversationId, T activity, CancellationToken cancellationToken = default) where T : IActivity
+    {
+        return Send(conversationId, activity, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// send a message proactively to a thread
+    /// </summary>
+    public Task<MessageActivity> Reply(string conversationId, string messageId, string text, CancellationToken cancellationToken = default)
+    {
+        return Reply(conversationId, messageId, new MessageActivity(text), cancellationToken);
+    }
+
+    /// <summary>
+    /// send a message proactively to a conversation
+    /// </summary>
+    public Task<MessageActivity> Reply(string conversationId, string text, CancellationToken cancellationToken = default)
+    {
+        return Reply<MessageActivity>(conversationId, new MessageActivity(text), cancellationToken);
+    }
+
+    /// <summary>
+    /// send a card proactively to a thread
+    /// </summary>
+    public Task<MessageActivity> Reply(string conversationId, string messageId, Cards.AdaptiveCard card, CancellationToken cancellationToken = default)
+    {
+        return Reply(conversationId, messageId, new MessageActivity().AddAttachment(card), cancellationToken);
+    }
+
+    /// <summary>
+    /// send a card proactively to a conversation
+    /// </summary>
+    public Task<MessageActivity> Reply(string conversationId, Cards.AdaptiveCard card, CancellationToken cancellationToken = default)
+    {
+        return Reply<MessageActivity>(conversationId, new MessageActivity().AddAttachment(card), cancellationToken);
     }
 
     /// <summary>

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -244,7 +244,7 @@ public partial class App
     /// send an activity proactively to a channel thread.
     /// In channels, constructs a threaded conversation ID from the conversation ID
     /// and message ID, then sends to that thread.
-    /// In flat scopes (1:1, group chat, meetings), sends as a normal message -
+    /// In scopes that do not support threading (group chat, meetings), sends as a normal message -
     /// the message ID is ignored.
     /// </summary>
     /// <param name="conversationId">the channel or conversation ID</param>

--- a/Libraries/Microsoft.Teams.Apps/Contexts/Context.Send.cs
+++ b/Libraries/Microsoft.Teams.Apps/Contexts/Context.Send.cs
@@ -11,7 +11,7 @@ public partial interface IContext<TActivity>
     /// send an activity in the current conversation without quoting.
     /// In channels, sends to the current thread. In scopes that do not
     /// support threading (group chat, meetings), sends as a normal message.
-    /// To send with a visual quote of the inbound message, use <see cref="Reply{T}"/>.
+    /// To send with a visual quote of the inbound message, use <see cref="Reply{T}(T, CancellationToken)"/>.
     /// </summary>
     /// <param name="activity">activity activity to send</param>
     /// <param name="cancellationToken">optional cancellation token</param>
@@ -35,7 +35,7 @@ public partial interface IContext<TActivity>
     /// send an activity in the current conversation with a visual quote
     /// of the inbound message. In channels, sends to the current thread
     /// with a quoted reply. In other scopes, sends with a quoted reply.
-    /// To send without quoting, use <see cref="Send{T}"/>.
+    /// To send without quoting, use <see cref="Send{T}(T, CancellationToken)"/>.
     /// </summary>
     /// <param name="activity">activity activity to send</param>
     /// <param name="cancellationToken">optional cancellation token</param>

--- a/Libraries/Microsoft.Teams.Apps/Contexts/Context.Send.cs
+++ b/Libraries/Microsoft.Teams.Apps/Contexts/Context.Send.cs
@@ -8,7 +8,10 @@ namespace Microsoft.Teams.Apps;
 public partial interface IContext<TActivity>
 {
     /// <summary>
-    /// send an activity to the conversation
+    /// send an activity in the current conversation without quoting.
+    /// In channels, sends to the current thread. In flat scopes (1:1,
+    /// group chat, meetings), sends as a normal message.
+    /// To send with a visual quote of the inbound message, use <see cref="Reply{T}"/>.
     /// </summary>
     /// <param name="activity">activity activity to send</param>
     /// <param name="cancellationToken">optional cancellation token</param>
@@ -29,7 +32,10 @@ public partial interface IContext<TActivity>
     public Task<MessageActivity> Send(Cards.AdaptiveCard card, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// send an activity to the conversation as a reply
+    /// send an activity in the current conversation with a visual quote
+    /// of the inbound message. In channels, sends to the current thread
+    /// with a quoted reply. In flat scopes, sends with a quoted reply.
+    /// To send without quoting, use <see cref="Send{T}"/>.
     /// </summary>
     /// <param name="activity">activity activity to send</param>
     /// <param name="cancellationToken">optional cancellation token</param>

--- a/Libraries/Microsoft.Teams.Apps/Contexts/Context.Send.cs
+++ b/Libraries/Microsoft.Teams.Apps/Contexts/Context.Send.cs
@@ -9,8 +9,8 @@ public partial interface IContext<TActivity>
 {
     /// <summary>
     /// send an activity in the current conversation without quoting.
-    /// In channels, sends to the current thread. In flat scopes (1:1,
-    /// group chat, meetings), sends as a normal message.
+    /// In channels, sends to the current thread. In scopes that do not
+    /// support threading (group chat, meetings), sends as a normal message.
     /// To send with a visual quote of the inbound message, use <see cref="Reply{T}"/>.
     /// </summary>
     /// <param name="activity">activity activity to send</param>
@@ -34,7 +34,7 @@ public partial interface IContext<TActivity>
     /// <summary>
     /// send an activity in the current conversation with a visual quote
     /// of the inbound message. In channels, sends to the current thread
-    /// with a quoted reply. In flat scopes, sends with a quoted reply.
+    /// with a quoted reply. In other scopes, sends with a quoted reply.
     /// To send without quoting, use <see cref="Send{T}"/>.
     /// </summary>
     /// <param name="activity">activity activity to send</param>

--- a/Samples/Samples.Threading/Program.cs
+++ b/Samples/Samples.Threading/Program.cs
@@ -1,0 +1,87 @@
+using Microsoft.Teams.Api;
+using Microsoft.Teams.Api.Activities;
+using Microsoft.Teams.Apps.Activities;
+using Microsoft.Teams.Apps.Extensions;
+using Microsoft.Teams.Plugins.AspNetCore.DevTools.Extensions;
+using Microsoft.Teams.Plugins.AspNetCore.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.AddTeams().AddTeamsDevTools();
+var app = builder.Build();
+var teams = app.UseTeams();
+
+teams.OnMessage(async (context, cancellationToken) =>
+{
+    var text = (context.Activity.Text ?? "").ToLower();
+    var conversationId = context.Ref.Conversation.Id;
+    var messageId = context.Activity.Id!;
+
+    // When inside a thread, conversationId contains ;messageid=<rootId>.
+    // Extract the root ID for threading; for top-level messages, use activity.id.
+    var threadParts = conversationId.Split(";messageid=");
+    var threadRootId = threadParts.Length > 1 ? threadParts[1] : messageId;
+
+    // ============================================
+    // context.Reply() — reactive threaded reply
+    // ============================================
+    if (text.Contains("test reply"))
+    {
+        await context.Reply("This is a threaded reply to your message.", cancellationToken);
+        return;
+    }
+
+    // ============================================
+    // context.Send() — reactive send to same thread
+    // ============================================
+    if (text.Contains("test send"))
+    {
+        await context.Send("This is sent to the same thread, without quoting.", cancellationToken);
+        return;
+    }
+
+    // ============================================
+    // teams.Reply() — proactive threaded reply
+    // ============================================
+    if (text.Contains("test proactive"))
+    {
+        await teams.Reply(conversationId, threadRootId, "This is a proactive threaded reply using teams.Reply().", cancellationToken);
+        return;
+    }
+
+    // ============================================
+    // ToThreadId() + teams.Send() — advanced manual control (channels only)
+    // ============================================
+    if (text.Contains("test manual"))
+    {
+        // ToThreadId() is only valid for conversations that support threading
+        var baseId = conversationId.Split(';')[0];
+        if (!baseId.EndsWith("@thread.tacv2") && !baseId.EndsWith("@thread.skype") && !baseId.EndsWith("@unq.gbl.spaces"))
+        {
+            await context.Reply("This command doesn't support threading in this conversation type.", cancellationToken);
+            return;
+        }
+        var threadId = Microsoft.Teams.Api.Conversation.ToThreadId(conversationId, threadRootId);
+        await teams.Send(threadId, "This was sent using ToThreadId() + teams.Send() for manual control.", cancellationToken: cancellationToken);
+        return;
+    }
+
+    // ============================================
+    // Help / Default
+    // ============================================
+    if (text.Contains("help"))
+    {
+        await context.Reply(
+            "**Threading Test Bot**\n\n" +
+            "**Commands:**\n" +
+            "- `test reply` - context.Reply() reactive threaded reply\n" +
+            "- `test send` - context.Send() to same thread without quoting\n" +
+            "- `test proactive` - teams.Reply() proactive threaded reply\n" +
+            "- `test manual` - ToThreadId() + teams.Send() for advanced control",
+            cancellationToken);
+        return;
+    }
+
+    await context.Send("Say \"help\" for available commands.", cancellationToken);
+});
+
+app.Run();

--- a/Samples/Samples.Threading/Program.cs
+++ b/Samples/Samples.Threading/Program.cs
@@ -49,19 +49,19 @@ teams.OnMessage(async (context, cancellationToken) =>
     }
 
     // ============================================
-    // ToThreadId() + teams.Send() — advanced manual control (channels only)
+    // ToThreadedConversationId() + teams.Send() — advanced manual control (channels only)
     // ============================================
     if (text.Contains("test manual"))
     {
-        // ToThreadId() is only valid for conversations that support threading
+        // ToThreadedConversationId() is only valid for conversations that support threading
         var baseId = conversationId.Split(';')[0];
         if (!baseId.EndsWith("@thread.tacv2") && !baseId.EndsWith("@thread.skype") && !baseId.EndsWith("@unq.gbl.spaces"))
         {
             await context.Reply("This command doesn't support threading in this conversation type.", cancellationToken);
             return;
         }
-        var threadId = Microsoft.Teams.Api.Conversation.ToThreadId(conversationId, threadRootId);
-        await teams.Send(threadId, "This was sent using ToThreadId() + teams.Send() for manual control.", cancellationToken: cancellationToken);
+        var threadId = Microsoft.Teams.Api.Conversation.ToThreadedConversationId(conversationId, threadRootId);
+        await teams.Send(threadId, "This was sent using ToThreadedConversationId() + teams.Send() for manual control.", cancellationToken: cancellationToken);
         return;
     }
 
@@ -76,7 +76,7 @@ teams.OnMessage(async (context, cancellationToken) =>
             "- `test reply` - context.Reply() reactive threaded reply\n" +
             "- `test send` - context.Send() to same thread without quoting\n" +
             "- `test proactive` - teams.Reply() proactive threaded reply\n" +
-            "- `test manual` - ToThreadId() + teams.Send() for advanced control",
+            "- `test manual` - ToThreadedConversationId() + teams.Send() for advanced control",
             cancellationToken);
         return;
     }

--- a/Samples/Samples.Threading/Program.cs
+++ b/Samples/Samples.Threading/Program.cs
@@ -12,7 +12,7 @@ var teams = app.UseTeams();
 
 teams.OnMessage(async (context, cancellationToken) =>
 {
-    var text = (context.Activity.Text ?? "").ToLower();
+    var text = (context.Activity.Text ?? "").ToLowerInvariant();
     var conversationId = context.Ref.Conversation.Id;
     var messageId = context.Activity.Id!;
 
@@ -49,7 +49,7 @@ teams.OnMessage(async (context, cancellationToken) =>
     }
 
     // ============================================
-    // ToThreadedConversationId() + teams.Send() — advanced manual control (channels only)
+    // ToThreadedConversationId() + teams.Send() — advanced manual control (channels and 1:1 chats only)
     // ============================================
     if (text.Contains("test manual"))
     {

--- a/Samples/Samples.Threading/README.md
+++ b/Samples/Samples.Threading/README.md
@@ -9,14 +9,14 @@ A bot that demonstrates reactive and proactive threading in Microsoft Teams chan
 | `test reply` | `context.Reply()` — reactive threaded reply with visual quote |
 | `test send` | `context.Send()` — reactive send to same thread, no quote |
 | `test proactive` | `teams.Reply()` — proactive threaded reply |
-| `test manual` | `Conversation.ToThreadId()` + `teams.Send()` — advanced manual control (channels and 1:1 chats only) |
+| `test manual` | `Conversation.ToThreadedConversationId()` + `teams.Send()` — advanced manual control (channels and 1:1 chats only) |
 | `help` | Shows available commands |
 
 ## Notes
 
 - `test reply` and `test send` work in all scopes (1:1, group chat, channels)
 - `test proactive` works in all scopes — in channels it threads, in non-threading scopes it sends normally
-- `test manual` only works in channels and 1:1 chats since `ToThreadId()` constructs a threaded conversation ID (group chats and meetings do not support threading)
+- `test manual` only works in channels and 1:1 chats since `ToThreadedConversationId()` constructs a threaded conversation ID (group chats and meetings do not support threading)
 
 ## Run
 

--- a/Samples/Samples.Threading/README.md
+++ b/Samples/Samples.Threading/README.md
@@ -15,7 +15,7 @@ A bot that demonstrates reactive and proactive threading in Microsoft Teams chan
 ## Notes
 
 - `test reply` and `test send` work in all scopes (1:1, group chat, channels)
-- `test proactive` works in all scopes — in channels it threads, in flat scopes it sends normally
+- `test proactive` works in all scopes — in channels it threads, in non-threading scopes it sends normally
 - `test manual` only works in channels and 1:1 chats since `ToThreadId()` constructs a threaded conversation ID (group chats and meetings do not support threading)
 
 ## Run

--- a/Samples/Samples.Threading/README.md
+++ b/Samples/Samples.Threading/README.md
@@ -1,0 +1,38 @@
+# Example: Threading
+
+A bot that demonstrates reactive and proactive threading in Microsoft Teams channels.
+
+## Commands
+
+| Command | Behavior |
+|---------|----------|
+| `test reply` | `context.Reply()` — reactive threaded reply with visual quote |
+| `test send` | `context.Send()` — reactive send to same thread, no quote |
+| `test proactive` | `teams.Reply()` — proactive threaded reply |
+| `test manual` | `Conversation.ToThreadId()` + `teams.Send()` — advanced manual control (channels and 1:1 chats only) |
+| `help` | Shows available commands |
+
+## Notes
+
+- `test reply` and `test send` work in all scopes (1:1, group chat, channels)
+- `test proactive` works in all scopes — in channels it threads, in flat scopes it sends normally
+- `test manual` only works in channels and 1:1 chats since `ToThreadId()` constructs a threaded conversation ID (group chats and meetings do not support threading)
+
+## Run
+
+```bash
+dotnet run
+```
+
+## Configuration
+
+Set credentials in `appsettings.json`:
+
+```json
+{
+  "Teams": {
+    "ClientId": "<your-azure-bot-app-id>",
+    "ClientSecret": "<your-azure-bot-app-secret>"
+  }
+}
+```

--- a/Samples/Samples.Threading/Samples.Threading.csproj
+++ b/Samples/Samples.Threading/Samples.Threading.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Libraries\Microsoft.Teams.Common\Microsoft.Teams.Common.csproj" />
+    <ProjectReference Include="..\..\Libraries\Microsoft.Teams.Api\Microsoft.Teams.Api.csproj" />
+    <ProjectReference Include="..\..\Libraries\Microsoft.Teams.Apps\Microsoft.Teams.Apps.csproj" />
+    <ProjectReference Include="..\..\Libraries\Microsoft.Teams.Cards\Microsoft.Teams.Cards.csproj" />
+    <ProjectReference Include="..\..\Libraries\Microsoft.Teams.Extensions\Microsoft.Teams.Extensions.Hosting\Microsoft.Teams.Extensions.Hosting.csproj" />
+    <ProjectReference Include="..\..\Libraries\Microsoft.Teams.Plugins\Microsoft.Teams.Plugins.AspNetCore\Microsoft.Teams.Plugins.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\Libraries\Microsoft.Teams.Plugins\Microsoft.Teams.Plugins.AspNetCore.DevTools\Microsoft.Teams.Plugins.AspNetCore.DevTools.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/Samples.Threading/appsettings.json
+++ b/Samples/Samples.Threading/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    },
+    "Microsoft.Teams": {
+      "Enable": "*",
+      "Level": "debug"
+    }
+  },
+  "Teams": {
+    "TenantId": "",
+    "ClientId": "",
+    "ClientSecret": ""
+  }
+}

--- a/Tests/Microsoft.Teams.Api.Tests/ConversationTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/ConversationTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Teams.Api.Tests;
+
+public class ConversationTests
+{
+    [Fact]
+    public void ToThreadId_ConstructsThreadedConversationId()
+    {
+        var result = Conversation.ToThreadId("19:abc@thread.skype", "1680000000000");
+        Assert.Equal("19:abc@thread.skype;messageid=1680000000000", result);
+    }
+
+    [Fact]
+    public void ToThreadId_WorksWithDifferentConversationIdFormats()
+    {
+        var result = Conversation.ToThreadId("19:meeting_abc@thread.v2", "999");
+        Assert.Equal("19:meeting_abc@thread.v2;messageid=999", result);
+    }
+
+    [Fact]
+    public void ToThreadId_ThrowsOnEmptyConversationId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId("", "123"));
+    }
+
+    [Fact]
+    public void ToThreadId_ThrowsOnNullConversationId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId(null!, "123"));
+    }
+
+    [Fact]
+    public void ToThreadId_ThrowsOnEmptyMessageId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId("19:abc@thread.skype", ""));
+    }
+
+    [Fact]
+    public void ToThreadId_ThrowsOnZeroMessageId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId("19:abc@thread.skype", "0"));
+    }
+
+    [Fact]
+    public void ToThreadId_ThrowsOnNonNumericMessageId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId("19:abc@thread.skype", "abc"));
+    }
+
+    [Fact]
+    public void ToThreadId_ThrowsOnNegativeMessageId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId("19:abc@thread.skype", "-1"));
+    }
+
+    [Fact]
+    public void ToThreadId_ThrowsOnDecimalMessageId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId("19:abc@thread.skype", "1.5"));
+    }
+
+    [Fact]
+    public void ToThreadId_StripsExistingMessageIdAndReplacesWithThreadRoot()
+    {
+        var result = Conversation.ToThreadId("19:abc@thread.skype;messageid=111", "222");
+        Assert.Equal("19:abc@thread.skype;messageid=222", result);
+    }
+}

--- a/Tests/Microsoft.Teams.Api.Tests/ConversationTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/ConversationTests.cs
@@ -6,65 +6,65 @@ namespace Microsoft.Teams.Api.Tests;
 public class ConversationTests
 {
     [Fact]
-    public void ToThreadId_ConstructsThreadedConversationId()
+    public void ToThreadedConversationId_ConstructsThreadedConversationId()
     {
-        var result = Conversation.ToThreadId("19:abc@thread.skype", "1680000000000");
+        var result = Conversation.ToThreadedConversationId("19:abc@thread.skype", "1680000000000");
         Assert.Equal("19:abc@thread.skype;messageid=1680000000000", result);
     }
 
     [Fact]
-    public void ToThreadId_WorksWithDifferentConversationIdFormats()
+    public void ToThreadedConversationId_WorksWithDifferentConversationIdFormats()
     {
-        var result = Conversation.ToThreadId("19:meeting_abc@thread.v2", "999");
+        var result = Conversation.ToThreadedConversationId("19:meeting_abc@thread.v2", "999");
         Assert.Equal("19:meeting_abc@thread.v2;messageid=999", result);
     }
 
     [Fact]
-    public void ToThreadId_ThrowsOnEmptyConversationId()
+    public void ToThreadedConversationId_ThrowsOnEmptyConversationId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId("", "123"));
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("", "123"));
     }
 
     [Fact]
-    public void ToThreadId_ThrowsOnNullConversationId()
+    public void ToThreadedConversationId_ThrowsOnNullConversationId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId(null!, "123"));
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId(null!, "123"));
     }
 
     [Fact]
-    public void ToThreadId_ThrowsOnEmptyMessageId()
+    public void ToThreadedConversationId_ThrowsOnEmptyMessageId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId("19:abc@thread.skype", ""));
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", ""));
     }
 
     [Fact]
-    public void ToThreadId_ThrowsOnZeroMessageId()
+    public void ToThreadedConversationId_ThrowsOnZeroMessageId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId("19:abc@thread.skype", "0"));
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", "0"));
     }
 
     [Fact]
-    public void ToThreadId_ThrowsOnNonNumericMessageId()
+    public void ToThreadedConversationId_ThrowsOnNonNumericMessageId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId("19:abc@thread.skype", "abc"));
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", "abc"));
     }
 
     [Fact]
-    public void ToThreadId_ThrowsOnNegativeMessageId()
+    public void ToThreadedConversationId_ThrowsOnNegativeMessageId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId("19:abc@thread.skype", "-1"));
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", "-1"));
     }
 
     [Fact]
-    public void ToThreadId_ThrowsOnDecimalMessageId()
+    public void ToThreadedConversationId_ThrowsOnDecimalMessageId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadId("19:abc@thread.skype", "1.5"));
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", "1.5"));
     }
 
     [Fact]
-    public void ToThreadId_StripsExistingMessageIdAndReplacesWithThreadRoot()
+    public void ToThreadedConversationId_StripsExistingMessageIdAndReplacesWithThreadRoot()
     {
-        var result = Conversation.ToThreadId("19:abc@thread.skype;messageid=111", "222");
+        var result = Conversation.ToThreadedConversationId("19:abc@thread.skype;messageid=111", "222");
         Assert.Equal("19:abc@thread.skype;messageid=222", result);
     }
 }

--- a/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
@@ -300,4 +300,71 @@ public class AppTests
         Assert.Equal("user123", targetedMessage.Recipient.Id);
     }
 
+    [Fact]
+    public async Task Test_App_Reply_ThreeArgs_ConstructsThreadedId()
+    {
+        // arrange
+        var sender = new Mock<ISenderPlugin>();
+        sender.Setup(s => s.Send<MessageActivity>(It.IsAny<MessageActivity>(), It.IsAny<ConversationReference>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MessageActivity a, ConversationReference r, CancellationToken c) => a);
+
+        var token = new Mock<IToken>();
+        token.Setup(t => t.AppId).Returns("test-app-id");
+        token.Setup(t => t.AppDisplayName).Returns("Test App");
+
+        var options = new AppOptions() { Plugins = [sender.Object] };
+        var app = new App(options);
+        app.Token = token.Object;
+
+        // act
+        await app.Reply("19:abc@thread.skype", "1680000000000", new MessageActivity("Hello thread"));
+
+        // assert
+        sender.Verify(s => s.Send<MessageActivity>(
+            It.IsAny<MessageActivity>(),
+            It.Is<ConversationReference>(r => r.Conversation.Id == "19:abc@thread.skype;messageid=1680000000000"),
+            It.IsAny<CancellationToken>()
+        ), Times.Once);
+    }
+
+    [Fact]
+    public async Task Test_App_Reply_TwoArgs_PassesConversationIdAsIs()
+    {
+        // arrange
+        var sender = new Mock<ISenderPlugin>();
+        sender.Setup(s => s.Send<MessageActivity>(It.IsAny<MessageActivity>(), It.IsAny<ConversationReference>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MessageActivity a, ConversationReference r, CancellationToken c) => a);
+
+        var token = new Mock<IToken>();
+        token.Setup(t => t.AppId).Returns("test-app-id");
+        token.Setup(t => t.AppDisplayName).Returns("Test App");
+
+        var options = new AppOptions() { Plugins = [sender.Object] };
+        var app = new App(options);
+        app.Token = token.Object;
+
+        // act
+        await app.Reply("19:abc@thread.skype", new MessageActivity("Hello flat"));
+
+        // assert
+        sender.Verify(s => s.Send<MessageActivity>(
+            It.IsAny<MessageActivity>(),
+            It.Is<ConversationReference>(r => r.Conversation.Id == "19:abc@thread.skype"),
+            It.IsAny<CancellationToken>()
+        ), Times.Once);
+    }
+
+    [Fact]
+    public async Task Test_App_Reply_ThreeArgs_InvalidMessageId_Throws()
+    {
+        // arrange
+        var credentials = new Mock<IHttpCredentials>();
+        var options = new AppOptions() { Credentials = credentials.Object };
+        var app = new App(options);
+
+        // act & assert
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            app.Reply("19:abc@thread.skype", "not-a-number", new MessageActivity("Hello")));
+    }
+
 }


### PR DESCRIPTION
## Summary
- Add `Reply()` overloads on `App` for proactive thread sends (generic, string, AdaptiveCard — 2-arg and 3-arg forms)
- Add `Conversation.ToThreadedConversationId()` for constructing threaded conversation IDs
- `supportsThreading` inline check covers channels (`@thread.tacv2`/`@thread.skype`) and 1:1 (`@unq.gbl.spaces`)
- Update `Context.Send()` and `Context.Reply()` doc comments
- Add threading sample

## Test plan
- [x] Unit tests for `ToThreadedConversationId()` (10 tests) and `Reply()` (3 tests)
- [x] E2E: All commands tested in 1:1 and channel (top-level + existing thread)
- [x] `dotnet build` 0 errors, `dotnet test` all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)