### PR TITLE
Remove unused allowed service URL properties

### DIFF
--- a/Libraries/Microsoft.Teams.Api/Auth/CloudEnvironment.cs
+++ b/Libraries/Microsoft.Teams.Api/Auth/CloudEnvironment.cs
@@ -45,11 +45,6 @@ public class CloudEnvironment
     /// </summary>
     public string GraphScope { get; }
 
-    /// <summary>
-    /// Allowed service URL hostnames for this cloud environment.
-    /// </summary>
-    public IReadOnlyList<string> AllowedServiceUrls { get; }
-
     public CloudEnvironment(
         string loginEndpoint,
         string loginTenant,
@@ -57,8 +52,7 @@ public class CloudEnvironment
         string tokenServiceUrl,
         string openIdMetadataUrl,
         string tokenIssuer,
-        string graphScope,
-        string[]? allowedServiceUrls = null)
+        string graphScope)
     {
         LoginEndpoint = loginEndpoint.TrimEnd('/');
         LoginTenant = loginTenant;
@@ -67,7 +61,6 @@ public class CloudEnvironment
         OpenIdMetadataUrl = openIdMetadataUrl;
         TokenIssuer = tokenIssuer;
         GraphScope = graphScope;
-        AllowedServiceUrls = allowedServiceUrls is not null ? Array.AsReadOnly(allowedServiceUrls) : [];
     }
 
     /// <summary>
@@ -80,8 +73,7 @@ public class CloudEnvironment
         tokenServiceUrl: "https://token.botframework.com",
         openIdMetadataUrl: "https://login.botframework.com/v1/.well-known/openidconfiguration",
         tokenIssuer: "https://api.botframework.com",
-        graphScope: "https://graph.microsoft.com/.default",
-        allowedServiceUrls: ["smba.trafficmanager.net", "smba.onyx.prod.teams.trafficmanager.net", "smba.infra.gcc.teams.microsoft.com"]
+        graphScope: "https://graph.microsoft.com/.default"
     );
 
     /// <summary>
@@ -94,8 +86,7 @@ public class CloudEnvironment
         tokenServiceUrl: "https://tokengcch.botframework.azure.us",
         openIdMetadataUrl: "https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
         tokenIssuer: "https://api.botframework.us",
-        graphScope: "https://graph.microsoft.us/.default",
-        allowedServiceUrls: ["smba.infra.gov.teams.microsoft.us"]
+        graphScope: "https://graph.microsoft.us/.default"
     );
 
     /// <summary>
@@ -108,8 +99,7 @@ public class CloudEnvironment
         tokenServiceUrl: "https://apiDoD.botframework.azure.us",
         openIdMetadataUrl: "https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
         tokenIssuer: "https://api.botframework.us",
-        graphScope: "https://dod-graph.microsoft.us/.default",
-        allowedServiceUrls: ["smba.infra.dod.teams.microsoft.us"]
+        graphScope: "https://dod-graph.microsoft.us/.default"
     );
 
     /// <summary>
@@ -122,8 +112,7 @@ public class CloudEnvironment
         tokenServiceUrl: "https://token.botframework.azure.cn",
         openIdMetadataUrl: "https://login.botframework.azure.cn/v1/.well-known/openidconfiguration",
         tokenIssuer: "https://api.botframework.azure.cn",
-        graphScope: "https://microsoftgraph.chinacloudapi.cn/.default",
-        allowedServiceUrls: ["frontend.botapi.msg.infra.teams.microsoftonline.cn"]
+        graphScope: "https://microsoftgraph.chinacloudapi.cn/.default"
     );
 
     /// <summary>
@@ -137,12 +126,11 @@ public class CloudEnvironment
         string? tokenServiceUrl = null,
         string? openIdMetadataUrl = null,
         string? tokenIssuer = null,
-        string? graphScope = null,
-        string[]? allowedServiceUrls = null)
+        string? graphScope = null)
     {
         if (loginEndpoint is null && loginTenant is null && botScope is null &&
             tokenServiceUrl is null && openIdMetadataUrl is null && tokenIssuer is null &&
-            graphScope is null && allowedServiceUrls is null)
+            graphScope is null)
         {
             return this;
         }
@@ -154,8 +142,7 @@ public class CloudEnvironment
             tokenServiceUrl ?? TokenServiceUrl,
             openIdMetadataUrl ?? OpenIdMetadataUrl,
             tokenIssuer ?? TokenIssuer,
-            graphScope ?? GraphScope,
-            allowedServiceUrls ?? [.. AllowedServiceUrls]
+            graphScope ?? GraphScope
         );
     }
 

--- a/Libraries/Microsoft.Teams.Apps/App.cs
+++ b/Libraries/Microsoft.Teams.Apps/App.cs
@@ -41,8 +41,6 @@ public partial class App
     internal IServiceProvider? Provider { get; set; }
     internal IContainer Container { get; set; }
 
-    private readonly IEnumerable<string>? _additionalAllowedDomains;
-    private readonly CloudEnvironment _cloud;
     internal string UserAgent
     {
         get
@@ -55,7 +53,6 @@ public partial class App
     public App(AppOptions? options = null)
     {
         var cloud = options?.Cloud ?? CloudEnvironment.Public;
-        _cloud = cloud;
 
         Logger = options?.Logger ?? new ConsoleLogger();
         Storage = options?.Storage ?? new LocalStorage<object>();
@@ -386,11 +383,6 @@ public partial class App
         Logger.Debug(path);
 
         var serviceUrl = @event.Activity.ServiceUrl ?? @event.Token.ServiceUrl;
-        if (!ServiceUrlValidator.IsAllowed(serviceUrl, _cloud, _additionalAllowedDomains))
-        {
-            Logger.Warn($"Rejected service URL: {serviceUrl}");
-            throw new InvalidOperationException("Service URL is not from an allowed domain");
-        }
 
         var reference = new ConversationReference()
         {

--- a/Libraries/Microsoft.Teams.Apps/AppOptions.cs
+++ b/Libraries/Microsoft.Teams.Apps/AppOptions.cs
@@ -18,12 +18,6 @@ public class AppOptions
     public OAuthSettings OAuth { get; set; } = new OAuthSettings();
     public CloudEnvironment? Cloud { get; set; }
 
-    /// <summary>
-    /// Additional allowed service URL hostnames beyond the built-in defaults.
-    /// Use this if your bot receives activities from non-standard channels.
-    /// </summary>
-    public IEnumerable<string>? AdditionalAllowedDomains { get; set; }
-
     public AppOptions()
     {
 

--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
@@ -11,7 +11,6 @@ public class TeamsSettings
     public string? ClientSecret { get; set; }
     public string? TenantId { get; set; }
     public string? Cloud { get; set; }
-    public string[]? AdditionalAllowedDomains { get; set; }
 
     /// <summary>Override the Azure AD login endpoint.</summary>
     public string? LoginEndpoint { get; set; }
@@ -79,11 +78,6 @@ public class TeamsSettings
         else if (options.Credentials is ClientCredentials existingCredentials)
         {
             existingCredentials.Cloud = cloud;
-        }
-
-        if (AdditionalAllowedDomains is { Length: > 0 })
-        {
-            options.AdditionalAllowedDomains = AdditionalAllowedDomains;
         }
 
         return options;


### PR DESCRIPTION
Eliminate unused properties related to allowed service URLs from the `CloudEnvironment`, `App`, `AppOptions`, and `TeamsSettings` classes to streamline the codebase.