### PR TITLE
feat: implement custom feedback form 

### DIFF
--- a/Libraries/Microsoft.Teams.Api/Activities/Activity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Activity.cs
@@ -269,7 +269,29 @@ public partial class Activity : IActivity
     {
         ChannelData ??= new();
         ChannelData.Merge(value);
+        NormalizeFeedback();
         return this;
+    }
+
+    /// <summary>
+    /// The Teams service rejects <c>feedbackLoop</c> and <c>feedbackLoopEnabled</c>
+    /// set at the same time. When <see cref="ChannelData.FeedbackLoop"/> is set it
+    /// wins; otherwise a legacy <c>FeedbackLoopEnabled = true</c> is upgraded to
+    /// <see cref="FeedbackType.Default"/>.
+    /// </summary>
+    private void NormalizeFeedback()
+    {
+        if (ChannelData is null) return;
+
+        if (ChannelData.FeedbackLoop is not null)
+        {
+            ChannelData.FeedbackLoopEnabled = null;
+        }
+        else if (ChannelData.FeedbackLoopEnabled == true)
+        {
+            ChannelData.FeedbackLoop = new FeedbackLoop(FeedbackType.Default);
+            ChannelData.FeedbackLoopEnabled = null;
+        }
     }
 
     public virtual Activity WithData(string key, object? value)
@@ -373,12 +395,38 @@ public partial class Activity : IActivity
     }
 
     /// <summary>
-    /// enable/disable message feedback
-    /// </summary>
+    /// Legacy builder method of enabling default message feedback.
+    /// </param>
     public virtual Activity AddFeedback(bool value = true)
     {
         ChannelData ??= new();
-        ChannelData.FeedbackLoopEnabled = value;
+
+        if (value)
+        {
+            ChannelData.FeedbackLoop = new FeedbackLoop(FeedbackType.Default);
+        }
+        else
+        {
+            ChannelData.FeedbackLoop = null;
+        }
+
+        ChannelData.FeedbackLoopEnabled = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Enable message feedback with an explicit mode (default or custom).
+    /// </summary>
+    /// <param name="mode">
+    /// <see cref="FeedbackType.Default"/> shows Teams' built-in thumbs up/down UI.
+    /// <see cref="FeedbackType.Custom"/> triggers a <c>message/fetchTask</c> invoke
+    /// so the bot can return its own task module dialog.
+    /// </param>
+    public virtual Activity AddFeedback(FeedbackType mode)
+    {
+        ChannelData ??= new();
+        ChannelData.FeedbackLoop = new FeedbackLoop(mode);
+        ChannelData.FeedbackLoopEnabled = null;
         return this;
     }
 

--- a/Libraries/Microsoft.Teams.Api/Activities/Activity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Activity.cs
@@ -396,7 +396,8 @@ public partial class Activity : IActivity
 
     /// <summary>
     /// Legacy builder method of enabling default message feedback.
-    /// </param>
+    /// </summary>
+    /// <param name="value">Whether to enable default message feedback.</param>
     public virtual Activity AddFeedback(bool value = true)
     {
         ChannelData ??= new();

--- a/Libraries/Microsoft.Teams.Api/Activities/Invokes/MessageActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Invokes/MessageActivity.cs
@@ -20,10 +20,12 @@ public partial class Name : StringEnum
 public abstract class MessageActivity(Name.Messages name) : InvokeActivity(new(name.Value))
 {
     public Messages.SubmitActionActivity ToSubmitAction() => (Messages.SubmitActionActivity)this;
+    public Messages.FetchTaskActivity ToFetchTask() => (Messages.FetchTaskActivity)this;
 
     public override object ToType(Type type, IFormatProvider? provider)
     {
         if (type == typeof(Messages.SubmitActionActivity)) return ToSubmitAction();
+        if (type == typeof(Messages.FetchTaskActivity)) return ToFetchTask();
         return this;
     }
 
@@ -53,6 +55,7 @@ public abstract class MessageActivity(Name.Messages name) : InvokeActivity(new(n
             return name switch
             {
                 "message/submitAction" => JsonSerializer.Deserialize<Messages.SubmitActionActivity>(element.ToString(), options),
+                "message/fetchTask" => JsonSerializer.Deserialize<Messages.FetchTaskActivity>(element.ToString(), options),
                 _ => throw new JsonException($"failed to deserialize message activity '{name}' doesn't match any known types.")
             };
         }
@@ -62,6 +65,12 @@ public abstract class MessageActivity(Name.Messages name) : InvokeActivity(new(n
             if (value is Messages.SubmitActionActivity submitAction)
             {
                 JsonSerializer.Serialize(writer, submitAction, options);
+                return;
+            }
+
+            if (value is Messages.FetchTaskActivity fetchTask)
+            {
+                JsonSerializer.Serialize(writer, fetchTask, options);
                 return;
             }
 

--- a/Libraries/Microsoft.Teams.Api/Activities/Invokes/Messages/FetchTaskActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Invokes/Messages/FetchTaskActivity.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+using Microsoft.Teams.Common;
+
+namespace Microsoft.Teams.Api.Activities.Invokes;
+
+public partial class Name : StringEnum
+{
+    public partial class Messages : StringEnum
+    {
+        public static readonly Messages FetchTask = new("message/fetchTask");
+        public bool IsFetchTask => FetchTask.Equals(Value);
+    }
+}
+
+/// <summary>
+/// The feedback button the user clicked.
+/// </summary>
+[JsonConverter(typeof(JsonConverter<Reaction>))]
+public partial class Reaction(string value) : StringEnum(value)
+{
+    public static readonly Reaction Like = new("like");
+    public bool IsLike => Like.Equals(Value);
+
+    public static readonly Reaction Dislike = new("dislike");
+    public bool IsDislike => Dislike.Equals(Value);
+}
+
+public static partial class Messages
+{
+    /// <summary>
+    /// Sent when a message has a custom feedback loop and the user clicks a
+    /// feedback button. The bot should respond with a task module (dialog) to
+    /// collect feedback.
+    /// </summary>
+    public class FetchTaskActivity() : MessageActivity(Name.Messages.FetchTask)
+    {
+        /// <summary>
+        /// A value that is associated with the activity.
+        /// </summary>
+        [JsonPropertyName("value")]
+        [JsonPropertyOrder(32)]
+        public new required FetchTaskValue Value
+        {
+            get => (FetchTaskValue)base.Value!;
+            set => base.Value = value;
+        }
+
+        /// <summary>
+        /// The value associated with a message fetch task.
+        /// </summary>
+        public class FetchTaskValue
+        {
+            /// <summary>
+            /// The data payload containing action name and value.
+            /// </summary>
+            [JsonPropertyName("data")]
+            [JsonPropertyOrder(0)]
+            public required FetchTaskData Data { get; set; }
+        }
+
+        /// <summary>
+        /// The data payload nested inside the fetch task value.
+        /// </summary>
+        public class FetchTaskData
+        {
+            /// <summary>
+            /// The name of the action.
+            /// </summary>
+            [JsonPropertyName("actionName")]
+            [JsonPropertyOrder(0)]
+            public string ActionName { get; set; } = "feedback";
+
+            /// <summary>
+            /// Contains the user's reaction.
+            /// </summary>
+            [JsonPropertyName("actionValue")]
+            [JsonPropertyOrder(1)]
+            public required FetchTaskActionValue ActionValue { get; set; }
+        }
+
+        /// <summary>
+        /// The nested action value containing the user's reaction.
+        /// </summary>
+        public class FetchTaskActionValue
+        {
+            /// <summary>
+            /// The feedback button the user clicked.
+            /// </summary>
+            [JsonPropertyName("reaction")]
+            [JsonPropertyOrder(0)]
+            public required Reaction Reaction { get; set; }
+        }
+    }
+}

--- a/Libraries/Microsoft.Teams.Api/ChannelData.cs
+++ b/Libraries/Microsoft.Teams.Api/ChannelData.cs
@@ -63,7 +63,10 @@ public class ChannelData
     public App? App { get; set; }
 
     /// <summary>
-    /// Whether or not the feedback loop feature is enabled
+    /// Legacy feedback loop flag. Setting this to <c>true</c> is equivalent to
+    /// <c>FeedbackLoop = new FeedbackLoop(FeedbackType.Default)</c>.
+    /// Prefer setting <see cref="FeedbackLoop"/> directly; this field is normalized
+    /// by <see cref="Activities.Activity.WithData(ChannelData)"/>.
     /// </summary>
     [JsonPropertyName("feedbackLoopEnabled")]
     [JsonPropertyOrder(7)]
@@ -108,6 +111,17 @@ public class ChannelData
     [JsonPropertyName("membershipSource")]
     [JsonPropertyOrder(14)]
     public MembershipSource? MembershipSource { get; set; }
+
+    /// <summary>
+    /// Feedback loop configuration.
+    /// Set <c>Type</c> to <see cref="FeedbackType.Custom"/> to trigger a
+    /// <c>message/fetchTask</c> invoke for a bot-provided task module dialog.
+    /// Set <c>Type</c> to <see cref="FeedbackType.Default"/> for the standard
+    /// Teams thumbs up/down UI.
+    /// </summary>
+    [JsonPropertyName("feedbackLoop")]
+    [JsonPropertyOrder(15)]
+    public FeedbackLoop? FeedbackLoop { get; set; }
 
     /// <summary>
     /// All extra data present

--- a/Libraries/Microsoft.Teams.Api/FeedbackLoop.cs
+++ b/Libraries/Microsoft.Teams.Api/FeedbackLoop.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+using Microsoft.Teams.Common;
+
+namespace Microsoft.Teams.Api;
+
+/// <summary>
+/// The type of feedback loop.
+/// Use <c>Custom</c> to trigger a <c>message/fetchTask</c> invoke so the bot
+/// can return its own task module dialog.
+/// Use <c>Default</c> for the standard Teams thumbs up/down UI.
+/// </summary>
+[JsonConverter(typeof(JsonConverter<FeedbackType>))]
+public partial class FeedbackType(string value) : StringEnum(value)
+{
+    public static readonly FeedbackType Default = new("default");
+    public bool IsDefault => Default.Equals(Value);
+
+    public static readonly FeedbackType Custom = new("custom");
+    public bool IsCustom => Custom.Equals(Value);
+}
+
+/// <summary>
+/// Configuration for a feedback loop on a message.
+/// </summary>
+public class FeedbackLoop
+{
+    /// <summary>
+    /// The type of feedback loop.
+    /// </summary>
+    [JsonPropertyName("type")]
+    [JsonPropertyOrder(0)]
+    public FeedbackType Type { get; set; } = FeedbackType.Default;
+
+    public FeedbackLoop() { }
+
+    public FeedbackLoop(FeedbackType type)
+    {
+        Type = type;
+    }
+}

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Messages/FetchTaskActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Messages/FetchTaskActivity.cs
@@ -22,7 +22,7 @@ public static partial class AppInvokeActivityExtensions
     /// Registers a handler for <c>message/fetchTask</c> activities.
     /// The bot should return a task module response containing the dialog to show the user.
     /// </summary>
-    public static App OnMessageFetchTask(this App app, Func<IContext<Messages.FetchTaskActivity>, CancellationToken, Task<Response<Api.TaskModules.Response>>> handler)
+    public static App OnMessageFetchTask(this App app, Func<IContext<Messages.FetchTaskActivity>, CancellationToken, Task<Api.TaskModules.Response>> handler)
     {
         app.Router.Register(new Route()
         {

--- a/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Messages/FetchTaskActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Invokes/Messages/FetchTaskActivity.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Teams.Api.Activities;
+using Microsoft.Teams.Api.Activities.Invokes;
+using Microsoft.Teams.Apps.Routing;
+
+namespace Microsoft.Teams.Apps.Activities.Invokes;
+
+public static partial class Message
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = true)]
+    public class FetchTaskAttribute() : InvokeAttribute(Api.Activities.Invokes.Name.Messages.FetchTask, typeof(Messages.FetchTaskActivity))
+    {
+        public override object Coerce(IContext<IActivity> context) => context.ToActivityType<Messages.FetchTaskActivity>();
+    }
+}
+
+public static partial class AppInvokeActivityExtensions
+{
+    /// <summary>
+    /// Registers a handler for <c>message/fetchTask</c> activities.
+    /// The bot should return a task module response containing the dialog to show the user.
+    /// </summary>
+    public static App OnMessageFetchTask(this App app, Func<IContext<Messages.FetchTaskActivity>, CancellationToken, Task<Response<Api.TaskModules.Response>>> handler)
+    {
+        app.Router.Register(new Route()
+        {
+            Name = string.Join("/", [ActivityType.Invoke, Name.Messages.FetchTask]),
+            Type = app.Status is null ? RouteType.System : RouteType.User,
+            Handler = async context => await handler(context.ToActivityType<Messages.FetchTaskActivity>(), context.CancellationToken),
+            Selector = activity => activity is Messages.FetchTaskActivity
+        });
+
+        return app;
+    }
+}

--- a/Samples/Samples.AI/Handlers/FeedbackHandler.cs
+++ b/Samples/Samples.AI/Handlers/FeedbackHandler.cs
@@ -80,7 +80,7 @@ public static class FeedbackHandler
     /// Builds the task module (dialog) shown when the user clicks a feedback
     /// button on a message whose feedback loop type is <c>custom</c>.
     /// </summary>
-    public static Response<TaskModules.Response> HandleFeedbackFetchTask(IContext<Messages.FetchTaskActivity> context)
+    public static TaskModules.Response HandleFeedbackFetchTask(IContext<Messages.FetchTaskActivity> context)
     {
         var reaction = context.Activity.Value.Data.ActionValue.Reaction;
         context.Log.Info($"[HANDLER] Feedback fetch-task invoked, reaction: {reaction}");
@@ -104,11 +104,11 @@ public static class FeedbackHandler
             }
         };
 
-        return new Response<TaskModules.Response>(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo
+        return new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo
         {
             Title = "Feedback",
             Card = new Attachment(card),
-        })));
+        }));
     }
 
     /// <summary>

--- a/Samples/Samples.AI/Handlers/FeedbackHandler.cs
+++ b/Samples/Samples.AI/Handlers/FeedbackHandler.cs
@@ -3,8 +3,12 @@ using System.Collections.Concurrent;
 using Microsoft.Teams.AI.Models.OpenAI;
 using Microsoft.Teams.AI.Prompts;
 using Microsoft.Teams.AI.Templates;
+using Microsoft.Teams.Api;
 using Microsoft.Teams.Api.Activities.Invokes;
 using Microsoft.Teams.Apps;
+using Microsoft.Teams.Cards;
+
+using TaskModules = Microsoft.Teams.Api.TaskModules;
 
 namespace Samples.AI.Handlers;
 
@@ -38,13 +42,15 @@ public static class FeedbackHandler
         {
             context.Log.Info($"[HANDLER] AI response received: {result.Content}");
 
-            // Create message with AI generated indicator and feedback buttons
+            // Create message with AI generated indicator and custom feedback buttons.
+            // Clicking a feedback button in 'custom' mode triggers a message/fetchTask
+            // invoke (handled by HandleFeedbackFetchTask) so the bot can show its own dialog.
             var messageActivity = new Microsoft.Teams.Api.Activities.MessageActivity
             {
                 Text = result.Content,
             }
             .AddAIGenerated()
-            .AddFeedback(); // This adds the thumbs up/down buttons
+            .AddFeedback(FeedbackType.Custom);
 
             context.Log.Info("[HANDLER] Sending message with feedback buttons");
             var sentActivity = await context.Send(messageActivity, cancellationToken);
@@ -68,6 +74,41 @@ public static class FeedbackHandler
             context.Log.Warn("[HANDLER] AI did not generate a response");
             await context.Reply("I did not generate a response.", cancellationToken);
         }
+    }
+
+    /// <summary>
+    /// Builds the task module (dialog) shown when the user clicks a feedback
+    /// button on a message whose feedback loop type is <c>custom</c>.
+    /// </summary>
+    public static Response<TaskModules.Response> HandleFeedbackFetchTask(IContext<Messages.FetchTaskActivity> context)
+    {
+        var reaction = context.Activity.Value.Data.ActionValue.Reaction;
+        context.Log.Info($"[HANDLER] Feedback fetch-task invoked, reaction: {reaction}");
+
+        var card = new AdaptiveCard
+        {
+            Schema = "http://adaptivecards.io/schemas/adaptive-card.json",
+            Body = new List<CardElement>
+            {
+                new TextBlock($"You reacted {reaction}. Tell us more (optional):") { Wrap = true },
+                new TextInput
+                {
+                    Id = "feedbackText",
+                    Placeholder = "Your feedback...",
+                    IsMultiline = true,
+                }
+            },
+            Actions = new List<Microsoft.Teams.Cards.Action>
+            {
+                new SubmitAction { Title = "Submit" }
+            }
+        };
+
+        return new Response<TaskModules.Response>(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo
+        {
+            Title = "Feedback",
+            Card = new Attachment(card),
+        })));
     }
 
     /// <summary>

--- a/Samples/Samples.AI/Program.cs
+++ b/Samples/Samples.AI/Program.cs
@@ -144,7 +144,16 @@ teamsApp.OnMessage(@"^/weather\b", async (context, cancellationToken) =>
     }
 });
 
-// Feedback submission handler
+// Custom feedback fetch-task handler.
+// Teams fires this when the user clicks a feedback button on a message whose
+// feedback loop type is 'custom' — the bot must return a task module dialog.
+teamsApp.OnMessageFetchTask((context, cancellationToken) =>
+{
+    context.Log.Info($"[HANDLER] Feedback fetch-task received");
+    return Task.FromResult(FeedbackHandler.HandleFeedbackFetchTask(context));
+});
+
+// Feedback submission handler (fires after the user submits the dialog above).
 teamsApp.OnFeedback((context, cancellationToken) =>
 {
     context.Log.Info($"[HANDLER] Feedback submission received");

--- a/Samples/Samples.AI/Samples.AI.csproj
+++ b/Samples/Samples.AI/Samples.AI.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="../../Libraries/Microsoft.Teams.Api/Microsoft.Teams.Api.csproj" />
     <ProjectReference Include="../../Libraries/Microsoft.Teams.Apps/Microsoft.Teams.Apps.csproj" />
+    <ProjectReference Include="../../Libraries/Microsoft.Teams.Cards/Microsoft.Teams.Cards.csproj" />
     <ProjectReference Include="../../Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Hosting/Microsoft.Teams.Extensions.Hosting.csproj" />
     <ProjectReference Include="../../Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore.DevTools/Microsoft.Teams.Plugins.AspNetCore.DevTools.csproj" />
   </ItemGroup>

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/Messages/FetchTaskActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/Messages/FetchTaskActivityTests.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Teams.Api.Activities;
+using Microsoft.Teams.Api.Activities.Invokes;
+using Microsoft.Teams.Api.Auth;
+using Microsoft.Teams.Apps.Activities.Invokes;
+using Microsoft.Teams.Apps.Annotations;
+using Microsoft.Teams.Apps.Testing.Plugins;
+
+using TaskModules = Microsoft.Teams.Api.TaskModules;
+
+namespace Microsoft.Teams.Apps.Tests.Activities;
+
+public class FetchTaskActivityTests
+{
+    private readonly App _app = new();
+    private readonly IToken _token = Globals.Token;
+    private readonly Controller _controller = new();
+
+    public FetchTaskActivityTests()
+    {
+        _app.AddPlugin(new TestPlugin());
+        _app.AddController(_controller);
+    }
+
+    private static Messages.FetchTaskActivity SetupFetchTaskActivity(string reaction = "like")
+    {
+        return new Messages.FetchTaskActivity
+        {
+            Value = new Messages.FetchTaskActivity.FetchTaskValue
+            {
+                Data = new Messages.FetchTaskActivity.FetchTaskData
+                {
+                    ActionValue = new Messages.FetchTaskActivity.FetchTaskActionValue
+                    {
+                        Reaction = new Reaction(reaction),
+                    },
+                },
+            },
+        };
+    }
+
+    [Fact]
+    public async Task Should_CallHandler()
+    {
+        var calls = 0;
+
+        _app.OnMessageFetchTask((context, ct) =>
+        {
+            calls++;
+            Assert.True(context.Activity.Type.IsInvoke);
+            Assert.True(context.Activity.Name == Name.Messages.FetchTask);
+            Assert.True(context.Activity.Value.Data.ActionValue.Reaction.IsLike);
+            return Task.FromResult(new Response<TaskModules.Response>(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo { Title = "Feedback" }))));
+        });
+
+        var res = await _app.Process<TestPlugin>(_token, SetupFetchTaskActivity());
+
+        Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
+        Assert.Equal(1, calls);
+        Assert.Equal(1, _controller.Calls);
+        Assert.Equal(2, res.Meta.Routes);
+    }
+
+    [Fact]
+    public async Task Should_Not_CallHandler_OnOtherActivity()
+    {
+        var calls = 0;
+
+        _app.OnMessageFetchTask((context, ct) =>
+        {
+            calls++;
+            return Task.FromResult(new Response<TaskModules.Response>(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo()))));
+        });
+
+        var res = await _app.Process<TestPlugin>(_token, new TypingActivity());
+
+        Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
+        Assert.Equal(0, calls);
+        Assert.Equal(0, _controller.Calls);
+        Assert.Equal(0, res.Meta.Routes);
+    }
+
+    [Fact]
+    public async Task Should_Not_CallHandler_OnSubmitAction()
+    {
+        var calls = 0;
+
+        _app.OnMessageFetchTask((context, ct) =>
+        {
+            calls++;
+            return Task.FromResult(new Response<TaskModules.Response>(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo()))));
+        });
+
+        var submit = new Messages.SubmitActionActivity
+        {
+            Value = new Messages.SubmitActionActivity.SubmitActionValue
+            {
+                ActionName = "feedback",
+                ActionValue = "test",
+            },
+        };
+
+        var res = await _app.Process<TestPlugin>(_token, submit);
+
+        Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
+        Assert.Equal(0, calls);
+    }
+
+    [Fact]
+    public async Task Should_CallHandler_OnDislikeReaction()
+    {
+        var calls = 0;
+
+        _app.OnMessageFetchTask((context, ct) =>
+        {
+            calls++;
+            Assert.True(context.Activity.Value.Data.ActionValue.Reaction.IsDislike);
+            return Task.FromResult(new Response<TaskModules.Response>(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo()))));
+        });
+
+        var res = await _app.Process<TestPlugin>(_token, SetupFetchTaskActivity("dislike"));
+
+        Assert.Equal(System.Net.HttpStatusCode.OK, res.Status);
+        Assert.Equal(1, calls);
+    }
+
+    [TeamsController]
+    public class Controller
+    {
+        public int Calls { get; private set; }
+
+        [Microsoft.Teams.Apps.Activities.Invokes.Message.FetchTask]
+        public void OnFetchTask([Context] IContext.Next next)
+        {
+            Calls++;
+            next();
+        }
+    }
+}

--- a/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/Messages/FetchTaskActivityTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/Activities/Invokes/Messages/FetchTaskActivityTests.cs
@@ -52,7 +52,7 @@ public class FetchTaskActivityTests
             Assert.True(context.Activity.Type.IsInvoke);
             Assert.True(context.Activity.Name == Name.Messages.FetchTask);
             Assert.True(context.Activity.Value.Data.ActionValue.Reaction.IsLike);
-            return Task.FromResult(new Response<TaskModules.Response>(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo { Title = "Feedback" }))));
+            return Task.FromResult(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo { Title = "Feedback" })));
         });
 
         var res = await _app.Process<TestPlugin>(_token, SetupFetchTaskActivity());
@@ -71,7 +71,7 @@ public class FetchTaskActivityTests
         _app.OnMessageFetchTask((context, ct) =>
         {
             calls++;
-            return Task.FromResult(new Response<TaskModules.Response>(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo()))));
+            return Task.FromResult(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo())));
         });
 
         var res = await _app.Process<TestPlugin>(_token, new TypingActivity());
@@ -90,7 +90,7 @@ public class FetchTaskActivityTests
         _app.OnMessageFetchTask((context, ct) =>
         {
             calls++;
-            return Task.FromResult(new Response<TaskModules.Response>(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo()))));
+            return Task.FromResult(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo())));
         });
 
         var submit = new Messages.SubmitActionActivity
@@ -117,7 +117,7 @@ public class FetchTaskActivityTests
         {
             calls++;
             Assert.True(context.Activity.Value.Data.ActionValue.Reaction.IsDislike);
-            return Task.FromResult(new Response<TaskModules.Response>(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo()))));
+            return Task.FromResult(new TaskModules.Response(new TaskModules.ContinueTask(new TaskModules.TaskInfo())));
         });
 
         var res = await _app.Process<TestPlugin>(_token, SetupFetchTaskActivity("dislike"));
@@ -139,3 +139,4 @@ public class FetchTaskActivityTests
         }
     }
 }
+


### PR DESCRIPTION
Custom Feedback Context:
[Learn Doc](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bot-messages-ai-generated-content?tabs=desktop%2Cjs%2Cbotmessage#feedback-buttons)

- previously we had a flag called feedbackLoopEnabled which only enables the default feedback form
- now, we have a param called feedbackLoop that can either be default or custom.
- updated AI sample to feature the custom feedback loop
- also included the normalization to feedbackLoop when using withChannelData..
- py equivalent: https://github.com/microsoft/teams.py/pull/349
- ts equivalent: https://github.com/microsoft/teams.ts/pull/522