### PR TITLE
Tighten AdditionalAllowedDomains API contract

### DIFF
--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -41,7 +41,7 @@ public partial class App
     internal IServiceProvider? Provider { get; set; }
     internal IContainer Container { get; set; }
 
-    internal readonly IReadOnlyList<string>? _additionalAllowedDomains;
+    private readonly IReadOnlyList<string>? _additionalAllowedDomains;
     private readonly CloudEnvironment _cloud;
     internal string UserAgent
     {

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -41,7 +41,7 @@ public partial class App
     internal IServiceProvider? Provider { get; set; }
     internal IContainer Container { get; set; }
 
-    private readonly IEnumerable<string>? _additionalAllowedDomains;
+    internal readonly IReadOnlyList<string>? _additionalAllowedDomains;
     private readonly CloudEnvironment _cloud;
     internal string UserAgent
     {
@@ -63,7 +63,9 @@ public partial class App
         Plugins = options?.Plugins ?? [];
         OAuth = options?.OAuth ?? new OAuthSettings();
         Provider = options?.Provider;
-        _additionalAllowedDomains = options?.AdditionalAllowedDomains;
+        // Defensive copy so a caller-provided list can't mutate validator behavior
+        // after construction (IEnumerable may be lazy or mutable).
+        _additionalAllowedDomains = options?.AdditionalAllowedDomains?.ToList();
 
         if (_additionalAllowedDomains?.Contains("*") == true)
         {

--- a/Libraries/Microsoft.Teams.Apps/AppOptions.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppOptions.cs
@@ -19,9 +19,12 @@ public class AppOptions
     public CloudEnvironment? Cloud { get; set; }
 
     /// <summary>
-    /// Additional allowed service URL hostnames beyond the built-in defaults.
-    /// Use this if your bot receives activities from non-standard channels.
+    /// Additional service URL hostnames accepted beyond the cloud preset.
+    /// Entries must be bare hostnames matched exactly (case-insensitive)
+    /// wildcard patterns like <c>"*.example.com"</c>, URL suffixes, or full URLs are NOT supported.
+    /// Pass <c>["*"]</c> as the sole wildcard to accept any hostname (disables service-URL validation).
     /// </summary>
+    /// <example>new[] { "api.my-custom-channel.com" }</example>
     public IEnumerable<string>? AdditionalAllowedDomains { get; set; }
 
     public AppOptions()

--- a/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
@@ -368,45 +368,27 @@ public class AppTests
     }
 
     [Fact]
-    public void Test_App_AdditionalAllowedDomains_DefensivelyCopied()
-    {
-        // Guards against a future regression: if App stored the caller's IEnumerable
-        // by reference, post-construction mutation (or lazy re-enumeration) could
-        // change validator behavior at runtime.
-        var mutableList = new List<string> { "first.example.com" };
-        var options = new AppOptions { AdditionalAllowedDomains = mutableList };
-        var app = new App(options);
-
-        mutableList.Add("mutation.example.com");
-
-        Assert.NotNull(app._additionalAllowedDomains);
-        Assert.Single(app._additionalAllowedDomains);
-        Assert.Equal("first.example.com", app._additionalAllowedDomains[0]);
-    }
-
-    [Fact]
-    public void Test_App_AdditionalAllowedDomains_NullStaysNull()
+    public void Test_App_AdditionalAllowedDomains_NullConstructionSucceeds()
     {
         var options = new AppOptions { AdditionalAllowedDomains = null };
-        var app = new App(options);
-        Assert.Null(app._additionalAllowedDomains);
+        var exception = Record.Exception(() => new App(options));
+        Assert.Null(exception);
     }
 
     [Fact]
-    public void Test_App_AdditionalAllowedDomains_EmptyListPreserved()
+    public void Test_App_AdditionalAllowedDomains_EmptyConstructionSucceeds()
     {
         var options = new AppOptions { AdditionalAllowedDomains = Array.Empty<string>() };
-        var app = new App(options);
-
-        Assert.NotNull(app._additionalAllowedDomains);
-        Assert.Empty(app._additionalAllowedDomains);
+        var exception = Record.Exception(() => new App(options));
+        Assert.Null(exception);
     }
 
     [Fact]
     public void Test_App_AdditionalAllowedDomains_MaterializesLazyEnumerable()
     {
-        // Lazy IEnumerable is materialized at construction so late evaluation
-        // cannot alter validator behavior.
+        // A lazy IEnumerable must be materialized at construction (not held and
+        // re-enumerated later), otherwise mutation between iterations could change
+        // validator behavior. Asserts the caller's lazy is invoked exactly once.
         var callCount = 0;
         IEnumerable<string> Lazy()
         {
@@ -415,11 +397,9 @@ public class AppTests
         }
 
         var options = new AppOptions { AdditionalAllowedDomains = Lazy() };
-        var app = new App(options);
+        _ = new App(options);
 
         Assert.Equal(1, callCount);
-        Assert.NotNull(app._additionalAllowedDomains);
-        Assert.Single(app._additionalAllowedDomains);
     }
 
 }

--- a/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
+++ b/Tests/Microsoft.Teams.Apps.Tests/AppTests.cs
@@ -367,4 +367,59 @@ public class AppTests
             app.Reply("19:abc@thread.skype", "not-a-number", new MessageActivity("Hello")));
     }
 
+    [Fact]
+    public void Test_App_AdditionalAllowedDomains_DefensivelyCopied()
+    {
+        // Guards against a future regression: if App stored the caller's IEnumerable
+        // by reference, post-construction mutation (or lazy re-enumeration) could
+        // change validator behavior at runtime.
+        var mutableList = new List<string> { "first.example.com" };
+        var options = new AppOptions { AdditionalAllowedDomains = mutableList };
+        var app = new App(options);
+
+        mutableList.Add("mutation.example.com");
+
+        Assert.NotNull(app._additionalAllowedDomains);
+        Assert.Single(app._additionalAllowedDomains);
+        Assert.Equal("first.example.com", app._additionalAllowedDomains[0]);
+    }
+
+    [Fact]
+    public void Test_App_AdditionalAllowedDomains_NullStaysNull()
+    {
+        var options = new AppOptions { AdditionalAllowedDomains = null };
+        var app = new App(options);
+        Assert.Null(app._additionalAllowedDomains);
+    }
+
+    [Fact]
+    public void Test_App_AdditionalAllowedDomains_EmptyListPreserved()
+    {
+        var options = new AppOptions { AdditionalAllowedDomains = Array.Empty<string>() };
+        var app = new App(options);
+
+        Assert.NotNull(app._additionalAllowedDomains);
+        Assert.Empty(app._additionalAllowedDomains);
+    }
+
+    [Fact]
+    public void Test_App_AdditionalAllowedDomains_MaterializesLazyEnumerable()
+    {
+        // Lazy IEnumerable is materialized at construction so late evaluation
+        // cannot alter validator behavior.
+        var callCount = 0;
+        IEnumerable<string> Lazy()
+        {
+            callCount++;
+            yield return "api.custom-channel.com";
+        }
+
+        var options = new AppOptions { AdditionalAllowedDomains = Lazy() };
+        var app = new App(options);
+
+        Assert.Equal(1, callCount);
+        Assert.NotNull(app._additionalAllowedDomains);
+        Assert.Single(app._additionalAllowedDomains);
+    }
+
 }


### PR DESCRIPTION
Follow-up to the allowlist feature (shipped via #418). No runtime behavior change for correct callers. Adds hardening informed by review feedback on the sibling Python PR (microsoft/teams.py#404):

  1. Docstring clarity. `AppOptions.AdditionalAllowedDomains` XML doc now documents that entries must be bare hostnames matched exactly (case-insensitive); wildcard patterns like `"*.example.com"`, URL suffixes, and full URLs are NOT supported. `["*"]` is the sole wildcard, used as a disable-validation sentinel.
  2. Defensive copy. `App` no longer stores the caller's `IEnumerable<string>` by reference. A post-construction mutation of the collection would previously have changed validator behavior at runtime; now it is isolated.
  3. Tests verifying the new contract: lazy enumerable materialization, null input, empty input.