### PR TITLE
MCP Server Example 

### DIFF
--- a/core/core.slnx
+++ b/core/core.slnx
@@ -16,6 +16,7 @@
     <Project Path="samples/CompatProactive/CompatProactive.csproj" Id="60e946ea-ea2f-4994-8b5b-e6aa98723aa4" />
     <Project Path="samples/CoreBot/CoreBot.csproj" Id="142a67bc-68e7-4020-83cf-51423e317b53" />
     <Project Path="samples/CustomHosting/CustomHosting.csproj" Id="de2e42de-3d8f-4a9d-920f-14c7e39fc3c0" />
+    <Project Path="samples/McpServer/McpServer.csproj" />
     <Project Path="samples/MeetingsBot/MeetingsBot.csproj" />
     <Project Path="samples/MessageExtensionBot/MessageExtensionBot.csproj" />
     <Project Path="samples/OAuthFlowBot/OAuthFlowBot.csproj" />

--- a/core/samples/McpServer/Cards.cs
+++ b/core/samples/McpServer/Cards.cs
@@ -1,61 +1,57 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Text.Json.Nodes;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Teams.Cards;
+using Microsoft.Teams.Common;
 
 namespace McpServer;
 
 public static class Cards
 {
-    // Action.Execute fires an `adaptiveCard/action` invoke that lands in
-    // OnAdaptiveCardAction; the `verb` field tells that handler which kind of
-    // card click this is (here, "approval_response"). Action.Submit would
-    // route elsewhere and wouldn't reach the same handler.
-    public static JsonObject ApprovalCard(string approvalId, string title, string description) => new()
+    private static readonly JsonSerializerOptions SerializerOptions = new()
     {
-        ["type"] = "AdaptiveCard",
-        ["version"] = "1.4",
-        ["body"] = new JsonArray
-        {
-            new JsonObject
-            {
-                ["type"] = "TextBlock",
-                ["text"] = title,
-                ["weight"] = "Bolder",
-                ["size"] = "Large",
-                ["wrap"] = true
-            },
-            new JsonObject
-            {
-                ["type"] = "TextBlock",
-                ["text"] = description,
-                ["wrap"] = true
-            }
-        },
-        ["actions"] = new JsonArray
-        {
-            new JsonObject
-            {
-                ["type"] = "Action.Execute",
-                ["title"] = "Approve",
-                ["verb"] = "approval_response",
-                ["data"] = new JsonObject
-                {
-                    ["approval_id"] = approvalId,
-                    ["decision"] = "approved"
-                }
-            },
-            new JsonObject
-            {
-                ["type"] = "Action.Execute",
-                ["title"] = "Reject",
-                ["verb"] = "approval_response",
-                ["data"] = new JsonObject
-                {
-                    ["approval_id"] = approvalId,
-                    ["decision"] = "rejected"
-                }
-            }
-        }
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
+
+    public static JsonElement ApprovalCard(string approvalId, string title, string description)
+    {
+        AdaptiveCard card = new(
+            new TextBlock(title) { Weight = TextWeight.Bolder, Size = TextSize.Large, Wrap = true },
+            new TextBlock(description) { Wrap = true })
+        {
+            Version = Microsoft.Teams.Cards.Version.Version1_4,
+            Actions = new List<Microsoft.Teams.Cards.Action>
+            {
+                new ExecuteAction
+                {
+                    Title = "Approve",
+                    Verb = "approval_response",
+                    Data = new Union<string, SubmitActionData>(new SubmitActionData
+                    {
+                        NonSchemaProperties = new Dictionary<string, object?>
+                        {
+                            ["approval_id"] = approvalId,
+                            ["decision"] = ApprovalStatus.Approved
+                        }
+                    })
+                },
+                new ExecuteAction
+                {
+                    Title = "Reject",
+                    Verb = "approval_response",
+                    Data = new Union<string, SubmitActionData>(new SubmitActionData
+                    {
+                        NonSchemaProperties = new Dictionary<string, object?>
+                        {
+                            ["approval_id"] = approvalId,
+                            ["decision"] = ApprovalStatus.Rejected
+                        }
+                    })
+                }
+            }
+        };
+        return JsonSerializer.SerializeToElement(card, SerializerOptions);
+    }
 }

--- a/core/samples/McpServer/Cards.cs
+++ b/core/samples/McpServer/Cards.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Nodes;
+
+namespace McpServer;
+
+public static class Cards
+{
+    // Action.Execute fires an `adaptiveCard/action` invoke that lands in
+    // OnAdaptiveCardAction; the `verb` field tells that handler which kind of
+    // card click this is (here, "approval_response"). Action.Submit would
+    // route elsewhere and wouldn't reach the same handler.
+    public static JsonObject ApprovalCard(string approvalId, string title, string description) => new()
+    {
+        ["type"] = "AdaptiveCard",
+        ["version"] = "1.4",
+        ["body"] = new JsonArray
+        {
+            new JsonObject
+            {
+                ["type"] = "TextBlock",
+                ["text"] = title,
+                ["weight"] = "Bolder",
+                ["size"] = "Large",
+                ["wrap"] = true
+            },
+            new JsonObject
+            {
+                ["type"] = "TextBlock",
+                ["text"] = description,
+                ["wrap"] = true
+            }
+        },
+        ["actions"] = new JsonArray
+        {
+            new JsonObject
+            {
+                ["type"] = "Action.Execute",
+                ["title"] = "Approve",
+                ["verb"] = "approval_response",
+                ["data"] = new JsonObject
+                {
+                    ["approval_id"] = approvalId,
+                    ["decision"] = "approved"
+                }
+            },
+            new JsonObject
+            {
+                ["type"] = "Action.Execute",
+                ["title"] = "Reject",
+                ["verb"] = "approval_response",
+                ["data"] = new JsonObject
+                {
+                    ["approval_id"] = approvalId,
+                    ["decision"] = "rejected"
+                }
+            }
+        }
+    };
+}

--- a/core/samples/McpServer/McpServer.csproj
+++ b/core/samples/McpServer/McpServer.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Teams.Apps\Microsoft.Teams.Apps.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/core/samples/McpServer/McpServer.csproj
+++ b/core/samples/McpServer/McpServer.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Teams.Apps\Microsoft.Teams.Apps.csproj" />
+    <PackageReference Include="Microsoft.Teams.Cards" Version="2.0.6" />
   </ItemGroup>
 
 </Project>

--- a/core/samples/McpServer/McpTools.cs
+++ b/core/samples/McpServer/McpTools.cs
@@ -23,7 +23,7 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
         CancellationToken cancellationToken = default)
     {
         string conversationId = await GetOrCreateConversationAsync(userId, cancellationToken);
-        await app.Send(conversationId, message, cancellationToken: cancellationToken);
+        await app.Send(conversationId, message, state.ServiceUrl, cancellationToken);
         return new NotifyResult(Notified: true, UserId: userId);
     }
 
@@ -37,7 +37,7 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
     {
         string conversationId = await GetOrCreateConversationAsync(userId, cancellationToken);
         string requestId = Guid.NewGuid().ToString();
-        await app.Send(conversationId, question, cancellationToken: cancellationToken);
+        await app.Send(conversationId, question, state.ServiceUrl, cancellationToken);
         // The user's next message looks up these entries and flips status to 'answered'.
         state.PendingAsks[requestId] = new PendingAsk { UserId = userId };
         state.UserPendingAsk[userId] = requestId;
@@ -67,13 +67,9 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
         string conversationId = await GetOrCreateConversationAsync(userId, cancellationToken);
         string approvalId = Guid.NewGuid().ToString();
 
-        Uri serviceUrl = state.LastServiceUrl
-            ?? throw new InvalidOperationException(
-                "No service URL cached. The bot must receive at least one activity before proactive sends work.");
-
         TeamsActivity activity = TeamsActivity.CreateBuilder()
             .WithType(TeamsActivityType.Message)
-            .WithServiceUrl(serviceUrl)
+            .WithServiceUrl(state.ServiceUrl)
             .WithChannelId("msteams")
             .WithConversation(new Conversation(conversationId))
             .WithAdaptiveCardAttachment(Cards.ApprovalCard(approvalId, title, description))
@@ -104,9 +100,6 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
             return existing;
         }
 
-        Uri serviceUrl = state.LastServiceUrl
-            ?? throw new InvalidOperationException(
-                "No service URL cached. The bot must receive at least one activity before proactive sends work.");
         ConversationParameters parameters = new()
         {
             Members = [new ConversationAccount { Id = userId }],
@@ -114,7 +107,7 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
         };
 
         CreateConversationResponse resource = await app.Api
-            .ForServiceUrl(serviceUrl)
+            .ForServiceUrl(state.ServiceUrl)
             .Conversations
             .CreateAsync(parameters, cancellationToken: cancellationToken);
 

--- a/core/samples/McpServer/McpTools.cs
+++ b/core/samples/McpServer/McpTools.cs
@@ -75,8 +75,17 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
             .WithAdaptiveCardAttachment(Cards.ApprovalCard(approvalId, title, description))
             .Build();
 
-        await app.SendActivityAsync(activity, cancellationToken);
         state.Approvals[approvalId] = ApprovalStatus.Pending;
+        try
+        {
+            await app.SendActivityAsync(activity, cancellationToken);
+        }
+        catch
+        {
+            state.Approvals.Remove(approvalId);
+            throw;
+        }
+
         return new ApprovalRequestResult(ApprovalId: approvalId);
     }
 

--- a/core/samples/McpServer/McpTools.cs
+++ b/core/samples/McpServer/McpTools.cs
@@ -37,10 +37,28 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
     {
         string conversationId = await GetOrCreateConversationAsync(userId, cancellationToken);
         string requestId = Guid.NewGuid().ToString();
-        await app.Send(conversationId, question, state.ServiceUrl, cancellationToken);
-        // The user's next message looks up these entries and flips status to 'answered'.
+
+        // If the user already has a pending ask, mark it as superseded before replacing it,
+        // so callers polling get_reply on the old request_id don't wait indefinitely.
+        if (state.UserPendingAsk.TryGetValue(userId, out string? previousRequestId)
+            && state.PendingAsks.TryGetValue(previousRequestId, out PendingAsk? previousAsk))
+        {
+            previousAsk.TryMarkSuperseded();
+        }
+
+        // Record the pending ask before sending, so a fast reply is never lost.
         state.PendingAsks[requestId] = new PendingAsk { UserId = userId };
         state.UserPendingAsk[userId] = requestId;
+        try
+        {
+            await app.Send(conversationId, question, state.ServiceUrl, cancellationToken);
+        }
+        catch
+        {
+            state.PendingAsks.TryRemove(requestId, out _);
+            state.UserPendingAsk.TryRemove(userId, out _);
+            throw;
+        }
         return new AskResult(RequestId: requestId);
     }
 
@@ -82,7 +100,7 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
         }
         catch
         {
-            state.Approvals.Remove(approvalId);
+            state.Approvals.TryRemove(approvalId, out _);
             throw;
         }
 

--- a/core/samples/McpServer/McpTools.cs
+++ b/core/samples/McpServer/McpTools.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.ComponentModel;
+using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Schema;
+using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Schema;
+using ModelContextProtocol.Server;
+
+namespace McpServer;
+
+// [McpServerToolType] marks the class for tool discovery; each
+// [McpServerTool] method below becomes one tool surfaced to MCP clients.
+// The class is registered via WithTools<McpTools>() in Program.cs.
+[McpServerToolType]
+public sealed class McpTools(TeamsBotApplication app, State state, IConfiguration config)
+{
+    [McpServerTool(Name = "notify"), Description("Send a notification to a Teams user. No response expected.")]
+    public async Task<NotifyResult> Notify(
+        [Description("The Teams user id (e.g. 29:...) to notify.")] string userId,
+        [Description("The message text to send.")] string message,
+        CancellationToken cancellationToken = default)
+    {
+        string conversationId = await GetOrCreateConversationAsync(userId, cancellationToken);
+        await app.Send(conversationId, message, cancellationToken: cancellationToken);
+        return new NotifyResult(Notified: true, UserId: userId);
+    }
+
+    [McpServerTool(Name = "ask"), Description(
+        "Ask a Teams user a question. Returns a request_id — use get_reply for their response. " +
+        "Only one outstanding ask per user is supported; their next message answers it.")]
+    public async Task<AskResult> Ask(
+        [Description("The Teams user id to ask.")] string userId,
+        [Description("The question to ask.")] string question,
+        CancellationToken cancellationToken = default)
+    {
+        string conversationId = await GetOrCreateConversationAsync(userId, cancellationToken);
+        string requestId = Guid.NewGuid().ToString();
+        await app.Send(conversationId, question, cancellationToken: cancellationToken);
+        // The user's next message looks up these entries and flips status to 'answered'.
+        state.PendingAsks[requestId] = new PendingAsk { UserId = userId };
+        state.UserPendingAsk[userId] = requestId;
+        return new AskResult(RequestId: requestId);
+    }
+
+    [McpServerTool(Name = "get_reply"), Description(
+        "Get the reply to a question sent with ask. Returns status 'pending' until the user responds.")]
+    public ReplyResult GetReply(
+        [Description("The request_id returned from ask.")] string requestId)
+    {
+        if (!state.PendingAsks.TryGetValue(requestId, out PendingAsk? entry))
+        {
+            throw new InvalidOperationException($"No ask found with request_id {requestId}.");
+        }
+        return new ReplyResult(Status: entry.Status, Reply: entry.Reply);
+    }
+
+    [McpServerTool(Name = "request_approval"), Description(
+        "Send an approval request to a Teams user. Returns an approval_id — use get_approval for the decision.")]
+    public async Task<ApprovalRequestResult> RequestApproval(
+        [Description("The Teams user id to ask for approval.")] string userId,
+        [Description("Title of the approval request.")] string title,
+        [Description("Description of what is being approved.")] string description,
+        CancellationToken cancellationToken = default)
+    {
+        string conversationId = await GetOrCreateConversationAsync(userId, cancellationToken);
+        string approvalId = Guid.NewGuid().ToString();
+
+        Uri serviceUrl = state.LastServiceUrl
+            ?? throw new InvalidOperationException(
+                "No service URL cached. The bot must receive at least one activity before proactive sends work.");
+
+        TeamsActivity activity = TeamsActivity.CreateBuilder()
+            .WithType(TeamsActivityType.Message)
+            .WithServiceUrl(serviceUrl)
+            .WithChannelId("msteams")
+            .WithConversation(new Conversation(conversationId))
+            .WithAdaptiveCardAttachment(Cards.ApprovalCard(approvalId, title, description))
+            .Build();
+
+        await app.SendActivityAsync(activity, cancellationToken);
+        state.Approvals[approvalId] = ApprovalStatus.Pending;
+        return new ApprovalRequestResult(ApprovalId: approvalId);
+    }
+
+    [McpServerTool(Name = "get_approval"), Description(
+        "Get the status of an approval request. Returns 'pending', 'approved', or 'rejected'.")]
+    public ApprovalResult GetApproval(
+        [Description("The approval_id returned from request_approval.")] string approvalId)
+    {
+        if (!state.Approvals.TryGetValue(approvalId, out string? status))
+        {
+            throw new InvalidOperationException($"No approval found with approval_id {approvalId}.");
+        }
+        return new ApprovalResult(ApprovalId: approvalId, Status: status);
+    }
+
+    // Returns the cached 1:1 conversation id for a user, or opens a new 1:1 proactively.
+    private async Task<string> GetOrCreateConversationAsync(string userId, CancellationToken cancellationToken)
+    {
+        if (state.Conversations.TryGetValue(userId, out string? existing))
+        {
+            return existing;
+        }
+
+        Uri serviceUrl = state.LastServiceUrl
+            ?? throw new InvalidOperationException(
+                "No service URL cached. The bot must receive at least one activity before proactive sends work.");
+        ConversationParameters parameters = new()
+        {
+            Members = [new ConversationAccount { Id = userId }],
+            TenantId = config["AzureAd:TenantId"],
+        };
+
+        CreateConversationResponse resource = await app.Api
+            .ForServiceUrl(serviceUrl)
+            .Conversations
+            .CreateAsync(parameters, cancellationToken: cancellationToken);
+
+        string id = resource.Id
+            ?? throw new InvalidOperationException("conversations.create returned no id.");
+        state.Conversations[userId] = id;
+        return id;
+    }
+}

--- a/core/samples/McpServer/McpTools.cs
+++ b/core/samples/McpServer/McpTools.cs
@@ -38,16 +38,18 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
         string conversationId = await GetOrCreateConversationAsync(userId, cancellationToken);
         string requestId = Guid.NewGuid().ToString();
 
-        // If the user already has a pending ask, mark it as superseded before replacing it,
+        // If the user already has a pending ask, mark it superseded before replacing it,
         // so callers polling get_reply on the old request_id don't wait indefinitely.
         if (state.UserPendingAsk.TryGetValue(userId, out string? previousRequestId)
-            && state.PendingAsks.TryGetValue(previousRequestId, out PendingAsk? previousAsk))
+            && state.PendingAsks.TryGetValue(previousRequestId, out PendingAsk? previousAsk)
+            && previousAsk.Status == AskStatus.Pending)
         {
-            previousAsk.TryMarkSuperseded();
+            PendingAsk superseded = previousAsk with { Status = AskStatus.Superseded };
+            state.PendingAsks.TryUpdate(previousRequestId, superseded, previousAsk);
         }
 
         // Record the pending ask before sending, so a fast reply is never lost.
-        state.PendingAsks[requestId] = new PendingAsk { UserId = userId };
+        state.PendingAsks[requestId] = new PendingAsk(userId);
         state.UserPendingAsk[userId] = requestId;
         try
         {

--- a/core/samples/McpServer/McpTools.cs
+++ b/core/samples/McpServer/McpTools.cs
@@ -23,7 +23,13 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
         CancellationToken cancellationToken = default)
     {
         string conversationId = await GetOrCreateConversationAsync(userId, cancellationToken);
-        await app.Send(conversationId, message, state.ServiceUrl, cancellationToken);
+        TeamsActivity notifyActivity = TeamsActivity.CreateBuilder()
+            .WithType(TeamsActivityType.Message)
+            .WithServiceUrl(state.ServiceUrl)
+            .WithConversation(new Conversation(conversationId))
+            .WithText(message)
+            .Build();
+        await app.SendActivityAsync(notifyActivity, cancellationToken);
         return new NotifyResult(Notified: true, UserId: userId);
     }
 
@@ -51,9 +57,15 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
         // Record the pending ask before sending, so a fast reply is never lost.
         state.PendingAsks[requestId] = new PendingAsk(userId);
         state.UserPendingAsk[userId] = requestId;
+        TeamsActivity askActivity = TeamsActivity.CreateBuilder()
+            .WithType(TeamsActivityType.Message)
+            .WithServiceUrl(state.ServiceUrl)
+            .WithConversation(new Conversation(conversationId))
+            .WithText(question)
+            .Build();
         try
         {
-            await app.Send(conversationId, question, state.ServiceUrl, cancellationToken);
+            await app.SendActivityAsync(askActivity, cancellationToken);
         }
         catch
         {
@@ -90,7 +102,6 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
         TeamsActivity activity = TeamsActivity.CreateBuilder()
             .WithType(TeamsActivityType.Message)
             .WithServiceUrl(state.ServiceUrl)
-            .WithChannelId("msteams")
             .WithConversation(new Conversation(conversationId))
             .WithAdaptiveCardAttachment(Cards.ApprovalCard(approvalId, title, description))
             .Build();

--- a/core/samples/McpServer/Models.cs
+++ b/core/samples/McpServer/Models.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace McpServer;
+
+// MCP clients (and their JSON output schemas) expect snake_case field names,
+// so each positional record parameter carries an explicit JsonPropertyName.
+// The `property:` target is required: without it, the attribute would land on
+// the constructor parameter and System.Text.Json would ignore it.
+
+public sealed record NotifyResult(
+    [property: JsonPropertyName("notified")] bool Notified,
+    [property: JsonPropertyName("user_id")] string UserId);
+
+public sealed record AskResult(
+    [property: JsonPropertyName("request_id")] string RequestId);
+
+public sealed record ReplyResult(
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("reply")] string? Reply);
+
+public sealed record ApprovalRequestResult(
+    [property: JsonPropertyName("approval_id")] string ApprovalId);
+
+public sealed record ApprovalResult(
+    [property: JsonPropertyName("approval_id")] string ApprovalId,
+    [property: JsonPropertyName("status")] string Status);

--- a/core/samples/McpServer/Program.cs
+++ b/core/samples/McpServer/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using McpServer;
+using Microsoft.Extensions.Logging;
 using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Handlers;
 using Microsoft.Teams.Apps.Schema;
@@ -10,13 +11,7 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 builder.Services.AddTeamsBotApplication();
 // State is a singleton so the same maps are shared between the bot's
 // activity handlers and the MCP tools. Replace with a persistent store for production.
-// Seeded with the configured service URL so MCP tools work from startup.
-builder.Services.AddSingleton<State>(sp =>
-{
-    string serviceUrl = sp.GetRequiredService<IConfiguration>()["Bot:ServiceUrl"]
-        ?? "https://smba.trafficmanager.net/teams/";
-    return new State(new Uri(serviceUrl));
-});
+builder.Services.AddSingleton<State>();
 builder.Services
     .AddMcpServer()
     .WithHttpTransport()
@@ -26,11 +21,16 @@ WebApplication webApp = builder.Build();
 
 TeamsBotApplication bot = webApp.UseTeamsBotApplication();
 State state = webApp.Services.GetRequiredService<State>();
+ILogger<Program> logger = webApp.Services.GetRequiredService<ILogger<Program>>();
+
 
 bot.OnMessage(async (context, cancellationToken) =>
 {
     string userId = context.Activity.From?.Id ?? string.Empty;
     string conversationId = context.Activity.Conversation?.Id ?? string.Empty;
+
+    if (context.Activity.ServiceUrl is not null)
+        state.ServiceUrl = context.Activity.ServiceUrl;
 
     // cache the personal conversation_id so MCP tools can DM this user later.
     TeamsConversation? conv = TeamsConversation.FromConversation(context.Activity.Conversation);
@@ -47,13 +47,14 @@ bot.OnMessage(async (context, cancellationToken) =>
     {
         PendingAsk answered = entry with { Status = AskStatus.Answered, Reply = context.Activity.Text ?? string.Empty };
         state.PendingAsks.TryUpdate(requestId, answered, entry);
-        await context.Send("Got it, thank you!", cancellationToken);
+        await context.SendActivityAsync("Got it, thank you!", cancellationToken);
         return;
     }
 
-    context.Log.Info(
-        $"Received message from user {userId} in conversation {conversationId}, but no pending ask found.");
-    await context.Send("Hi! I'll let you know if I need anything.", cancellationToken);
+    logger.LogInformation(
+        "Received message from user {UserId} in conversation {ConversationId}, but no pending ask found.",
+        userId, conversationId);
+    await context.SendActivityAsync("Hi! I'll let you know if I need anything.", cancellationToken);
 });
 
 
@@ -76,6 +77,7 @@ bot.OnAdaptiveCardAction(async (context, cancellationToken) =>
         return AdaptiveCardResponse.CreateMessageResponse("Response recorded");
     }
 
+    await Task.CompletedTask;
     return AdaptiveCardResponse.CreateMessageResponse(
         "Unable to record response. The approval request may be invalid or expired.");
 });

--- a/core/samples/McpServer/Program.cs
+++ b/core/samples/McpServer/Program.cs
@@ -72,10 +72,13 @@ bot.OnAdaptiveCardAction(async (context, cancellationToken) =>
         && (decision == ApprovalStatus.Approved || decision == ApprovalStatus.Rejected))
     {
         state.Approvals[approvalId] = decision;
+        await Task.CompletedTask;
+        return AdaptiveCardResponse.CreateMessageResponse("Response recorded");
     }
 
     await Task.CompletedTask;
-    return AdaptiveCardResponse.CreateMessageResponse("Response recorded");
+    return AdaptiveCardResponse.CreateMessageResponse(
+        "Unable to record response. The approval request may be invalid or expired.");
 });
 
 webApp.MapMcp("/mcp");

--- a/core/samples/McpServer/Program.cs
+++ b/core/samples/McpServer/Program.cs
@@ -41,7 +41,8 @@ bot.OnMessage(async (context, cancellationToken) =>
 
     // If this user has a pending ask, treat their next message as the answer.
     // Only one outstanding ask per user is supported (see README Limitations).
-    if (state.UserPendingAsk.TryRemove(userId, out string? requestId)
+    if (!string.IsNullOrEmpty(userId)
+        && state.UserPendingAsk.TryRemove(userId, out string? requestId)
         && state.PendingAsks.TryGetValue(requestId, out PendingAsk? entry))
     {
         entry.MarkAnswered(context.Activity.Text ?? string.Empty);

--- a/core/samples/McpServer/Program.cs
+++ b/core/samples/McpServer/Program.cs
@@ -26,6 +26,7 @@ WebApplication webApp = builder.Build();
 
 TeamsBotApplication bot = webApp.UseTeamsBotApplication();
 State state = webApp.Services.GetRequiredService<State>();
+ILogger logger = webApp.Services.GetRequiredService<ILoggerFactory>().CreateLogger("McpServer");
 
 bot.OnMessage(async (context, cancellationToken) =>
 {
@@ -51,8 +52,10 @@ bot.OnMessage(async (context, cancellationToken) =>
         return;
     }
 
-    Console.WriteLine(
-        $"Received message from user {userId} in conversation {conversationId}, but no pending ask found.");
+    logger.LogInformation(
+        "Received message from user {UserId} in conversation {ConversationId}, but no pending ask found.",
+        userId,
+        conversationId);
     await context.Send("Hi! I'll let you know if I need anything.", cancellationToken);
 });
 

--- a/core/samples/McpServer/Program.cs
+++ b/core/samples/McpServer/Program.cs
@@ -44,8 +44,7 @@ bot.OnMessage(async (context, cancellationToken) =>
     if (state.UserPendingAsk.TryRemove(userId, out string? requestId)
         && state.PendingAsks.TryGetValue(requestId, out PendingAsk? entry))
     {
-        entry.Reply = context.Activity.Text ?? string.Empty;
-        entry.Status = AskStatus.Answered;
+        entry.MarkAnswered(context.Activity.Text ?? string.Empty);
         await context.Send("Got it, thank you!", cancellationToken);
         return;
     }

--- a/core/samples/McpServer/Program.cs
+++ b/core/samples/McpServer/Program.cs
@@ -10,7 +10,13 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 builder.Services.AddTeamsBotApplication();
 // State is a singleton so the same maps are shared between the bot's
 // activity handlers and the MCP tools. Replace with a persistent store for production.
-builder.Services.AddSingleton<State>();
+// Seeded with the configured service URL so MCP tools work from startup.
+builder.Services.AddSingleton<State>(sp =>
+{
+    string serviceUrl = sp.GetRequiredService<IConfiguration>()["Bot:ServiceUrl"]
+        ?? "https://smba.trafficmanager.net/teams/";
+    return new State(new Uri(serviceUrl));
+});
 builder.Services
     .AddMcpServer()
     .WithHttpTransport()
@@ -25,13 +31,6 @@ bot.OnMessage(async (context, cancellationToken) =>
 {
     string userId = context.Activity.From?.Id ?? string.Empty;
     string conversationId = context.Activity.Conversation?.Id ?? string.Empty;
-
-    // Cache the service URL: proactive sends and conversations.create both
-    // require one, and there's no way to discover it without an inbound activity.
-    if (context.Activity.ServiceUrl is not null)
-    {
-        state.LastServiceUrl = context.Activity.ServiceUrl;
-    }
 
     // cache the personal conversation_id so MCP tools can DM this user later.
     TeamsConversation? conv = TeamsConversation.FromConversation(context.Activity.Conversation);

--- a/core/samples/McpServer/Program.cs
+++ b/core/samples/McpServer/Program.cs
@@ -26,7 +26,6 @@ WebApplication webApp = builder.Build();
 
 TeamsBotApplication bot = webApp.UseTeamsBotApplication();
 State state = webApp.Services.GetRequiredService<State>();
-ILogger logger = webApp.Services.GetRequiredService<ILoggerFactory>().CreateLogger("McpServer");
 
 bot.OnMessage(async (context, cancellationToken) =>
 {
@@ -52,10 +51,8 @@ bot.OnMessage(async (context, cancellationToken) =>
         return;
     }
 
-    logger.LogInformation(
-        "Received message from user {UserId} in conversation {ConversationId}, but no pending ask found.",
-        userId,
-        conversationId);
+    context.Log.Info(
+        $"Received message from user {userId} in conversation {conversationId}, but no pending ask found.");
     await context.Send("Hi! I'll let you know if I need anything.", cancellationToken);
 });
 

--- a/core/samples/McpServer/Program.cs
+++ b/core/samples/McpServer/Program.cs
@@ -45,7 +45,8 @@ bot.OnMessage(async (context, cancellationToken) =>
         && state.UserPendingAsk.TryRemove(userId, out string? requestId)
         && state.PendingAsks.TryGetValue(requestId, out PendingAsk? entry))
     {
-        entry.MarkAnswered(context.Activity.Text ?? string.Empty);
+        PendingAsk answered = entry with { Status = AskStatus.Answered, Reply = context.Activity.Text ?? string.Empty };
+        state.PendingAsks.TryUpdate(requestId, answered, entry);
         await context.Send("Got it, thank you!", cancellationToken);
         return;
     }

--- a/core/samples/McpServer/Program.cs
+++ b/core/samples/McpServer/Program.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using McpServer;
+using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Handlers;
+using Microsoft.Teams.Apps.Schema;
+
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+builder.Services.AddTeamsBotApplication();
+// State is a singleton so the same maps are shared between the bot's
+// activity handlers and the MCP tools. Replace with a persistent store for production.
+builder.Services.AddSingleton<State>();
+builder.Services
+    .AddMcpServer()
+    .WithHttpTransport()
+    .WithTools<McpTools>();
+
+WebApplication webApp = builder.Build();
+
+TeamsBotApplication bot = webApp.UseTeamsBotApplication();
+State state = webApp.Services.GetRequiredService<State>();
+
+bot.OnMessage(async (context, cancellationToken) =>
+{
+    string userId = context.Activity.From?.Id ?? string.Empty;
+    string conversationId = context.Activity.Conversation?.Id ?? string.Empty;
+
+    // Cache the service URL: proactive sends and conversations.create both
+    // require one, and there's no way to discover it without an inbound activity.
+    if (context.Activity.ServiceUrl is not null)
+    {
+        state.LastServiceUrl = context.Activity.ServiceUrl;
+    }
+
+    // cache the personal conversation_id so MCP tools can DM this user later.
+    TeamsConversation? conv = TeamsConversation.FromConversation(context.Activity.Conversation);
+    if (conv?.ConversationType == ConversationType.Personal && !string.IsNullOrEmpty(userId))
+    {
+        state.Conversations[userId] = conversationId;
+    }
+
+    // If this user has a pending ask, treat their next message as the answer.
+    // Only one outstanding ask per user is supported (see README Limitations).
+    if (state.UserPendingAsk.TryRemove(userId, out string? requestId)
+        && state.PendingAsks.TryGetValue(requestId, out PendingAsk? entry))
+    {
+        entry.Reply = context.Activity.Text ?? string.Empty;
+        entry.Status = AskStatus.Answered;
+        await context.Send("Got it, thank you!", cancellationToken);
+        return;
+    }
+
+    Console.WriteLine(
+        $"Received message from user {userId} in conversation {conversationId}, but no pending ask found.");
+    await context.Send("Hi! I'll let you know if I need anything.", cancellationToken);
+});
+
+
+bot.OnAdaptiveCardAction(async (context, cancellationToken) =>
+{
+    AdaptiveCardAction? action = context.Activity.Value?.Action;
+    if (action?.Verb != "approval_response")
+    {
+        return AdaptiveCardResponse.CreateMessageResponse("Unknown action");
+    }
+
+    string? approvalId = TryGetString(action.Data, "approval_id");
+    string? decision = TryGetString(action.Data, "decision");
+
+    if (approvalId is not null
+        && state.Approvals.ContainsKey(approvalId)
+        && (decision == ApprovalStatus.Approved || decision == ApprovalStatus.Rejected))
+    {
+        state.Approvals[approvalId] = decision;
+    }
+
+    await Task.CompletedTask;
+    return AdaptiveCardResponse.CreateMessageResponse("Response recorded");
+});
+
+webApp.MapMcp("/mcp");
+webApp.Run();
+
+static string? TryGetString(Dictionary<string, object>? data, string key)
+    => data is not null && data.TryGetValue(key, out object? value) ? value?.ToString() : null;

--- a/core/samples/McpServer/Program.cs
+++ b/core/samples/McpServer/Program.cs
@@ -67,15 +67,13 @@ bot.OnAdaptiveCardAction(async (context, cancellationToken) =>
     string? decision = TryGetString(action.Data, "decision");
 
     if (approvalId is not null
-        && state.Approvals.ContainsKey(approvalId)
-        && (decision == ApprovalStatus.Approved || decision == ApprovalStatus.Rejected))
+        && (decision == ApprovalStatus.Approved || decision == ApprovalStatus.Rejected)
+        && state.Approvals.TryGetValue(approvalId, out string? currentDecision)
+        && state.Approvals.TryUpdate(approvalId, decision, currentDecision))
     {
-        state.Approvals[approvalId] = decision;
-        await Task.CompletedTask;
         return AdaptiveCardResponse.CreateMessageResponse("Response recorded");
     }
 
-    await Task.CompletedTask;
     return AdaptiveCardResponse.CreateMessageResponse(
         "Unable to record response. The approval request may be invalid or expired.");
 });

--- a/core/samples/McpServer/README.md
+++ b/core/samples/McpServer/README.md
@@ -14,16 +14,6 @@ wait for them to reply or approve.
 | `request_approval` | Send an Approve/Reject card to a user. Returns an `approvalId`.                      | `userId`, `title`, `description`    |
 | `get_approval`     | Poll for the decision on an earlier `request_approval`.                              | `approvalId`                        |
 
-## Layout
-
-| File          | Responsibility                                                                            |
-| ------------- | ----------------------------------------------------------------------------------------- |
-| `Program.cs`  | Wires `/api/messages` (Teams) and `/mcp` (MCP) on the same `WebApplication`.              |
-| `McpTools.cs` | The five `[McpServerTool]` methods, registered via `WithTools<McpTools>()`.               |
-| `Cards.cs`    | Adaptive Card factory for the Approve/Reject card (built with `Microsoft.Teams.Cards`).   |
-| `Models.cs`   | Typed result records (`NotifyResult`, `AskResult`, `ReplyResult`, …) — snake_case wire.   |
-| `State.cs`    | DI-singleton: conversation map, pending asks, approvals, current service URL.             |
-
 ## Configure
 
 Set credentials in `appsettings.json` *or* `Properties/launchSettings.json`
@@ -34,7 +24,6 @@ Set credentials in `appsettings.json` *or* `Properties/launchSettings.json`
 ```json
 {
   "AzureAd": {
-    "Instance": "https://login.microsoftonline.com/",
     "TenantId": "<your-tenant-id>",
     "ClientId": "<your-azure-bot-app-id>",
     "ClientCredentials": [
@@ -47,16 +36,11 @@ Set credentials in `appsettings.json` *or* `Properties/launchSettings.json`
 Or via env vars in `launchSettings.json`:
 
 ```
-AzureAd__Instance=https://login.microsoftonline.com/
 AzureAd__TenantId=<your-tenant-id>
 AzureAd__ClientId=<your-azure-bot-app-id>
 AzureAd__ClientCredentials__0__SourceType=ClientSecret
 AzureAd__ClientCredentials__0__ClientSecret=<your-azure-bot-app-secret>
 ```
-
-`TenantId` is required because the MCP tools open 1:1 conversations
-*proactively* via `app.Api.Conversations.CreateAsync` — it can't be inferred
-from the bot's own credentials.
 
 The `userId` argument passed to `notify`, `ask`, and `request_approval` is the
 Teams user id of someone in the same tenant. For the simplest setup, message

--- a/core/samples/McpServer/README.md
+++ b/core/samples/McpServer/README.md
@@ -20,7 +20,7 @@ wait for them to reply or approve.
 | ------------- | ----------------------------------------------------------------------------------------- |
 | `Program.cs`  | Wires `/api/messages` (Teams) and `/mcp` (MCP) on the same `WebApplication`.              |
 | `McpTools.cs` | The five `[McpServerTool]` methods, registered via `WithTools<McpTools>()`.               |
-| `Cards.cs`    | Adaptive Card factory for the Approve/Reject card.                                        |
+| `Cards.cs`    | Adaptive Card factory for the Approve/Reject card (built with `Microsoft.Teams.Cards`).   |
 | `Models.cs`   | Typed result records (`NotifyResult`, `AskResult`, `ReplyResult`, …) — snake_case wire.   |
 | `State.cs`    | DI-singleton: conversation map, pending asks, approvals, current service URL.             |
 
@@ -57,12 +57,6 @@ AzureAd__ClientCredentials__0__ClientSecret=<your-azure-bot-app-secret>
 `TenantId` is required because the MCP tools open 1:1 conversations
 *proactively* via `app.Api.Conversations.CreateAsync` — it can't be inferred
 from the bot's own credentials.
-
-### `Bot:ServiceUrl`
-
-`appsettings.json` also configures `Bot:ServiceUrl`, the Bot Framework
-endpoint proactive sends target. Default is the production Teams URL
-(`https://smba.trafficmanager.net/teams/`).
 
 The `userId` argument passed to `notify`, `ask`, and `request_approval` is the
 Teams user id of someone in the same tenant. For the simplest setup, message

--- a/core/samples/McpServer/README.md
+++ b/core/samples/McpServer/README.md
@@ -1,0 +1,111 @@
+# Sample: MCP Server
+
+A Teams bot that doubles as an MCP server, exposing human-in-the-loop tools that
+let an MCP client (an agent, an IDE, etc.) reach a real user through Teams and
+wait for them to reply or approve.
+
+## Tools
+
+| Tool               | Description                                                                          | Parameters                          |
+| ------------------ | ------------------------------------------------------------------------------------ | ----------------------------------- |
+| `notify`           | Send a one-way notification to a user. No response expected.                         | `userId`, `message`                 |
+| `ask`              | Ask a user a question. Returns a `requestId`.                                        | `userId`, `question`                |
+| `get_reply`        | Poll for the reply to an earlier `ask`. Returns `pending` until the user responds.   | `requestId`                         |
+| `request_approval` | Send an Approve/Reject card to a user. Returns an `approvalId`.                      | `userId`, `title`, `description`    |
+| `get_approval`     | Poll for the decision on an earlier `request_approval`.                              | `approvalId`                        |
+
+## Layout
+
+| File          | Responsibility                                                                            |
+| ------------- | ----------------------------------------------------------------------------------------- |
+| `Program.cs`  | Wires `/api/messages` (Teams) and `/mcp` (MCP) on the same `WebApplication`.              |
+| `McpTools.cs` | The five `[McpServerTool]` methods, registered via `WithTools<McpTools>()`.               |
+| `Cards.cs`    | Adaptive Card factory for the Approve/Reject card.                                        |
+| `Models.cs`   | Typed result records (`NotifyResult`, `AskResult`, `ReplyResult`, …) — snake_case wire.   |
+| `State.cs`    | DI-singleton: conversation map, pending asks, approvals, last seen service URL.           |
+
+## Configure
+
+Set credentials in `appsettings.json` *or* `Properties/launchSettings.json`
+(env-var form).
+
+`appsettings.json`:
+
+```json
+{
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "TenantId": "<your-tenant-id>",
+    "ClientId": "<your-azure-bot-app-id>",
+    "ClientCredentials": [
+      { "SourceType": "ClientSecret", "ClientSecret": "<your-azure-bot-app-secret>" }
+    ]
+  }
+}
+```
+
+Or via env vars in `launchSettings.json`:
+
+```
+AzureAd__Instance=https://login.microsoftonline.com/
+AzureAd__TenantId=<your-tenant-id>
+AzureAd__ClientId=<your-azure-bot-app-id>
+AzureAd__ClientCredentials__0__SourceType=ClientSecret
+AzureAd__ClientCredentials__0__ClientSecret=<your-azure-bot-app-secret>
+```
+
+`TenantId` is required because the MCP tools open 1:1 conversations
+*proactively* via `app.Api.Conversations.CreateAsync` — it can't be inferred
+from the bot's own credentials.
+
+The `userId` argument passed to `notify`, `ask`, and `request_approval` is the
+Teams user id of someone in the same tenant. For the simplest setup, message
+the bot once with a real user, then read the user id off the first incoming
+activity in the server log and use that.
+
+## Run
+
+```bash
+dotnet run --project samples/McpServer
+```
+
+The bot listens for Teams activity on `POST /api/messages` (port 3978 by
+default) and serves the MCP endpoint at `http://localhost:3978/mcp`.
+
+## Run with the MCP Inspector
+
+```bash
+dotnet run --project samples/McpServer
+# in a second terminal:
+npx @modelcontextprotocol/inspector
+```
+
+In the Inspector UI, pick **Streamable HTTP** as the transport and enter
+`http://localhost:3978/mcp` as the URL, then click **Connect**.
+
+## Example agent flow
+
+1. Agent calls `request_approval(userId, title, description)` → gets `approvalId`.
+2. The user sees an Approve/Reject card in Teams and clicks a button.
+3. The `OnAdaptiveCardAction` handler records the decision in shared state.
+4. Agent polls `get_approval(approvalId)` until the status flips to
+   `approved` or `rejected`.
+
+## Limitations
+
+All state is in-memory. A server restart clears everything — pending asks and
+approvals in flight will be lost.
+
+**Only one outstanding `ask` per user.** The next message that user sends to
+the bot is treated as the answer to their open ask. Calling `ask` again for
+the same user while a previous ask is still pending overwrites the
+correlation, and the user's reply will resolve whichever ask is current.
+
+## Security
+
+The `/mcp` endpoint is mounted **without authentication**. Anyone who can reach
+the port can call the tools — which means they can DM arbitrary users and
+mutate approval state on your behalf. This is fine for local dev (the MCP
+Inspector connects from the same machine), but **do not expose `/mcp` on the
+network as-is.** Add an authentication check before deploying — e.g. a bearer
+token / shared secret in a header, or proper OAuth.

--- a/core/samples/McpServer/README.md
+++ b/core/samples/McpServer/README.md
@@ -22,7 +22,7 @@ wait for them to reply or approve.
 | `McpTools.cs` | The five `[McpServerTool]` methods, registered via `WithTools<McpTools>()`.               |
 | `Cards.cs`    | Adaptive Card factory for the Approve/Reject card.                                        |
 | `Models.cs`   | Typed result records (`NotifyResult`, `AskResult`, `ReplyResult`, …) — snake_case wire.   |
-| `State.cs`    | DI-singleton: conversation map, pending asks, approvals, last seen service URL.           |
+| `State.cs`    | DI-singleton: conversation map, pending asks, approvals, current service URL.             |
 
 ## Configure
 
@@ -57,6 +57,12 @@ AzureAd__ClientCredentials__0__ClientSecret=<your-azure-bot-app-secret>
 `TenantId` is required because the MCP tools open 1:1 conversations
 *proactively* via `app.Api.Conversations.CreateAsync` — it can't be inferred
 from the bot's own credentials.
+
+### `Bot:ServiceUrl`
+
+`appsettings.json` also configures `Bot:ServiceUrl`, the Bot Framework
+endpoint proactive sends target. Default is the production Teams URL
+(`https://smba.trafficmanager.net/teams/`).
 
 The `userId` argument passed to `notify`, `ask`, and `request_approval` is the
 Teams user id of someone in the same tenant. For the simplest setup, message

--- a/core/samples/McpServer/State.cs
+++ b/core/samples/McpServer/State.cs
@@ -9,6 +9,7 @@ public static class AskStatus
 {
     public const string Pending = "pending";
     public const string Answered = "answered";
+    public const string Superseded = "superseded";
 }
 
 public static class ApprovalStatus
@@ -21,8 +22,26 @@ public static class ApprovalStatus
 public sealed class PendingAsk
 {
     public required string UserId { get; init; }
-    public string Status { get; set; } = AskStatus.Pending;
+    private string _status = AskStatus.Pending;
+    public string Status => _status;
     public string? Reply { get; set; }
+
+    /// <summary>
+    /// Atomically transitions status from <see cref="AskStatus.Pending"/> to
+    /// <see cref="AskStatus.Superseded"/>. Returns true if the transition occurred.
+    /// </summary>
+    public bool TryMarkSuperseded()
+    {
+        string original = Interlocked.CompareExchange(ref _status, AskStatus.Superseded, AskStatus.Pending);
+        return original == AskStatus.Pending;
+    }
+
+    /// <summary>Sets status to <see cref="AskStatus.Answered"/>.</summary>
+    public void MarkAnswered(string reply)
+    {
+        Reply = reply;
+        Volatile.Write(ref _status, AskStatus.Answered);
+    }
 }
 
 /// <summary>

--- a/core/samples/McpServer/State.cs
+++ b/core/samples/McpServer/State.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+
+namespace McpServer;
+
+// Status values are sent verbatim to MCP clients (and matched against verbatim
+// in card payloads), so storing the wire-format strings avoids a translation
+// layer between the in-memory model and the JSON output.
+public static class AskStatus
+{
+    public const string Pending = "pending";
+    public const string Answered = "answered";
+}
+
+public static class ApprovalStatus
+{
+    public const string Pending = "pending";
+    public const string Approved = "approved";
+    public const string Rejected = "rejected";
+}
+
+public sealed class PendingAsk
+{
+    public required string UserId { get; init; }
+    public string Status { get; set; } = AskStatus.Pending;
+    public string? Reply { get; set; }
+}
+
+/// <summary>
+/// In-memory state shared between the Teams bot handlers and the MCP tools.
+/// A server restart clears everything — pending asks and approvals in flight will be lost.
+/// </summary>
+public sealed class State
+{
+    /// <summary>userId -> personal conversationId. Populated on first incoming 1:1 message.</summary>
+    public ConcurrentDictionary<string, string> Conversations { get; } = new();
+
+    /// <summary>requestId -> PendingAsk.</summary>
+    public ConcurrentDictionary<string, PendingAsk> PendingAsks { get; } = new();
+
+    /// <summary>userId -> requestId for their current pending ask. Cleared once the user replies.</summary>
+    public ConcurrentDictionary<string, string> UserPendingAsk { get; } = new();
+
+    /// <summary>approvalId -> approval status. Values: "pending", "approved", "rejected".</summary>
+    public ConcurrentDictionary<string, string> Approvals { get; } = new();
+
+    /// <summary>
+    /// Last service URL seen on an inbound activity. Required by proactive sends and
+    /// <c>conversations.create</c> — there is no way to discover it otherwise.
+    /// </summary>
+    public Uri? LastServiceUrl { get; set; }
+}

--- a/core/samples/McpServer/State.cs
+++ b/core/samples/McpServer/State.cs
@@ -19,30 +19,10 @@ public static class ApprovalStatus
     public const string Rejected = "rejected";
 }
 
-public sealed class PendingAsk
-{
-    public required string UserId { get; init; }
-    private string _status = AskStatus.Pending;
-    public string Status => _status;
-    public string? Reply { get; set; }
-
-    /// <summary>
-    /// Atomically transitions status from <see cref="AskStatus.Pending"/> to
-    /// <see cref="AskStatus.Superseded"/>. Returns true if the transition occurred.
-    /// </summary>
-    public bool TryMarkSuperseded()
-    {
-        string original = Interlocked.CompareExchange(ref _status, AskStatus.Superseded, AskStatus.Pending);
-        return original == AskStatus.Pending;
-    }
-
-    /// <summary>Sets status to <see cref="AskStatus.Answered"/>.</summary>
-    public void MarkAnswered(string reply)
-    {
-        Reply = reply;
-        Volatile.Write(ref _status, AskStatus.Answered);
-    }
-}
+// Immutable so readers always see a consistent (Status, Reply) snapshot — no locks,
+// no Volatile, no torn state. Transitions go through ConcurrentDictionary.TryUpdate
+// in State.PendingAsks: build a new record, swap atomically against the old one.
+public sealed record PendingAsk(string UserId, string Status = AskStatus.Pending, string? Reply = null);
 
 /// <summary>
 /// In-memory state shared between the Teams bot handlers and the MCP tools.

--- a/core/samples/McpServer/State.cs
+++ b/core/samples/McpServer/State.cs
@@ -5,9 +5,6 @@ using System.Collections.Concurrent;
 
 namespace McpServer;
 
-// Status values are sent verbatim to MCP clients (and matched against verbatim
-// in card payloads), so storing the wire-format strings avoids a translation
-// layer between the in-memory model and the JSON output.
 public static class AskStatus
 {
     public const string Pending = "pending";
@@ -32,7 +29,7 @@ public sealed class PendingAsk
 /// In-memory state shared between the Teams bot handlers and the MCP tools.
 /// A server restart clears everything — pending asks and approvals in flight will be lost.
 /// </summary>
-public sealed class State
+public sealed class State(Uri serviceUrl)
 {
     /// <summary>userId -> personal conversationId. Populated on first incoming 1:1 message.</summary>
     public ConcurrentDictionary<string, string> Conversations { get; } = new();
@@ -47,8 +44,8 @@ public sealed class State
     public ConcurrentDictionary<string, string> Approvals { get; } = new();
 
     /// <summary>
-    /// Last service URL seen on an inbound activity. Required by proactive sends and
-    /// <c>conversations.create</c> — there is no way to discover it otherwise.
+    /// Service URL used by proactive sends and <c>conversations.create</c>. Seeded from
+    /// <c>Bot:ServiceUrl</c> config at startup.
     /// </summary>
-    public Uri? LastServiceUrl { get; set; }
+    public Uri ServiceUrl { get; set; } = serviceUrl;
 }

--- a/core/samples/McpServer/State.cs
+++ b/core/samples/McpServer/State.cs
@@ -28,7 +28,7 @@ public sealed record PendingAsk(string UserId, string Status = AskStatus.Pending
 /// In-memory state shared between the Teams bot handlers and the MCP tools.
 /// A server restart clears everything — pending asks and approvals in flight will be lost.
 /// </summary>
-public sealed class State(Uri serviceUrl)
+public sealed class State
 {
     /// <summary>userId -> personal conversationId. Populated on first incoming 1:1 message.</summary>
     public ConcurrentDictionary<string, string> Conversations { get; } = new();
@@ -43,8 +43,8 @@ public sealed class State(Uri serviceUrl)
     public ConcurrentDictionary<string, string> Approvals { get; } = new();
 
     /// <summary>
-    /// Service URL used by proactive sends and <c>conversations.create</c>. Seeded from
-    /// <c>Bot:ServiceUrl</c> config at startup.
+    /// Service URL used by proactive sends and <c>conversations.create</c>. Updated from
+    /// the first incoming activity; falls back to the default Teams endpoint until then.
     /// </summary>
-    public Uri ServiceUrl { get; set; } = serviceUrl;
+    public Uri ServiceUrl { get; set; } = new Uri("https://smba.trafficmanager.net/teams/");
 }

--- a/core/samples/McpServer/appsettings.json
+++ b/core/samples/McpServer/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.Teams": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/core/samples/McpServer/appsettings.json
+++ b/core/samples/McpServer/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.Teams": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Bot": {
+    "ServiceUrl": "https://smba.trafficmanager.net/teams/"
+  }
 }

--- a/core/samples/McpServer/appsettings.json
+++ b/core/samples/McpServer/appsettings.json
@@ -2,11 +2,9 @@
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
-      "Microsoft.Teams": "Information"
+      "Microsoft.Teams": "Information",
+      "Program": "Information"
     }
   },
-  "AllowedHosts": "*",
-  "Bot": {
-    "ServiceUrl": "https://smba.trafficmanager.net/teams/"
-  }
+  "AllowedHosts": "*"
 }


### PR DESCRIPTION
This pull request introduces a new sample project, `McpServer`, which demonstrates how to build a Teams bot that also acts as a Model Context Protocol (MCP) server. This bot exposes several human-in-the-loop tools that allow MCP clients (such as agents or IDEs) to interact with real users via Teams for notifications, questions, and approval workflows. The sample includes all necessary code, configuration, and documentation to run and extend the project.

The most important changes are:

**New sample project: MCP Server**

* Added new sample project `samples/McpServer` to the solution, including project configuration and dependencies. (`core/core.slnx`, `core/samples/McpServer/McpServer.csproj`) [[1]](diffhunk://#diff-19ad97af5c1b7109a9c62f830310091f393489def210b9ec1ffce152b8bf958cR19) [[2]](diffhunk://#diff-090636d840f051f11c7d84302b8778b00fa1057ff975459f00a17cffe516b6daR1-R17)

**Core functionality and tools**

* Implemented `McpTools` class exposing five MCP tools (`notify`, `ask`, `get_reply`, `request_approval`, `get_approval`) for Teams user interaction, including proactive messaging, question/answer, and approval card workflows. (`core/samples/McpServer/McpTools.cs`)
* Added result models with snake_case JSON serialization for all tool responses, ensuring compatibility with MCP clients. (`core/samples/McpServer/Models.cs`)
* Added in-memory state management for conversations, pending asks, and approvals, with clear documentation on status values and limitations. (`core/samples/McpServer/State.cs`)

**Bot and server wiring**

* Created `Program.cs` to wire up Teams bot handlers, MCP endpoint, and shared state, including logic for handling messages, adaptive card actions, and proactive operations. (`core/samples/McpServer/Program.cs`)
* Added Adaptive Card factory for approval requests, supporting Approve/Reject workflows via card actions. (`core/samples/McpServer/Cards.cs`)

**Documentation and configuration**

* Provided comprehensive `README.md` explaining the sample, tool usage, configuration, running instructions, and security considerations. (`core/samples/McpServer/README.md`)
* Added sample `appsettings.json` for logging and host configuration. (`core/samples/McpServer/appsettings.json`)