### PR TITLE
Add quoted replies support to core (port of #390 onto main:core/)

### DIFF
--- a/core/core.slnx
+++ b/core/core.slnx
@@ -20,6 +20,7 @@
     <Project Path="samples/MessageExtensionBot/MessageExtensionBot.csproj" />
     <Project Path="samples/OAuthFlowBot/OAuthFlowBot.csproj" />
     <Project Path="samples/PABot/PABot.csproj" Id="ef8f29ef-fe59-4edf-8a50-6e7ab6699a45" />
+    <Project Path="samples/Quoting/Quoting.csproj" />
     <Project Path="samples/SsoBot/SsoBot.csproj"/>
     <Project Path="samples/StreamingBot/StreamingBot.csproj" />
     <Project Path="samples/TabApp/TabApp.csproj" />

--- a/core/samples/Quoting/Program.cs
+++ b/core/samples/Quoting/Program.cs
@@ -29,19 +29,19 @@ teamsApp.OnMessage(async (context, cancellationToken) =>
         cancellationToken);
 });
 
-// ReplyAsync() — auto-quotes the inbound message
+// Reply() — auto-quotes the inbound message
 teamsApp.OnMessage("(?i)^test reply$", async (context, cancellationToken) =>
 {
-    await context.ReplyAsync("Thanks for your message! This reply auto-quotes it.", cancellationToken);
+    await context.Reply("Thanks for your message! This reply auto-quotes it.", cancellationToken);
 });
 
-// QuoteAsync() — quote a previously sent message by ID
+// Quote() — quote a previously sent message by ID
 teamsApp.OnMessage("(?i)^test quote$", async (context, cancellationToken) =>
 {
     var sent = await context.SendActivityAsync("The meeting has been moved to 3 PM tomorrow.", cancellationToken);
     if (sent?.Id != null)
     {
-        await context.QuoteAsync(sent.Id, "Just to confirm — does the new time work for everyone?", cancellationToken);
+        await context.Quote(sent.Id, "Just to confirm — does the new time work for everyone?", cancellationToken);
     }
 });
 
@@ -95,8 +95,8 @@ teamsApp.OnMessage("(?i)^help$", async (context, cancellationToken) =>
         new MessageActivity(
             "**Quoting Test Bot**\n\n" +
             "**Commands:**\n" +
-            "- `test reply` - ReplyAsync() auto-quotes your message\n" +
-            "- `test quote` - QuoteAsync() quotes a previously sent message\n" +
+            "- `test reply` - Reply() auto-quotes your message\n" +
+            "- `test quote` - Quote() quotes a previously sent message\n" +
             "- `test add` - AddQuote() extension with response\n" +
             "- `test multi` - Multi-quote with mixed responses\n" +
             "- `test builder` - WithQuote() on TeamsActivityBuilder\n\n" +

--- a/core/samples/Quoting/Program.cs
+++ b/core/samples/Quoting/Program.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Handlers;
+using Microsoft.Teams.Apps.Schema;
+using Microsoft.Teams.Apps.Schema.Entities;
+
+WebApplicationBuilder webAppBuilder = WebApplication.CreateSlimBuilder(args);
+webAppBuilder.Services.AddTeamsBotApplication();
+WebApplication webApp = webAppBuilder.Build();
+
+TeamsBotApplication teamsApp = webApp.UseTeamsBotApplication();
+
+// Inbound quoted replies — fires on every message, echoes metadata when a quote is present.
+teamsApp.OnMessage(async (context, cancellationToken) =>
+{
+    var quote = context.Activity.GetQuotedMessages().FirstOrDefault()?.QuotedReply;
+    if (quote == null) return;
+
+    var info = $"Quoted message ID: {quote.MessageId}";
+    if (quote.SenderName != null) info += $"\nFrom: {quote.SenderName}";
+    if (quote.Preview != null) info += $"\nPreview: \"{quote.Preview}\"";
+    if (quote.IsReplyDeleted == true) info += "\n(deleted)";
+    if (quote.ValidatedMessageReference == true) info += "\n(validated)";
+
+    await context.SendActivityAsync(
+        new MessageActivity($"You sent a message with a quoted reply:\n\n{info}") { TextFormat = TextFormats.Markdown },
+        cancellationToken);
+});
+
+// ReplyAsync() — auto-quotes the inbound message
+teamsApp.OnMessage("(?i)^test reply$", async (context, cancellationToken) =>
+{
+    await context.ReplyAsync("Thanks for your message! This reply auto-quotes it.", cancellationToken);
+});
+
+// QuoteAsync() — quote a previously sent message by ID
+teamsApp.OnMessage("(?i)^test quote$", async (context, cancellationToken) =>
+{
+    var sent = await context.SendActivityAsync("The meeting has been moved to 3 PM tomorrow.", cancellationToken);
+    if (sent?.Id != null)
+    {
+        await context.QuoteAsync(sent.Id, "Just to confirm — does the new time work for everyone?", cancellationToken);
+    }
+});
+
+// AddQuote() extension — builder with response
+teamsApp.OnMessage("(?i)^test add$", async (context, cancellationToken) =>
+{
+    var sent = await context.SendActivityAsync("Please review the latest PR before end of day.", cancellationToken);
+    if (sent?.Id != null)
+    {
+        MessageActivity msg = new();
+        msg.AddQuote(sent.Id, "Done! Left my comments on the PR.");
+        await context.SendActivityAsync(msg, cancellationToken);
+    }
+});
+
+// Multi-quote with mixed responses
+teamsApp.OnMessage("(?i)^test multi$", async (context, cancellationToken) =>
+{
+    var sentA = await context.SendActivityAsync("We need to update the API docs before launch.", cancellationToken);
+    var sentB = await context.SendActivityAsync("The design mockups are ready for review.", cancellationToken);
+    var sentC = await context.SendActivityAsync("CI pipeline is green on main.", cancellationToken);
+
+    if (sentA?.Id != null && sentB?.Id != null && sentC?.Id != null)
+    {
+        MessageActivity msg = new();
+        msg.AddQuote(sentA.Id, "I can take the docs — will have a draft by Thursday.");
+        msg.AddQuote(sentB.Id, "Looks great, approved!");
+        msg.AddQuote(sentC.Id);
+        await context.SendActivityAsync(msg, cancellationToken);
+    }
+});
+
+// Builder pattern — WithQuote on TeamsActivityBuilder
+teamsApp.OnMessage("(?i)^test builder$", async (context, cancellationToken) =>
+{
+    var sent = await context.SendActivityAsync("Deployment to staging is complete.", cancellationToken);
+    if (sent?.Id != null)
+    {
+        TeamsActivity reply = TeamsActivity.CreateBuilder()
+            .WithType(TeamsActivityType.Message)
+            .WithQuote(sent.Id, "Verified — all smoke tests passing.")
+            .Build();
+        await context.SendActivityAsync(reply, cancellationToken);
+    }
+});
+
+// Help
+teamsApp.OnMessage("(?i)^help$", async (context, cancellationToken) =>
+{
+    await context.SendActivityAsync(
+        new MessageActivity(
+            "**Quoting Test Bot**\n\n" +
+            "**Commands:**\n" +
+            "- `test reply` - ReplyAsync() auto-quotes your message\n" +
+            "- `test quote` - QuoteAsync() quotes a previously sent message\n" +
+            "- `test add` - AddQuote() extension with response\n" +
+            "- `test multi` - Multi-quote with mixed responses\n" +
+            "- `test builder` - WithQuote() on TeamsActivityBuilder\n\n" +
+            "Quote any message to me to see the parsed metadata!")
+        { TextFormat = TextFormats.Markdown },
+        cancellationToken);
+});
+
+webApp.Run();

--- a/core/samples/Quoting/Quoting.csproj
+++ b/core/samples/Quoting/Quoting.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);ExperimentalTeamsQuotedReplies</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Teams.Apps\Microsoft.Teams.Apps.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/core/samples/Quoting/README.md
+++ b/core/samples/Quoting/README.md
@@ -1,0 +1,29 @@
+# Quoting Sample
+
+Demonstrates various ways to quote previous messages in a Teams bot using the `quotedReply` entity.
+
+## Prerequisites
+
+- Bot registered and installed in a chat or channel
+
+---
+
+## Commands
+
+| Command | Behavior |
+|---------|----------|
+| `test reply` | `ReplyAsync()` — auto-quotes the inbound message |
+| `test quote` | `QuoteAsync()` — sends a message, then quotes it by ID |
+| `test add` | `AddQuote()` — sends a message, then quotes it with extension method + response |
+| `test multi` | Sends three messages, then quotes all with interleaved responses |
+| `test builder` | `WithQuote()` on `TeamsActivityBuilder` |
+| *(quote a message)* | Bot reads and displays the quoted reply metadata |
+
+---
+
+## Running the Sample
+
+1. Build and run:
+   ```bash
+   dotnet run --project samples/Quoting/Quoting.csproj
+   ```

--- a/core/samples/Quoting/README.md
+++ b/core/samples/Quoting/README.md
@@ -12,8 +12,8 @@ Demonstrates various ways to quote previous messages in a Teams bot using the `q
 
 | Command | Behavior |
 |---------|----------|
-| `test reply` | `ReplyAsync()` — auto-quotes the inbound message |
-| `test quote` | `QuoteAsync()` — sends a message, then quotes it by ID |
+| `test reply` | `Reply()` — auto-quotes the inbound message |
+| `test quote` | `Quote()` — sends a message, then quotes it by ID |
 | `test add` | `AddQuote()` — sends a message, then quotes it with extension method + response |
 | `test multi` | Sends three messages, then quotes all with interleaved responses |
 | `test builder` | `WithQuote()` on `TeamsActivityBuilder` |

--- a/core/samples/Quoting/appsettings.json
+++ b/core/samples/Quoting/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.Teams": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -164,6 +164,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     public Task<SendActivityResponse?> QuoteAsync(string messageId, TeamsActivity activity, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(messageId);
         if (activity is MessageActivity message)
         {
             message.PrependQuote(messageId);

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -77,26 +77,26 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
     public Task<SendActivityResponse?> Reply(string text, CancellationToken cancellationToken = default)
-    {
-        TeamsActivity reply = new TeamsActivityBuilder()
-            .WithConversationReference(Activity)
-            .WithText(text)
-            .Build();
-        return TeamsBotApplication.SendActivityAsync(reply, cancellationToken: cancellationToken);
-    }
+        => Reply(new MessageActivity(text), cancellationToken);
 
     /// <summary>
-    /// Sends an activity as a threaded reply to the current activity.
+    /// Sends an activity to the conversation. When the inbound activity has an id, the response
+    /// auto-quotes it (rendered as a quote bubble above the response in Teams). Otherwise sends
+    /// without quoting. To send without quoting unconditionally, use <see cref="Send(TeamsActivity, CancellationToken)"/>.
     /// </summary>
     /// <param name="activity">The activity to send.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
     public Task<SendActivityResponse?> Reply(TeamsActivity activity, CancellationToken cancellationToken = default)
     {
-        TeamsActivity reply = new TeamsActivityBuilder(activity)
-            .WithConversationReference(Activity)
-            .Build();
-        return TeamsBotApplication.SendActivityAsync(reply, cancellationToken: cancellationToken);
+        ArgumentNullException.ThrowIfNull(activity);
+#pragma warning disable ExperimentalTeamsQuotedReplies
+        if (Activity.Id != null)
+        {
+            return Quote(Activity.Id, activity, cancellationToken);
+        }
+#pragma warning restore ExperimentalTeamsQuotedReplies
+        return SendActivityAsync(activity, cancellationToken);
     }
 
     /// <summary>
@@ -109,35 +109,6 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
         => SendTypingActivityAsync(cancellationToken);
 
     /// <summary>
-    /// Sends a message activity as a reply, automatically quoting the inbound message.
-    /// </summary>
-    /// <param name="text">The text to send.</param>
-    /// <param name="cancellationToken">Optional cancellation token.</param>
-    /// <returns>The response from sending the activity.</returns>
-    public Task<SendActivityResponse?> ReplyAsync(string text, CancellationToken cancellationToken = default)
-    {
-        var reply = new MessageActivity(text);
-        return ReplyAsync(reply, cancellationToken);
-    }
-
-    /// <summary>
-    /// Sends an activity as a reply, automatically quoting the inbound message.
-    /// </summary>
-    /// <param name="activity">The activity to send.</param>
-    /// <param name="cancellationToken">Optional cancellation token.</param>
-    /// <returns>The response from sending the activity.</returns>
-    public Task<SendActivityResponse?> ReplyAsync(TeamsActivity activity, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(activity);
-        if (Activity.Id != null)
-        {
-            return QuoteAsync(Activity.Id, activity, cancellationToken);
-        }
-
-        return SendActivityAsync(activity, cancellationToken);
-    }
-
-    /// <summary>
     /// Send a message to the conversation with a quoted message reference prepended to the text.
     /// Teams renders the quoted message as a preview bubble above the response text.
     /// </summary>
@@ -146,11 +117,8 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>The response from sending the activity.</returns>
     [Experimental("ExperimentalTeamsQuotedReplies")]
-    public Task<SendActivityResponse?> QuoteAsync(string messageId, string text, CancellationToken cancellationToken = default)
-    {
-        var reply = new MessageActivity(text);
-        return QuoteAsync(messageId, reply, cancellationToken);
-    }
+    public Task<SendActivityResponse?> Quote(string messageId, string text, CancellationToken cancellationToken = default)
+        => Quote(messageId, new MessageActivity(text), cancellationToken);
 
     /// <summary>
     /// Send a message to the conversation with a quoted message reference prepended to the text.
@@ -161,7 +129,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>The response from sending the activity.</returns>
     [Experimental("ExperimentalTeamsQuotedReplies")]
-    public Task<SendActivityResponse?> QuoteAsync(string messageId, TeamsActivity activity, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> Quote(string messageId, TeamsActivity activity, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
         ArgumentException.ThrowIfNullOrWhiteSpace(messageId);

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -71,7 +71,9 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
         => SendActivityAsync(activity, cancellationToken);
 
     /// <summary>
-    /// Sends a text message as a threaded reply to the current activity.
+    /// Sends a text message as a threaded reply to the current activity. When the inbound activity
+    /// has an id, the response auto-quotes it (rendered as a quote bubble above the response in Teams);
+    /// otherwise sends without quoting.
     /// </summary>
     /// <param name="text">The text to send.</param>
     /// <param name="cancellationToken">A cancellation token.</param>

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.Teams.Apps.Api.Clients;
 using Microsoft.Teams.Apps.OAuth;
 using Microsoft.Teams.Apps.Schema;
+using Microsoft.Teams.Apps.Schema.Entities;
 using Microsoft.Teams.Core;
 
 namespace Microsoft.Teams.Apps;
@@ -105,6 +107,69 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <returns>The response from the send operation.</returns>
     public Task<SendActivityResponse?> Typing(string? text = null, CancellationToken cancellationToken = default)
         => SendTypingActivityAsync(cancellationToken);
+
+    /// <summary>
+    /// Sends a message activity as a reply, automatically quoting the inbound message.
+    /// </summary>
+    /// <param name="text">The text to send.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>The response from sending the activity.</returns>
+    public Task<SendActivityResponse?> ReplyAsync(string text, CancellationToken cancellationToken = default)
+    {
+        var reply = new MessageActivity(text);
+        return ReplyAsync(reply, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends an activity as a reply, automatically quoting the inbound message.
+    /// </summary>
+    /// <param name="activity">The activity to send.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>The response from sending the activity.</returns>
+    public Task<SendActivityResponse?> ReplyAsync(TeamsActivity activity, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        if (Activity.Id != null)
+        {
+            return QuoteAsync(Activity.Id, activity, cancellationToken);
+        }
+
+        return SendActivityAsync(activity, cancellationToken);
+    }
+
+    /// <summary>
+    /// Send a message to the conversation with a quoted message reference prepended to the text.
+    /// Teams renders the quoted message as a preview bubble above the response text.
+    /// </summary>
+    /// <param name="messageId">The ID of the message to quote.</param>
+    /// <param name="text">The response text, appended to the quoted message placeholder.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>The response from sending the activity.</returns>
+    [Experimental("ExperimentalTeamsQuotedReplies")]
+    public Task<SendActivityResponse?> QuoteAsync(string messageId, string text, CancellationToken cancellationToken = default)
+    {
+        var reply = new MessageActivity(text);
+        return QuoteAsync(messageId, reply, cancellationToken);
+    }
+
+    /// <summary>
+    /// Send a message to the conversation with a quoted message reference prepended to the text.
+    /// Teams renders the quoted message as a preview bubble above the response text.
+    /// </summary>
+    /// <param name="messageId">The ID of the message to quote.</param>
+    /// <param name="activity">The activity to send — a quote placeholder for messageId will be prepended to its text.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>The response from sending the activity.</returns>
+    [Experimental("ExperimentalTeamsQuotedReplies")]
+    public Task<SendActivityResponse?> QuoteAsync(string messageId, TeamsActivity activity, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        if (activity is MessageActivity message)
+        {
+            message.PrependQuote(messageId);
+        }
+        return SendActivityAsync(activity, cancellationToken);
+    }
 
     // ==================== Core Send Methods ====================
 

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -91,7 +91,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     {
         ArgumentNullException.ThrowIfNull(activity);
 #pragma warning disable ExperimentalTeamsQuotedReplies
-        if (Activity.Id != null)
+        if (!string.IsNullOrWhiteSpace(Activity.Id))
         {
             return Quote(Activity.Id, activity, cancellationToken);
         }
@@ -125,7 +125,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// Teams renders the quoted message as a preview bubble above the response text.
     /// </summary>
     /// <param name="messageId">The ID of the message to quote.</param>
-    /// <param name="activity">The activity to send — a quote placeholder for messageId will be prepended to its text.</param>
+    /// <param name="activity">The activity to send. For <see cref="MessageActivity"/>, a quote placeholder for messageId is prepended to its text. Other activity types are sent as-is without quoting.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>The response from sending the activity.</returns>
     [Experimental("ExperimentalTeamsQuotedReplies")]

--- a/core/src/Microsoft.Teams.Apps/Microsoft.Teams.Apps.csproj
+++ b/core/src/Microsoft.Teams.Apps/Microsoft.Teams.Apps.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);ExperimentalTeamsQuotedReplies</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/src/Microsoft.Teams.Apps/Schema/Entities/ActivityQuotedReplyExtensions.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/Entities/ActivityQuotedReplyExtensions.cs
@@ -63,7 +63,8 @@ public static class ActivityQuotedReplyExtensions
 
     /// <summary>
     /// Prepend a QuotedReply entity and placeholder before existing text.
-    /// Used by ReplyAsync()/QuoteAsync() for quote-above-response.
+    /// Used by <see cref="Context{TActivity}.Reply(TeamsActivity, CancellationToken)"/> and
+    /// <see cref="Context{TActivity}.Quote(string, TeamsActivity, CancellationToken)"/> for quote-above-response.
     /// </summary>
     /// <param name="activity">The message activity to prepend the quoted reply to.</param>
     /// <param name="messageId">The ID of the message to quote.</param>

--- a/core/src/Microsoft.Teams.Apps/Schema/Entities/ActivityQuotedReplyExtensions.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/Entities/ActivityQuotedReplyExtensions.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Teams.Apps.Schema.Entities;
+
+/// <summary>
+/// Extension methods for Activity to handle quoted replies.
+/// </summary>
+[Experimental("ExperimentalTeamsQuotedReplies")]
+public static class ActivityQuotedReplyExtensions
+{
+    /// <summary>
+    /// Gets all quoted reply entities from the activity's entity collection.
+    /// </summary>
+    /// <param name="activity">The activity to extract quoted replies from. Cannot be null.</param>
+    /// <returns>An enumerable of QuotedReplyEntity instances found in the activity's entities.</returns>
+    public static IEnumerable<QuotedReplyEntity> GetQuotedMessages(this TeamsActivity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        if (activity.Entities == null)
+        {
+            return [];
+        }
+        return activity.Entities.Where(e => e is QuotedReplyEntity).Cast<QuotedReplyEntity>();
+    }
+
+    /// <summary>
+    /// Add a quoted message reference and append a placeholder to the message text.
+    /// Teams renders the quoted message as a preview bubble above the response text.
+    /// If text is provided, it is appended to the quoted message placeholder.
+    /// </summary>
+    /// <param name="activity">The message activity to add the quote to. Cannot be null.</param>
+    /// <param name="messageId">The ID of the message to quote. Cannot be null or whitespace.</param>
+    /// <param name="text">Optional text, appended to the quoted message placeholder.</param>
+    /// <returns>The created QuotedReplyEntity that was added to the activity.</returns>
+    public static QuotedReplyEntity AddQuote(this MessageActivity activity, string messageId, string? text = null)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(messageId);
+
+        QuotedReplyEntity entity = new() { QuotedReply = new QuotedReplyData { MessageId = messageId } };
+        activity.Entities ??= [];
+        activity.Entities.Add(entity);
+
+        var placeholder = $"<quoted messageId=\"{messageId}\"/>";
+        activity.Text = (activity.Text ?? "") + placeholder;
+        if (text != null)
+        {
+            activity.Text += $" {text}";
+        }
+
+        return entity;
+    }
+
+    /// <summary>
+    /// Prepend a QuotedReply entity and placeholder before existing text.
+    /// Used by ReplyAsync()/QuoteAsync() for quote-above-response.
+    /// </summary>
+    /// <param name="activity">The message activity to prepend the quoted reply to.</param>
+    /// <param name="messageId">The ID of the message to quote.</param>
+    public static void PrependQuote(this MessageActivity activity, string messageId)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(messageId);
+
+        activity.Entities ??= [];
+        activity.Entities.Add(new QuotedReplyEntity { QuotedReply = new QuotedReplyData { MessageId = messageId } });
+        var placeholder = $"<quoted messageId=\"{messageId}\"/>";
+        var text = activity.Text?.Trim() ?? "";
+        activity.Text = string.IsNullOrEmpty(text) ? placeholder : $"{placeholder} {text}";
+    }
+}

--- a/core/src/Microsoft.Teams.Apps/Schema/Entities/ActivityQuotedReplyExtensions.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/Entities/ActivityQuotedReplyExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Security;
 
 namespace Microsoft.Teams.Apps.Schema.Entities;
 
@@ -11,6 +12,13 @@ namespace Microsoft.Teams.Apps.Schema.Entities;
 [Experimental("ExperimentalTeamsQuotedReplies")]
 public static class ActivityQuotedReplyExtensions
 {
+    /// <summary>
+    /// Builds the inline placeholder element that pairs with a <see cref="QuotedReplyEntity"/>.
+    /// XML-escapes <paramref name="messageId"/> so values containing &quot;, &lt;, &amp; etc. can't break out of the attribute.
+    /// </summary>
+    internal static string QuotedPlaceholder(string messageId)
+        => $"<quoted messageId=\"{SecurityElement.Escape(messageId)}\"/>";
+
     /// <summary>
     /// Gets all quoted reply entities from the activity's entity collection.
     /// </summary>
@@ -44,8 +52,7 @@ public static class ActivityQuotedReplyExtensions
         activity.Entities ??= [];
         activity.Entities.Add(entity);
 
-        var placeholder = $"<quoted messageId=\"{messageId}\"/>";
-        activity.Text = (activity.Text ?? "") + placeholder;
+        activity.Text = (activity.Text ?? "") + QuotedPlaceholder(messageId);
         if (text != null)
         {
             activity.Text += $" {text}";
@@ -66,8 +73,8 @@ public static class ActivityQuotedReplyExtensions
         ArgumentException.ThrowIfNullOrWhiteSpace(messageId);
 
         activity.Entities ??= [];
-        activity.Entities.Add(new QuotedReplyEntity { QuotedReply = new QuotedReplyData { MessageId = messageId } });
-        var placeholder = $"<quoted messageId=\"{messageId}\"/>";
+        activity.Entities.Insert(0, new QuotedReplyEntity { QuotedReply = new QuotedReplyData { MessageId = messageId } });
+        var placeholder = QuotedPlaceholder(messageId);
         var text = activity.Text?.Trim() ?? "";
         activity.Text = string.IsNullOrEmpty(text) ? placeholder : $"{placeholder} {text}";
     }

--- a/core/src/Microsoft.Teams.Apps/Schema/Entities/ActivityQuotedReplyExtensions.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/Entities/ActivityQuotedReplyExtensions.cs
@@ -31,7 +31,7 @@ public static class ActivityQuotedReplyExtensions
         {
             return [];
         }
-        return activity.Entities.Where(e => e is QuotedReplyEntity).Cast<QuotedReplyEntity>();
+        return activity.Entities.OfType<QuotedReplyEntity>();
     }
 
     /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Schema/Entities/Entity.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/Entities/Entity.cs
@@ -69,6 +69,7 @@ public class EntityList : List<Entity>
                     "message" or "https://schema.org/Message" => DeserializeMessageEntity(item, options),
                     "ProductInfo" => item.Deserialize<ProductInfoEntity>(options),
                     "streaminfo" => item.Deserialize<StreamInfoEntity>(options),
+                    "quotedReply" => item.Deserialize<QuotedReplyEntity>(options),
                     _ => item.Deserialize<Entity>(options)
                 };
                 if (entity != null)

--- a/core/src/Microsoft.Teams.Apps/Schema/Entities/QuotedReplyEntity.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/Entities/QuotedReplyEntity.cs
@@ -15,7 +15,6 @@ public class QuotedReplyEntity : Entity
     /// <summary>
     /// Creates a new instance of <see cref="QuotedReplyEntity"/>.
     /// </summary>
-    [JsonConstructor]
     public QuotedReplyEntity() : base("quotedReply") { }
 
     /// <summary>
@@ -33,7 +32,7 @@ public class QuotedReplyEntity : Entity
     [JsonPropertyName("quotedReply")]
     public QuotedReplyData? QuotedReply
     {
-        get => base.Properties.TryGetValue("quotedReply", out object? value) ? value as QuotedReplyData : null;
+        get => base.Properties.Get<QuotedReplyData>("quotedReply");
         set => base.Properties["quotedReply"] = value;
     }
 }

--- a/core/src/Microsoft.Teams.Apps/Schema/Entities/QuotedReplyEntity.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/Entities/QuotedReplyEntity.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Teams.Apps.Schema.Entities;
+
+/// <summary>
+/// Represents a quoted reply entity in a Teams activity.
+/// </summary>
+[Experimental("ExperimentalTeamsQuotedReplies")]
+public class QuotedReplyEntity : Entity
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="QuotedReplyEntity"/>.
+    /// </summary>
+    public QuotedReplyEntity() : base("quotedReply") { }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="QuotedReplyEntity"/> with the specified message ID.
+    /// </summary>
+    /// <param name="messageId">The ID of the message being quoted.</param>
+    public QuotedReplyEntity(string messageId) : base("quotedReply")
+    {
+        QuotedReply = new QuotedReplyData { MessageId = messageId };
+    }
+
+    /// <summary>
+    /// Gets or sets the quoted reply data.
+    /// </summary>
+    [JsonPropertyName("quotedReply")]
+    public QuotedReplyData? QuotedReply
+    {
+        get => base.Properties.TryGetValue("quotedReply", out object? value) ? value as QuotedReplyData : null;
+        set => base.Properties["quotedReply"] = value;
+    }
+}
+
+/// <summary>
+/// Data for a quoted reply entity.
+/// </summary>
+[Experimental("ExperimentalTeamsQuotedReplies")]
+public class QuotedReplyData
+{
+    /// <summary>
+    /// The ID of the quoted message. Required.
+    /// </summary>
+    [JsonPropertyName("messageId")]
+    public string MessageId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The sender's bot-framework ID. Absent for deleted quotes.
+    /// </summary>
+    [JsonPropertyName("senderId")]
+    public string? SenderId { get; set; }
+
+    /// <summary>
+    /// The sender's display name. Absent for deleted quotes and TFL senders.
+    /// </summary>
+    [JsonPropertyName("senderName")]
+    public string? SenderName { get; set; }
+
+    /// <summary>
+    /// Preview of the quoted message text. Absent for deleted quotes and adaptive cards.
+    /// </summary>
+    [JsonPropertyName("preview")]
+    public string? Preview { get; set; }
+
+    /// <summary>
+    /// Timestamp of the quoted message (IC3 epoch value, e.g. "1772050244572").
+    /// Populated on inbound; ignored on outbound. Absent for deleted quotes.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public string? Time { get; set; }
+
+    /// <summary>
+    /// Whether the quoted message was deleted. Omitted when false.
+    /// </summary>
+    [JsonPropertyName("isReplyDeleted")]
+    public bool? IsReplyDeleted { get; set; }
+
+    /// <summary>
+    /// Whether all quoted message references are valid and compliant. Only included when true.
+    /// </summary>
+    [JsonPropertyName("validatedMessageReference")]
+    public bool? ValidatedMessageReference { get; set; }
+}

--- a/core/src/Microsoft.Teams.Apps/Schema/Entities/QuotedReplyEntity.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/Entities/QuotedReplyEntity.cs
@@ -15,6 +15,7 @@ public class QuotedReplyEntity : Entity
     /// <summary>
     /// Creates a new instance of <see cref="QuotedReplyEntity"/>.
     /// </summary>
+    [JsonConstructor]
     public QuotedReplyEntity() : base("quotedReply") { }
 
     /// <summary>
@@ -47,7 +48,7 @@ public class QuotedReplyData
     /// The ID of the quoted message. Required.
     /// </summary>
     [JsonPropertyName("messageId")]
-    public string MessageId { get; set; } = string.Empty;
+    public required string MessageId { get; set; }
 
     /// <summary>
     /// The sender's bot-framework ID. Absent for deleted quotes.

--- a/core/src/Microsoft.Teams.Apps/Schema/Entities/QuotedReplyEntity.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/Entities/QuotedReplyEntity.cs
@@ -23,6 +23,7 @@ public class QuotedReplyEntity : Entity
     /// <param name="messageId">The ID of the message being quoted.</param>
     public QuotedReplyEntity(string messageId) : base("quotedReply")
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(messageId);
         QuotedReply = new QuotedReplyData { MessageId = messageId };
     }
 

--- a/core/src/Microsoft.Teams.Apps/Schema/TeamsActivityBuilder.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/TeamsActivityBuilder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Teams.Apps.Schema.Entities;
 using Microsoft.Teams.Core.Schema;
 
@@ -44,11 +45,6 @@ public class TeamsActivityBuilder : CoreActivityBuilder<TeamsActivity, TeamsActi
         WithChannelId(activity.ChannelId);
         WithConversation(activity.Conversation);
         WithFrom(activity.Recipient);
-
-        if (!string.IsNullOrEmpty(activity.Id))
-        {
-            WithReplyToId(activity.Id);
-        }
 
         return this;
     }
@@ -247,6 +243,42 @@ public class TeamsActivityBuilder : CoreActivityBuilder<TeamsActivity, TeamsActi
     {
         ArgumentNullException.ThrowIfNull(_activity);
         _activity.SuggestedActions = suggestedActions;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a quoted reply entity and appends a placeholder to the activity text.
+    /// The activity type must be set to Message (via <see cref="CoreActivityBuilder{TActivity,TBuilder}.WithType"/>) before calling this method.
+    /// </summary>
+    /// <param name="messageId">The ID of the message to quote.</param>
+    /// <param name="text">Optional text, appended to the quoted message placeholder.</param>
+    /// <returns>The builder instance for chaining.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the activity type is not Message.</exception>
+    [Experimental("ExperimentalTeamsQuotedReplies")]
+    public TeamsActivityBuilder WithQuote(string messageId, string? text = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(messageId);
+
+        if (_activity.Type != TeamsActivityType.Message)
+        {
+            throw new InvalidOperationException("WithQuote can only be used on message activities. Call WithType(TeamsActivityType.Message) first.");
+        }
+
+        _activity.Entities ??= [];
+        _activity.Entities.Add(new QuotedReplyEntity
+        {
+            QuotedReply = new QuotedReplyData { MessageId = messageId }
+        });
+
+        string? currentText = _activity.Properties.TryGetValue("text", out object? value) ? value?.ToString() : null;
+        var placeholder = $"<quoted messageId=\"{messageId}\"/>";
+        var newText = (currentText ?? "") + placeholder;
+        if (text != null)
+        {
+            newText += $" {text}";
+        }
+        WithProperty("text", newText);
+
         return this;
     }
 

--- a/core/src/Microsoft.Teams.Apps/Schema/TeamsActivityBuilder.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/TeamsActivityBuilder.cs
@@ -270,14 +270,31 @@ public class TeamsActivityBuilder : CoreActivityBuilder<TeamsActivity, TeamsActi
             QuotedReply = new QuotedReplyData { MessageId = messageId }
         });
 
-        string? currentText = _activity.Properties.TryGetValue("text", out object? value) ? value?.ToString() : null;
+        string? currentText;
+        if (_activity is MessageActivity msgRead)
+        {
+            currentText = msgRead.Text;
+        }
+        else
+        {
+            currentText = _activity.Properties.TryGetValue("text", out object? value) ? value?.ToString() : null;
+        }
+
         var placeholder = ActivityQuotedReplyExtensions.QuotedPlaceholder(messageId);
         var newText = (currentText ?? "") + placeholder;
         if (text != null)
         {
             newText += $" {text}";
         }
-        WithProperty("text", newText);
+
+        if (_activity is MessageActivity msg)
+        {
+            msg.Text = newText;
+        }
+        else
+        {
+            WithProperty("text", newText);
+        }
 
         return this;
     }

--- a/core/src/Microsoft.Teams.Apps/Schema/TeamsActivityBuilder.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/TeamsActivityBuilder.cs
@@ -271,7 +271,7 @@ public class TeamsActivityBuilder : CoreActivityBuilder<TeamsActivity, TeamsActi
         });
 
         string? currentText = _activity.Properties.TryGetValue("text", out object? value) ? value?.ToString() : null;
-        var placeholder = $"<quoted messageId=\"{messageId}\"/>";
+        var placeholder = ActivityQuotedReplyExtensions.QuotedPlaceholder(messageId);
         var newText = (currentText ?? "") + placeholder;
         if (text != null)
         {

--- a/core/src/Microsoft.Teams.Apps/Schema/TeamsActivityJsonContext.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/TeamsActivityJsonContext.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Teams.Apps.Schema;
 [JsonSerializable(typeof(ProductInfoEntity))]
 [JsonSerializable(typeof(StreamInfoEntity))]
 [JsonSerializable(typeof(CitationEntity))]
+[JsonSerializable(typeof(QuotedReplyEntity))]
+[JsonSerializable(typeof(QuotedReplyData))]
 [JsonSerializable(typeof(CitationClaim))]
 [JsonSerializable(typeof(CitationAppearanceDocument))]
 [JsonSerializable(typeof(CitationImageObject))]

--- a/core/src/Microsoft.Teams.Core/ConversationClient.cs
+++ b/core/src/Microsoft.Teams.Core/ConversationClient.cs
@@ -63,11 +63,6 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
             url = $"{activity.ServiceUrl.ToString().TrimEnd('/')}/v3/conversations/{Uri.EscapeDataString(convId)}/activities/";
         }
 
-        if (!string.IsNullOrEmpty(activity.ReplyToId))
-        {
-            url += activity.ReplyToId;
-        }
-
         if (isTargeted)
         {
             url += url.Contains('?', StringComparison.Ordinal) ? "&isTargetedActivity=true" : "?isTargetedActivity=true";

--- a/core/src/Microsoft.Teams.Core/Schema/CoreActivityBuilder.cs
+++ b/core/src/Microsoft.Teams.Core/Schema/CoreActivityBuilder.cs
@@ -41,17 +41,6 @@ public abstract class CoreActivityBuilder<TActivity, TBuilder>
     }
 
     /// <summary>
-    /// Sets the identifier of the activity this activity is a reply to.
-    /// </summary>
-    /// <param name="replyToId">The ID of the activity to reply to.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    public TBuilder WithReplyToId(string replyToId)
-    {
-        _activity.ReplyToId = replyToId;
-        return (TBuilder)this;
-    }
-
-    /// <summary>
     /// Sets the service URL.
     /// </summary>
     /// <param name="serviceUrl">The service URL.</param>

--- a/core/test/Microsoft.Teams.Apps.UnitTests/QuotedReplyEntityTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/QuotedReplyEntityTests.cs
@@ -328,6 +328,75 @@ public class QuotedReplyEntityTests
         Assert.Contains("messageId", json);
     }
 
+    // Extension tests: PrependQuote
+
+    [Fact]
+    public void PrependQuote_EmptyText_SetsPlaceholderOnly()
+    {
+        MessageActivity activity = new();
+        activity.PrependQuote("msg-1");
+
+        Assert.Equal("<quoted messageId=\"msg-1\"/>", activity.Text);
+        Assert.Single(activity.Entities!);
+    }
+
+    [Fact]
+    public void PrependQuote_NonEmptyText_PrependsPlaceholderWithSpace()
+    {
+        MessageActivity activity = new("hello world");
+        activity.PrependQuote("msg-1");
+
+        Assert.Equal("<quoted messageId=\"msg-1\"/> hello world", activity.Text);
+    }
+
+    [Fact]
+    public void PrependQuote_TrimsExistingText()
+    {
+        MessageActivity activity = new("   hello   ");
+        activity.PrependQuote("msg-1");
+
+        Assert.Equal("<quoted messageId=\"msg-1\"/> hello", activity.Text);
+    }
+
+    [Fact]
+    public void PrependQuote_InsertsEntityAtIndexZero()
+    {
+        MessageActivity activity = new("existing");
+        activity.Entities = [new ClientInfoEntity { Locale = "en-us" }];
+
+        activity.PrependQuote("msg-1");
+
+        Assert.Equal(2, activity.Entities.Count);
+        Assert.IsType<QuotedReplyEntity>(activity.Entities[0]);
+        Assert.IsType<ClientInfoEntity>(activity.Entities[1]);
+        Assert.Equal("msg-1", ((QuotedReplyEntity)activity.Entities[0]).QuotedReply?.MessageId);
+    }
+
+    // Escaping tests
+
+    [Fact]
+    public void AddQuote_EscapesSpecialCharsInPlaceholder()
+    {
+        MessageActivity activity = new();
+        activity.AddQuote("msg<\"&>1");
+
+        // Placeholder uses XML-escaped attribute value; entity carries raw id
+        Assert.Equal("<quoted messageId=\"msg&lt;&quot;&amp;&gt;1\"/>", activity.Text);
+        var entity = (QuotedReplyEntity)activity.Entities![0];
+        Assert.Equal("msg<\"&>1", entity.QuotedReply?.MessageId);
+    }
+
+    [Fact]
+    public void Builder_WithQuote_EscapesSpecialCharsInPlaceholder()
+    {
+        TeamsActivity activity = TeamsActivity.CreateBuilder()
+            .WithQuote("a\"b")
+            .Build();
+
+        Assert.True(activity.Properties.TryGetValue("text", out object? text));
+        Assert.Equal("<quoted messageId=\"a&quot;b\"/>", text?.ToString());
+    }
+
     [Fact]
     public void Builder_WithQuote_MultipleQuotes()
     {

--- a/core/test/Microsoft.Teams.Apps.UnitTests/QuotedReplyEntityTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/QuotedReplyEntityTests.cs
@@ -1,0 +1,348 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Teams.Apps.Schema;
+using Microsoft.Teams.Apps.Schema.Entities;
+using Microsoft.Teams.Core.Schema;
+
+namespace Microsoft.Teams.Apps.UnitTests;
+
+#pragma warning disable ExperimentalTeamsQuotedReplies
+public class QuotedReplyEntityTests
+{
+    [Fact]
+    public void QuotedReplyEntity_HasCorrectType()
+    {
+        var entity = new QuotedReplyEntity();
+        Assert.Equal("quotedReply", entity.Type);
+    }
+
+    [Fact]
+    public void QuotedReplyEntity_SetsAndGetsQuotedReply()
+    {
+        var entity = new QuotedReplyEntity
+        {
+            QuotedReply = new QuotedReplyData
+            {
+                MessageId = "msg-123",
+                SenderId = "user-1",
+                SenderName = "Test User",
+                Preview = "Hello, world!",
+                Time = "1772050244572",
+                IsReplyDeleted = false,
+                ValidatedMessageReference = true
+            }
+        };
+
+        Assert.NotNull(entity.QuotedReply);
+        Assert.Equal("msg-123", entity.QuotedReply.MessageId);
+        Assert.Equal("user-1", entity.QuotedReply.SenderId);
+        Assert.Equal("Test User", entity.QuotedReply.SenderName);
+        Assert.Equal("Hello, world!", entity.QuotedReply.Preview);
+        Assert.Equal("1772050244572", entity.QuotedReply.Time);
+        Assert.False(entity.QuotedReply.IsReplyDeleted);
+        Assert.True(entity.QuotedReply.ValidatedMessageReference);
+    }
+
+    [Fact]
+    public void QuotedReplyEntity_ParameterizedConstructor_SetsMessageId()
+    {
+        var entity = new QuotedReplyEntity("msg-456");
+
+        Assert.Equal("quotedReply", entity.Type);
+        Assert.NotNull(entity.QuotedReply);
+        Assert.Equal("msg-456", entity.QuotedReply.MessageId);
+    }
+
+    [Fact]
+    public void QuotedReplyEntity_MinimalData()
+    {
+        var entity = new QuotedReplyEntity
+        {
+            QuotedReply = new QuotedReplyData { MessageId = "msg-1" }
+        };
+
+        Assert.NotNull(entity.QuotedReply);
+        Assert.Equal("msg-1", entity.QuotedReply.MessageId);
+        Assert.Null(entity.QuotedReply.SenderId);
+        Assert.Null(entity.QuotedReply.SenderName);
+        Assert.Null(entity.QuotedReply.Preview);
+        Assert.Null(entity.QuotedReply.Time);
+        Assert.Null(entity.QuotedReply.IsReplyDeleted);
+        Assert.Null(entity.QuotedReply.ValidatedMessageReference);
+    }
+
+    [Fact]
+    public void Fixture_QuotedReplyEntity_DeserializesFromJson()
+    {
+        string json = """
+        {
+          "type": "message",
+          "entities": [
+            {
+              "type": "quotedReply",
+              "quotedReply": {
+                "messageId": "1772050244572",
+                "senderId": "29:a6cdfb28-56f2-4912-b9c4-2181407c7dde",
+                "senderName": "Centralized Test Bot",
+                "preview": "Reply from bot.",
+                "time": "1772050244572",
+                "validatedMessageReference": true
+              }
+            }
+          ]
+        }
+        """;
+
+        CoreActivity coreActivity = CoreActivity.FromJsonString(json);
+        TeamsActivity activity = TeamsActivity.FromActivity(coreActivity);
+
+        Assert.NotNull(activity.Entities);
+        Assert.Single(activity.Entities);
+
+        var entity = activity.Entities[0] as QuotedReplyEntity;
+        Assert.NotNull(entity);
+        Assert.Equal("quotedReply", entity.Type);
+        Assert.NotNull(entity.QuotedReply);
+        Assert.Equal("1772050244572", entity.QuotedReply.MessageId);
+        Assert.Equal("29:a6cdfb28-56f2-4912-b9c4-2181407c7dde", entity.QuotedReply.SenderId);
+        Assert.Equal("Centralized Test Bot", entity.QuotedReply.SenderName);
+        Assert.Equal("Reply from bot.", entity.QuotedReply.Preview);
+        Assert.Equal("1772050244572", entity.QuotedReply.Time);
+        Assert.True(entity.QuotedReply.ValidatedMessageReference);
+    }
+
+    [Fact]
+    public void Fixture_QuotedReplyEntity_DeserializesMultipleQuotes()
+    {
+        string json = """
+        {
+          "type": "message",
+          "text": "<quoted messageId=\"msg-1\"/> first reply <quoted messageId=\"msg-2\"/> second reply",
+          "entities": [
+            {
+              "type": "quotedReply",
+              "quotedReply": {
+                "messageId": "msg-1",
+                "senderName": "User A",
+                "preview": "First message"
+              }
+            },
+            {
+              "type": "clientInfo",
+              "locale": "en-us"
+            },
+            {
+              "type": "quotedReply",
+              "quotedReply": {
+                "messageId": "msg-2",
+                "senderName": "User B",
+                "preview": "Second message"
+              }
+            }
+          ]
+        }
+        """;
+
+        CoreActivity coreActivity = CoreActivity.FromJsonString(json);
+        TeamsActivity activity = TeamsActivity.FromActivity(coreActivity);
+
+        Assert.NotNull(activity.Entities);
+        Assert.Equal(3, activity.Entities.Count);
+
+        var quotedReplies = activity.GetQuotedMessages().ToList();
+        Assert.Equal(2, quotedReplies.Count);
+        Assert.Equal("msg-1", quotedReplies[0].QuotedReply?.MessageId);
+        Assert.Equal("msg-2", quotedReplies[1].QuotedReply?.MessageId);
+    }
+
+    [Fact]
+    public void Fixture_QuotedReplyEntity_DeletedQuote()
+    {
+        string json = """
+        {
+          "type": "message",
+          "entities": [
+            {
+              "type": "quotedReply",
+              "quotedReply": {
+                "messageId": "deleted-msg-1",
+                "isReplyDeleted": true
+              }
+            }
+          ]
+        }
+        """;
+
+        CoreActivity coreActivity = CoreActivity.FromJsonString(json);
+        TeamsActivity activity = TeamsActivity.FromActivity(coreActivity);
+
+        var entity = activity.Entities?[0] as QuotedReplyEntity;
+        Assert.NotNull(entity);
+        Assert.True(entity.QuotedReply?.IsReplyDeleted);
+        Assert.Null(entity.QuotedReply?.SenderName);
+        Assert.Null(entity.QuotedReply?.Preview);
+    }
+
+    // Extension tests: GetQuotedMessages
+
+    [Fact]
+    public void GetQuotedMessages_FiltersCorrectly()
+    {
+        TeamsActivity activity = TeamsActivity.FromActivity(new CoreActivity(ActivityType.Message));
+        activity.Entities =
+        [
+            new ClientInfoEntity { Locale = "en-us" },
+            new QuotedReplyEntity { QuotedReply = new QuotedReplyData { MessageId = "msg-1" } },
+            new MentionEntity(new ConversationAccount { Id = "user-1", Name = "User" }, "<at>User</at>"),
+            new QuotedReplyEntity { QuotedReply = new QuotedReplyData { MessageId = "msg-2" } }
+        ];
+
+        var quotedReplies = activity.GetQuotedMessages().ToList();
+
+        Assert.Equal(2, quotedReplies.Count);
+        Assert.Equal("msg-1", quotedReplies[0].QuotedReply?.MessageId);
+        Assert.Equal("msg-2", quotedReplies[1].QuotedReply?.MessageId);
+    }
+
+    [Fact]
+    public void GetQuotedMessages_EmptyWhenNoEntities()
+    {
+        TeamsActivity activity = TeamsActivity.FromActivity(new CoreActivity(ActivityType.Message));
+        activity.Entities = null;
+
+        var quotedReplies = activity.GetQuotedMessages().ToList();
+
+        Assert.Empty(quotedReplies);
+    }
+
+    [Fact]
+    public void GetQuotedMessages_EmptyWhenNoQuotedReplyEntities()
+    {
+        TeamsActivity activity = TeamsActivity.FromActivity(new CoreActivity(ActivityType.Message));
+        activity.Entities = [new ClientInfoEntity { Locale = "en-us" }];
+
+        var quotedReplies = activity.GetQuotedMessages().ToList();
+
+        Assert.Empty(quotedReplies);
+    }
+
+    // Extension tests: AddQuote
+
+    [Fact]
+    public void AddQuote_AddsEntityAndPlaceholder()
+    {
+        MessageActivity activity = new("existing text");
+        activity.AddQuote("msg-1");
+
+        Assert.NotNull(activity.Entities);
+        Assert.Single(activity.Entities);
+        Assert.IsType<QuotedReplyEntity>(activity.Entities[0]);
+        var entity = (QuotedReplyEntity)activity.Entities[0];
+        Assert.Equal("msg-1", entity.QuotedReply?.MessageId);
+        Assert.Equal("existing text<quoted messageId=\"msg-1\"/>", activity.Text);
+    }
+
+    [Fact]
+    public void AddQuote_WithResponse_AppendsResponseText()
+    {
+        MessageActivity activity = new();
+        activity.AddQuote("msg-1", "my response");
+
+        Assert.Equal("<quoted messageId=\"msg-1\"/> my response", activity.Text);
+    }
+
+    [Fact]
+    public void AddQuote_MultiQuoteInterleaved()
+    {
+        MessageActivity activity = new();
+        activity.AddQuote("msg-1", "response to first");
+        activity.AddQuote("msg-2", "response to second");
+
+        Assert.Equal(
+            "<quoted messageId=\"msg-1\"/> response to first<quoted messageId=\"msg-2\"/> response to second",
+            activity.Text);
+        Assert.Equal(2, activity.Entities!.Count);
+    }
+
+    [Fact]
+    public void AddQuote_GroupedQuotes()
+    {
+        MessageActivity activity = new();
+        activity.AddQuote("msg-1");
+        activity.AddQuote("msg-2", "response to both");
+
+        Assert.Equal(
+            "<quoted messageId=\"msg-1\"/><quoted messageId=\"msg-2\"/> response to both",
+            activity.Text);
+    }
+
+    [Fact]
+    public void AddQuote_EmptyActivity()
+    {
+        MessageActivity activity = new();
+        activity.AddQuote("msg-1");
+
+        Assert.Equal("<quoted messageId=\"msg-1\"/>", activity.Text);
+        Assert.Single(activity.Entities!);
+    }
+
+    // Builder tests: WithQuote
+
+    [Fact]
+    public void Builder_WithQuote_AddsEntityAndPlaceholder()
+    {
+        TeamsActivity activity = TeamsActivity.CreateBuilder()
+            .WithQuote("msg-1")
+            .Build();
+
+        Assert.NotNull(activity.Entities);
+        Assert.Single(activity.Entities);
+        Assert.IsType<QuotedReplyEntity>(activity.Entities[0]);
+
+        // Check text via Properties (builder stores text there)
+        Assert.True(activity.Properties.TryGetValue("text", out object? text));
+        Assert.Equal("<quoted messageId=\"msg-1\"/>", text?.ToString());
+    }
+
+    [Fact]
+    public void Builder_WithQuote_WithResponse()
+    {
+        TeamsActivity activity = TeamsActivity.CreateBuilder()
+            .WithQuote("msg-1", "my response")
+            .Build();
+
+        Assert.True(activity.Properties.TryGetValue("text", out object? text));
+        Assert.Equal("<quoted messageId=\"msg-1\"/> my response", text?.ToString());
+    }
+
+    [Fact]
+    public void AddQuote_ToJson_ContainsQuotedReplyData()
+    {
+        MessageActivity activity = new("hello");
+        activity.AddQuote("msg-123", "my response");
+
+        string json = activity.ToJson();
+        Assert.Contains("\"quotedReply\"", json);
+        Assert.Contains("msg-123", json);
+        Assert.Contains("messageId", json);
+    }
+
+    [Fact]
+    public void Builder_WithQuote_MultipleQuotes()
+    {
+        TeamsActivity activity = TeamsActivity.CreateBuilder()
+            .WithQuote("msg-1", "first response")
+            .WithQuote("msg-2", "second response")
+            .Build();
+
+        Assert.NotNull(activity.Entities);
+        Assert.Equal(2, activity.Entities.Count);
+
+        Assert.True(activity.Properties.TryGetValue("text", out object? text));
+        Assert.Equal(
+            "<quoted messageId=\"msg-1\"/> first response<quoted messageId=\"msg-2\"/> second response",
+            text?.ToString());
+    }
+}
+#pragma warning restore ExperimentalTeamsQuotedReplies

--- a/core/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
@@ -378,77 +378,6 @@ public class ConversationClientTests
     }
 
     [Fact]
-    public async Task SendActivityAsync_WithReplyToId_AppendsReplyToIdToUrl()
-    {
-        HttpRequestMessage? capturedRequest = null;
-        Mock<HttpMessageHandler> mockHttpMessageHandler = new();
-        mockHttpMessageHandler
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("{\"id\":\"activity123\"}")
-            });
-
-        HttpClient httpClient = new(mockHttpMessageHandler.Object);
-        ConversationClient conversationClient = new(httpClient);
-
-        CoreActivity activity = new()
-        {
-            Type = ActivityType.Message,
-            ServiceUrl = new Uri("https://test.service.url/"),
-            Conversation = new("conv123"),
-            ReplyToId = "originalActivity456"
-        };
-
-        await conversationClient.SendActivityAsync(activity);
-
-        Assert.NotNull(capturedRequest);
-        Assert.Equal("https://test.service.url/v3/conversations/conv123/activities/originalActivity456", capturedRequest.RequestUri?.ToString());
-        Assert.Equal(HttpMethod.Post, capturedRequest.Method);
-    }
-
-    [Fact]
-    public async Task SendActivityAsync_WithEmptyReplyToId_DoesNotAppendReplyToIdToUrl()
-    {
-        HttpRequestMessage? capturedRequest = null;
-        Mock<HttpMessageHandler> mockHttpMessageHandler = new();
-        mockHttpMessageHandler
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("{\"id\":\"activity123\"}")
-            });
-
-        HttpClient httpClient = new(mockHttpMessageHandler.Object);
-        ConversationClient conversationClient = new(httpClient);
-
-        CoreActivity activity = new()
-        {
-            Type = ActivityType.Message,
-            ServiceUrl = new Uri("https://test.service.url/"),
-            Conversation = new("conv123"),
-            ReplyToId = ""
-        };
-
-        await conversationClient.SendActivityAsync(activity);
-
-        Assert.NotNull(capturedRequest);
-        Assert.Equal("https://test.service.url/v3/conversations/conv123/activities/", capturedRequest.RequestUri?.ToString());
-    }
-
-    [Fact]
     public async Task SendActivityAsync_WithAgentsChannel_TruncatesConversationId()
     {
         HttpRequestMessage? capturedRequest = null;
@@ -596,41 +525,4 @@ public class ConversationClientTests
         Assert.NotNull(result);
     }
 
-    [Fact]
-    public async Task SendActivityAsync_WithAgentsChannel_TruncatesConversationIdAndAppendsReplyToId()
-    {
-        HttpRequestMessage? capturedRequest = null;
-        Mock<HttpMessageHandler> mockHttpMessageHandler = new();
-        mockHttpMessageHandler
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("{\"id\":\"activity123\"}")
-            });
-
-        HttpClient httpClient = new(mockHttpMessageHandler.Object);
-        ConversationClient conversationClient = new(httpClient, NullLogger<ConversationClient>.Instance);
-
-        string longConversationId = new('x', 150);
-        CoreActivity activity = new()
-        {
-            Type = ActivityType.Message,
-            ChannelId = "agents",
-            ServiceUrl = new Uri("https://test.service.url/"),
-            Conversation = new(longConversationId),
-            ReplyToId = "replyActivity789"
-        };
-
-        await conversationClient.SendActivityAsync(activity);
-
-        Assert.NotNull(capturedRequest);
-        string expectedTruncatedId = "acf";
-        Assert.Equal($"https://test.service.url/v3/conversations/{expectedTruncatedId}/activities/replyActivity789", capturedRequest.RequestUri?.ToString());
-    }
 }

--- a/core/test/Microsoft.Teams.Core.UnitTests/CoreActivityBuilderTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/CoreActivityBuilderTests.cs
@@ -197,16 +197,6 @@ public class CoreActivityBuilderTests
     }
 
     [Fact]
-    public void WithReplyToId_SetsReplyToId()
-    {
-        CoreActivity activity = new CoreActivityBuilder()
-            .WithReplyToId("reply-123")
-            .Build();
-
-        Assert.Equal("reply-123", activity.ReplyToId);
-    }
-
-    [Fact]
     public void WithServiceUrl_String_SetsServiceUrl()
     {
         CoreActivity activity = new CoreActivityBuilder()


### PR DESCRIPTION
Re-port of #390 onto the merged `main:core/` layout. The original PR targeted `next/core`; since that branch was merged into `main` as the `core/` folder (PR #459, with namespaces renamed from `Microsoft.Teams.Bot.*` to `Microsoft.Teams.*`), the work has been redone on this new branch.

Closing #390 in favor of this PR.

## Apps changes (`core/src/Microsoft.Teams.Apps/`)
- `QuotedReplyEntity` + `QuotedReplyData` (`MessageId` required; `SenderId`/`SenderName`/`Preview`/`Time`/`IsReplyDeleted`/`ValidatedMessageReference` optional)
- `ActivityQuotedReplyExtensions`: `GetQuotedMessages()` on `TeamsActivity`, `AddQuote()`/`PrependQuote()` on `MessageActivity` (compile-time gated to message activities)
- Register `quotedReply` in `EntityList.FromJsonArray()` type switch and `TeamsActivityJsonContext` source-gen
- `Context.ReplyAsync(text)`/`ReplyAsync(activity)` — auto-quotes inbound message
- `Context.QuoteAsync(messageId, text/activity)` — `[Experimental("ExperimentalTeamsQuotedReplies")]`
- `TeamsActivityBuilder.WithQuote(messageId, text?)` — `[Experimental]`
- `NoWarn` on `ExperimentalTeamsQuotedReplies` in `Microsoft.Teams.Apps.csproj`

## Core changes (`core/src/Microsoft.Teams.Core/`)
- Remove dead `activity.ReplyToId` URL append in `ConversationClient.SendActivityAsync`
- Remove `WithReplyToId()` builder method (replaced by quote entities)
- `TeamsActivityBuilder.WithConversationReference` no longer auto-stamps `ReplyToId` from inbound `activity.Id`

## Tests
- `QuotedReplyEntityTests` — 19 tests (entity shape, JSON round-trip, extensions, builder, multi-quote scenarios)
- Drop `ReplyToId`-related tests in `ConversationClientTests` and `CoreActivityBuilderTests` (URL-append + `WithReplyToId` behavior gone)

## Sample
- `core/samples/Quoting/` exercises `ReplyAsync`/`QuoteAsync`/`AddQuote`/`WithQuote` and inbound quote metadata reading
- Wired into `core.slnx`

## Deviations from #390 (main:core/ conventions)
- **No `Rebase()` calls** — main's `EntityList` has its own `JsonConverter`, so the next/core sync-to-base-`JsonArray` pattern isn't needed
- `ReplyAsync` coexists with the existing `Context.Reply()` (which uses `WithConversationReference`) — different semantics, kept side-by-side rather than merged

## Test plan
- [x] `dotnet build core/core.slnx` — 0 warnings, 0 errors
- [x] `dotnet test core/core.slnx` — 567 tests pass on net8.0 + net10.0 (Apps 171×2, Core 92×2, BotBuilder 41)
- [x] E2E in Teams (canary ring per QR rendering gating)