### PR TITLE
Fix HttpStream Close() race + AddStreamFinal() streamType override

### DIFF
--- a/Libraries/Microsoft.Teams.Api/Activities/Message/MessageActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Message/MessageActivity.cs
@@ -208,7 +208,7 @@ public class MessageActivity : Activity
     public MessageActivity AddStreamFinal()
     {
         ChannelData ??= new();
-        ChannelData.StreamId = Id;
+        ChannelData.StreamId ??= Id;
         ChannelData.StreamType = StreamType.Final;
 
         AddEntity(new StreamInfoEntity()

--- a/Libraries/Microsoft.Teams.Api/Activities/Message/MessageActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Message/MessageActivity.cs
@@ -208,8 +208,8 @@ public class MessageActivity : Activity
     public MessageActivity AddStreamFinal()
     {
         ChannelData ??= new();
-        ChannelData.StreamId ??= Id;
-        ChannelData.StreamType ??= StreamType.Final;
+        ChannelData.StreamId = Id;
+        ChannelData.StreamType = StreamType.Final;
 
         AddEntity(new StreamInfoEntity()
         {

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.Stream.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.Stream.cs
@@ -87,7 +87,9 @@ public partial class AspNetCorePlugin
         {
             if (_index == 1 && _queue.Count == 0 && _lock.CurrentCount > 0) return null;
             if (_result is not null) return _result;
-            while (_id is null || _queue.Count > 0)
+            // _lock.CurrentCount == 0 means Flush() is mid-await (queue drained but SendActivity calls
+            // still pending). Wait it out so the final message doesn't race in-flight chunks.
+            while (_id is null || _queue.Count > 0 || _lock.CurrentCount == 0)
             {
                 await Task.Delay(50, cancellationToken);
             }

--- a/Tests/Microsoft.Teams.Api.Tests/Activities/Message/MessageActivityTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/Activities/Message/MessageActivityTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 using Microsoft.Teams.Api.Activities;
+using Microsoft.Teams.Api.Entities;
 
 namespace Microsoft.Teams.Api.Tests.Activities;
 
@@ -547,7 +548,7 @@ public class MessageActivityTests
         var msg = new MessageActivity("Hello")
             .WithDeliveryMode(DeliveryMode.Notification)
             .WithRecipient(new Account() { Id = "user-123", Name = "Test User", Role = Role.User }, true)
-            .WithImportance(Importance.High); 
+            .WithImportance(Importance.High);
 
         Assert.Equal("Hello", msg.Text);
         Assert.True(msg.Recipient.IsTargeted);
@@ -555,5 +556,25 @@ public class MessageActivityTests
         Assert.Equal("user-123", msg.Recipient.Id);
         Assert.Equal("Test User", msg.Recipient.Name);
         Assert.Equal(Role.User, msg.Recipient.Role);
+    }
+
+    [Fact]
+    public void AddStreamFinal_OverridesExistingStreamType()
+    {
+        var activity = new MessageActivity("done")
+        {
+            Id = "stream-1",
+            ChannelData = new ChannelData { StreamType = StreamType.Informative }
+        };
+
+        activity.AddStreamFinal();
+
+        Assert.Equal(StreamType.Final, activity.ChannelData.StreamType);
+        Assert.Equal("stream-1", activity.ChannelData.StreamId);
+
+        var streamInfo = activity.Entities?.OfType<Microsoft.Teams.Api.Entities.StreamInfoEntity>().Single();
+        Assert.NotNull(streamInfo);
+        Assert.Equal(StreamType.Final, streamInfo.StreamType);
+        Assert.Equal("stream-1", streamInfo.StreamId);
     }
 }

--- a/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginStreamTests.cs
+++ b/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginStreamTests.cs
@@ -117,4 +117,89 @@ public class AspNetCorePluginStreamTests
         Assert.Equal(StreamType.Informative, ((TypingActivity)sentActivity).ChannelData?.StreamType);
     }
 
+    [Fact]
+    public async Task Stream_Close_FinalMessageHasStreamTypeFinal_AfterInformativeUpdate()
+    {
+        var sentActivities = new List<IActivity>();
+        var sendCallCount = 0;
+        var stream = new AspNetCorePlugin.Stream
+        {
+            Send = activity =>
+            {
+                sendCallCount++;
+                sentActivities.Add(activity);
+                activity.Id = $"id-{sendCallCount}";
+                return Task.FromResult(activity);
+            }
+        };
+
+        stream.Update("Thinking...");
+        await Task.Delay(700);
+
+        stream.Emit("Done");
+        await Task.Delay(700);
+
+        var result = await stream.Close();
+
+        Assert.NotNull(result);
+        // Final message must have StreamType.Final, not the accumulated Informative
+        // from the prior typing update.
+        Assert.Equal(StreamType.Final, result.ChannelData?.StreamType);
+
+        // The streaminfo entity on the final message should also be Final.
+        var streamInfo = result.Entities?.OfType<StreamInfoEntity>().Single();
+        Assert.NotNull(streamInfo);
+        Assert.Equal(StreamType.Final, streamInfo.StreamType);
+    }
+
+    [Fact]
+    public async Task Stream_Close_WaitsForInFlightFlushToComplete()
+    {
+        var sendCallCount = 0;
+        var secondSendStarted = new TaskCompletionSource<bool>();
+        var secondSendRelease = new TaskCompletionSource<bool>();
+        var stream = new AspNetCorePlugin.Stream
+        {
+            Send = async activity =>
+            {
+                sendCallCount++;
+                var thisCall = sendCallCount;
+                if (thisCall == 2)
+                {
+                    secondSendStarted.TrySetResult(true);
+                    await secondSendRelease.Task;
+                }
+                activity.Id = $"id-{thisCall}";
+                return activity;
+            }
+        };
+
+        // First flush: completes immediately and sets _id (so subsequent races aren't masked
+        // by the existing `_id is null` check).
+        stream.Emit("chunk 1");
+        await Task.Delay(700);
+        Assert.Equal(1, sendCallCount);
+
+        // Second flush: Send blocks indefinitely → queue drained, _id set, _lock held.
+        stream.Emit("chunk 2");
+        await Task.Delay(700);
+        await secondSendStarted.Task;
+
+        var closeTask = stream.Close();
+
+        // With the race-fix, Close() must not progress past its wait loop while the
+        // flush is mid-await. Pre-fix, closeTask would race ahead and call Send for the
+        // final activity (sendCallCount → 3) before we release the second flush.
+        await Task.Delay(200);
+        Assert.False(closeTask.IsCompleted);
+        Assert.Equal(2, sendCallCount);
+
+        // Releasing the second flush lets the lock drop, and Close() then sends the final.
+        secondSendRelease.SetResult(true);
+
+        var result = await closeTask;
+
+        Assert.NotNull(result);
+        Assert.Equal(3, sendCallCount);
+    }
 }

--- a/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginStreamTests.cs
+++ b/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginStreamTests.cs
@@ -153,9 +153,9 @@ public class AspNetCorePluginStreamTests
     public async Task Stream_Close_WaitsForInFlightFlushToComplete()
     {
         var sendCallCount = 0;
-        var firstSendCompleted = new TaskCompletionSource<bool>();
-        var secondSendStarted = new TaskCompletionSource<bool>();
-        var secondSendRelease = new TaskCompletionSource<bool>();
+        var firstSendCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondSendStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondSendRelease = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var stream = new AspNetCorePlugin.Stream
         {
             Send = async activity =>
@@ -177,13 +177,13 @@ public class AspNetCorePluginStreamTests
         // signal from the Send delegate). _id is assigned by the SendActivity helper after
         // the await — yielding once lets that post-await code run before we proceed.
         stream.Emit("chunk 1");
-        await firstSendCompleted.Task;
+        await firstSendCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await Task.Yield();
         Assert.Equal(1, sendCallCount);
 
         // Second flush: Send blocks → queue drained, _id set, _lock held.
         stream.Emit("chunk 2");
-        await secondSendStarted.Task;
+        await secondSendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
 
         var closeTask = stream.Close();
 
@@ -200,7 +200,7 @@ public class AspNetCorePluginStreamTests
         // Releasing the second flush lets the lock drop, and Close() then sends the final.
         secondSendRelease.SetResult(true);
 
-        var result = await closeTask;
+        var result = await closeTask.WaitAsync(TimeSpan.FromSeconds(2));
 
         Assert.NotNull(result);
         Assert.Equal(3, sendCallCount);

--- a/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginStreamTests.cs
+++ b/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginStreamTests.cs
@@ -120,24 +120,21 @@ public class AspNetCorePluginStreamTests
     [Fact]
     public async Task Stream_Close_FinalMessageHasStreamTypeFinal_AfterInformativeUpdate()
     {
-        var sentActivities = new List<IActivity>();
         var sendCallCount = 0;
         var stream = new AspNetCorePlugin.Stream
         {
             Send = activity =>
             {
                 sendCallCount++;
-                sentActivities.Add(activity);
                 activity.Id = $"id-{sendCallCount}";
                 return Task.FromResult(activity);
             }
         };
 
+        // Update + Emit both queue activities; Close() waits for the flush to drain the
+        // queue and complete, so no fixed sleeps are needed.
         stream.Update("Thinking...");
-        await Task.Delay(700);
-
         stream.Emit("Done");
-        await Task.Delay(700);
 
         var result = await stream.Close();
 
@@ -156,6 +153,7 @@ public class AspNetCorePluginStreamTests
     public async Task Stream_Close_WaitsForInFlightFlushToComplete()
     {
         var sendCallCount = 0;
+        var firstSendCompleted = new TaskCompletionSource<bool>();
         var secondSendStarted = new TaskCompletionSource<bool>();
         var secondSendRelease = new TaskCompletionSource<bool>();
         var stream = new AspNetCorePlugin.Stream
@@ -170,19 +168,21 @@ public class AspNetCorePluginStreamTests
                     await secondSendRelease.Task;
                 }
                 activity.Id = $"id-{thisCall}";
+                if (thisCall == 1) firstSendCompleted.TrySetResult(true);
                 return activity;
             }
         };
 
-        // First flush: completes immediately and sets _id (so subsequent races aren't masked
-        // by the existing `_id is null` check).
+        // First flush: emit and wait for the send to actually complete (deterministic
+        // signal from the Send delegate). _id is assigned by the SendActivity helper after
+        // the await — yielding once lets that post-await code run before we proceed.
         stream.Emit("chunk 1");
-        await Task.Delay(700);
+        await firstSendCompleted.Task;
+        await Task.Yield();
         Assert.Equal(1, sendCallCount);
 
-        // Second flush: Send blocks indefinitely → queue drained, _id set, _lock held.
+        // Second flush: Send blocks → queue drained, _id set, _lock held.
         stream.Emit("chunk 2");
-        await Task.Delay(700);
         await secondSendStarted.Task;
 
         var closeTask = stream.Close();
@@ -190,7 +190,10 @@ public class AspNetCorePluginStreamTests
         // With the race-fix, Close() must not progress past its wait loop while the
         // flush is mid-await. Pre-fix, closeTask would race ahead and call Send for the
         // final activity (sendCallCount → 3) before we release the second flush.
-        await Task.Delay(200);
+        // We yield several times rather than sleep — Close() polls every 50ms and we
+        // want to give it ample chance to make progress if the bug is present.
+        for (var i = 0; i < 10; i++) await Task.Yield();
+        await Task.Delay(100);
         Assert.False(closeTask.IsCompleted);
         Assert.Equal(2, sendCallCount);
 


### PR DESCRIPTION
Fixes #473

## Summary

Two bugs in the streaming path. Parity of [microsoft/teams.ts#553](https://github.com/microsoft/teams.ts/pull/553), but Bug 1 manifests via a different mechanism in C# (`??=`) than in TS.

### Bug 1: `AddStreamFinal()` cannot override existing `ChannelData.StreamType`

`MessageActivity.AddStreamFinal()` used null-coalescing assignment:

```csharp
ChannelData.StreamType ??= StreamType.Final;
```

In the streaming `Close()` path:

1. `Stream.Update("Thinking...")` accumulates `StreamType.Informative` into `_channelData`.
2. `Close()` calls `WithData(_channelData)`, populating `activity.ChannelData.StreamType = Informative`.
3. `AddStreamFinal()` runs `??=` against `Informative` → **no-op**. The wire `channelData.streamType` stays as `"informative"` on the final message, even though the `streaminfo` entity correctly has `"final"`.

**Fix:** direct assignment. The method's contract per its name is to mark the activity as a final stream message, so it must be able to override prior values.

> **Note:** This is a minor public-API behavior change. Any caller that pre-set `ChannelData.StreamType` and then called `AddStreamFinal()` expecting their value to persist will now have it overridden. The method's name and contract make the override semantic the obvious one; we judged this acceptable.

### Bug 2: Race condition in `Stream.Close()`

`Close()`'s wait loop checked `_id` and `_queue` but not whether `Flush()` was holding `_lock`. During a flush mid-await (queue drained, `SendActivity()` awaits pending), `Close()` would exit the loop and send the final activity, racing the in-flight chunk.

**Fix:** also wait while `_lock.CurrentCount == 0` (semaphore held). This is the same primitive already used in `Close()`'s early-return guard on line 88.

## Changes

- `Libraries/Microsoft.Teams.Api/Activities/Message/MessageActivity.cs` — `AddStreamFinal()` direct assignment.
- `Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.Stream.cs` — `Close()` lock-aware wait.
- Tests in `MessageActivityTests.cs` and `AspNetCorePluginStreamTests.cs`.

## Test plan

- [x] `AddStreamFinal_OverridesExistingStreamType` — `MessageActivity` with `StreamType.Informative` pre-set, `AddStreamFinal()` overrides to `Final`.
- [x] `Stream_Close_FinalMessageHasStreamTypeFinal_AfterInformativeUpdate` — full Update→Emit→Close flow asserts final activity has `StreamType.Final` on both `ChannelData` and the `streaminfo` entity.
- [x] `Stream_Close_WaitsForInFlightFlushToComplete` — uses a controllable `Send` delegate to block the second flush mid-await; asserts `Close()` does not progress until the lock releases.
- [x] All existing `MessageActivityTests` (21 passed) and `AspNetCorePluginStreamTests` (6 passed) still pass on net10.0. (net8.0 testhost not installed locally; CI will cover.)
- [x] Full solution builds clean.