### PR TITLE
pin crypto xml

### DIFF
--- a/core/src/Microsoft.Teams.Bot.Core/Microsoft.Teams.Bot.Core.csproj
+++ b/core/src/Microsoft.Teams.Bot.Core/Microsoft.Teams.Bot.Core.csproj
@@ -15,10 +15,12 @@
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.22" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.22" />
         <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.6" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.7.0" />


### PR DESCRIPTION
This pull request adds a new package dependency to the project to support XML cryptography functionality across both .NET 8 and .NET 10 target frameworks.

Dependency updates:

* Added `System.Security.Cryptography.Xml` as a package reference for both .NET 8 (`Version="8.0.3"`) and .NET 10 (`Version="10.0.6"`) in `Microsoft.Teams.Bot.Core.csproj` to enable XML cryptography features.