### PR TITLE
Remove supportsThreading guard from Reply()

### DIFF
--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -251,26 +251,18 @@ public partial class App
     }
 
     /// <summary>
-    /// send an activity proactively to a channel thread.
-    /// In channels, constructs a threaded conversation ID from the conversation ID
-    /// and message ID, then sends to that thread.
-    /// In scopes that do not support threading (group chat, meetings), sends as a normal message -
-    /// the message ID is ignored.
+    /// send an activity proactively as a threaded reply.
+    /// Constructs a threaded conversation ID from the conversation ID
+    /// and message ID via <see cref="Conversation.ToThreadedConversationId"/>,
+    /// then sends to that thread.
     /// </summary>
-    /// <param name="conversationId">the channel or conversation ID</param>
+    /// <param name="conversationId">the conversation ID</param>
     /// <param name="messageId">the thread root message ID</param>
     /// <param name="activity">the activity to send</param>
     /// <param name="cancellationToken">optional cancellation token</param>
     public Task<T> Reply<T>(string conversationId, string messageId, T activity, CancellationToken cancellationToken = default) where T : IActivity
     {
-        var baseId = conversationId.Split(';')[0];
-        // Channels use @thread.tacv2 or @thread.skype, 1:1 chats use @unq.gbl.spaces.
-        // Group chats and meetings use @thread.v2 which does not support threading.
-        var supportsThreading = baseId.EndsWith("@thread.tacv2", StringComparison.Ordinal) || baseId.EndsWith("@thread.skype", StringComparison.Ordinal) || baseId.EndsWith("@unq.gbl.spaces", StringComparison.Ordinal);
-        var targetId = supportsThreading
-            ? Conversation.ToThreadedConversationId(conversationId, messageId)
-            : conversationId;
-        return Send(targetId, activity, cancellationToken: cancellationToken);
+        return Send(Conversation.ToThreadedConversationId(conversationId, messageId), activity, cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -251,10 +251,11 @@ public partial class App
     }
 
     /// <summary>
-    /// send an activity proactively as a threaded reply.
+    /// send an activity proactively to a conversation, optionally as a threaded reply.
     /// Constructs a threaded conversation ID from the conversation ID
     /// and message ID via <see cref="Conversation.ToThreadedConversationId"/>,
-    /// then sends to that thread.
+    /// then sends to that thread. The service determines whether threading is
+    /// supported for the given conversation type.
     /// </summary>
     /// <param name="conversationId">the conversation ID</param>
     /// <param name="messageId">the thread root message ID</param>

--- a/Samples/Samples.Threading/Program.cs
+++ b/Samples/Samples.Threading/Program.cs
@@ -49,17 +49,10 @@ teams.OnMessage(async (context, cancellationToken) =>
     }
 
     // ============================================
-    // ToThreadedConversationId() + teams.Send() — advanced manual control (channels and 1:1 chats only)
+    // ToThreadedConversationId() + teams.Send() — advanced manual control
     // ============================================
     if (text.Contains("test manual"))
     {
-        // ToThreadedConversationId() is only valid for conversations that support threading
-        var baseId = conversationId.Split(';')[0];
-        if (!baseId.EndsWith("@thread.tacv2") && !baseId.EndsWith("@thread.skype") && !baseId.EndsWith("@unq.gbl.spaces"))
-        {
-            await context.Reply("This command doesn't support threading in this conversation type.", cancellationToken);
-            return;
-        }
         var threadId = Microsoft.Teams.Api.Conversation.ToThreadedConversationId(conversationId, threadRootId);
         await teams.Send(threadId, "This was sent using ToThreadedConversationId() + teams.Send() for manual control.", cancellationToken: cancellationToken);
         return;

--- a/Samples/Samples.Threading/README.md
+++ b/Samples/Samples.Threading/README.md
@@ -9,14 +9,15 @@ A bot that demonstrates reactive and proactive threading in Microsoft Teams chan
 | `test reply` | `context.Reply()` — reactive threaded reply with visual quote |
 | `test send` | `context.Send()` — reactive send to same thread, no quote |
 | `test proactive` | `teams.Reply()` — proactive threaded reply |
-| `test manual` | `Conversation.ToThreadedConversationId()` + `teams.Send()` — advanced manual control (channels and 1:1 chats only) |
+| `test manual` | `Conversation.ToThreadedConversationId()` + `teams.Send()` — advanced manual control |
 | `help` | Shows available commands |
 
 ## Notes
 
 - `test reply` and `test send` work in all scopes (1:1, group chat, channels)
-- `test proactive` works in all scopes — in channels it threads, in non-threading scopes it sends normally
-- `test manual` only works in channels and 1:1 chats since `ToThreadedConversationId()` constructs a threaded conversation ID (group chats and meetings do not support threading)
+- `test proactive` constructs a threaded conversation ID and sends to that thread
+- `test manual` does the same using `Conversation.ToThreadedConversationId()` + `teams.Send()` directly
+- `test proactive` and `test manual` will return a service error in meetings, which do not currently support threading
 
 ## Run
 

--- a/Samples/Samples.Threading/README.md
+++ b/Samples/Samples.Threading/README.md
@@ -17,7 +17,7 @@ A bot that demonstrates reactive and proactive threading in Microsoft Teams chan
 - `test reply` and `test send` work in all scopes (1:1, group chat, channels)
 - `test proactive` constructs a threaded conversation ID and sends to that thread
 - `test manual` does the same using `Conversation.ToThreadedConversationId()` + `teams.Send()` directly
-- `test proactive` and `test manual` will return a service error in meetings, which do not currently support threading
+- `test proactive` and `test manual` may return a service error in conversation types that do not currently support threading (e.g. meetings)
 
 ## Run
 


### PR DESCRIPTION
## Summary
- Remove `supportsThreading` guard from `Reply()` 3-arg form -- always calls `Conversation.ToThreadedConversationId()` when messageId is provided
- Update `test manual` example to remove conversation type guard
- Threading support is now determined by the service, not the SDK

**Why:** Threading support is expanding (channels, 1:1, group chats). Maintaining an allowlist of conversation ID suffixes creates a maintenance burden and can block developers from using newly supported scopes until the SDK is updated.

## Test plan
- [x] dotnet build: 0 errors
- [x] dotnet test: 558 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)