### PR TITLE
fix(plugins): support AAD v1 (sts.windows.net) issuer in token validation

### DIFF
--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/TeamsValidationSettings.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/TeamsValidationSettings.cs
@@ -46,7 +46,9 @@ public class TeamsValidationSettings
         var validIssuers = new List<string>();
         if (!string.IsNullOrEmpty(tenantId))
         {
-            // Azure AD v2 issuer (cloud-specific login endpoint)
+            // Cloud-specific login endpoint issuer (e.g. https://login.microsoftonline.com/{tenantId}/).
+            // Note: this is the tenant-prefixed login endpoint form, not the AAD v2.0
+            // issuer (which ends in `/v2.0`).
             validIssuers.Add($"{LoginEndpoint}/{tenantId}/");
             // Azure AD v1 issuer (sts.windows.net) — some valid Microsoft Entra tokens
             // are still issued with the v1 issuer format.

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/TeamsValidationSettings.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/TeamsValidationSettings.cs
@@ -46,7 +46,12 @@ public class TeamsValidationSettings
         var validIssuers = new List<string>();
         if (!string.IsNullOrEmpty(tenantId))
         {
+            // Azure AD v2 issuer (cloud-specific login endpoint)
             validIssuers.Add($"{LoginEndpoint}/{tenantId}/");
+            // Azure AD v1 issuer (sts.windows.net) — some valid Microsoft Entra tokens
+            // are still issued with the v1 issuer format.
+            // See https://learn.microsoft.com/en-us/entra/identity-platform/access-tokens
+            validIssuers.Add($"https://sts.windows.net/{tenantId}/");
         }
         else
         {

--- a/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/Extensions/TeamsValidationSettingsTests.cs
+++ b/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/Extensions/TeamsValidationSettingsTests.cs
@@ -80,8 +80,22 @@ public class TeamsValidationSettingsTests
 
         var issuers = settings.GetValidIssuersForTenant("my-tenant").ToList();
 
-        Assert.Single(issuers);
+        Assert.Equal(2, issuers.Count);
         Assert.Equal("https://login.microsoftonline.us/my-tenant/", issuers[0]);
+        Assert.Equal("https://sts.windows.net/my-tenant/", issuers[1]);
+    }
+
+    [Fact]
+    public void GetValidIssuersForTenant_IncludesV1StsIssuer()
+    {
+        var settings = new TeamsValidationSettings(CloudEnvironment.Public);
+
+        var issuers = settings.GetValidIssuersForTenant("my-tenant").ToList();
+
+        // Some valid Microsoft Entra tokens are still issued with the AAD v1
+        // issuer (sts.windows.net) instead of the v2 login.microsoftonline.com issuer.
+        Assert.Contains("https://login.microsoftonline.com/my-tenant/", issuers);
+        Assert.Contains("https://sts.windows.net/my-tenant/", issuers);
     }
 
     [Fact]

--- a/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/Extensions/TeamsValidationSettingsTests.cs
+++ b/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/Extensions/TeamsValidationSettingsTests.cs
@@ -81,8 +81,8 @@ public class TeamsValidationSettingsTests
         var issuers = settings.GetValidIssuersForTenant("my-tenant").ToList();
 
         Assert.Equal(2, issuers.Count);
-        Assert.Equal("https://login.microsoftonline.us/my-tenant/", issuers[0]);
-        Assert.Equal("https://sts.windows.net/my-tenant/", issuers[1]);
+        Assert.Contains("https://login.microsoftonline.us/my-tenant/", issuers);
+        Assert.Contains("https://sts.windows.net/my-tenant/", issuers);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Mirrors [microsoft/teams.ts#556](https://github.com/microsoft/teams.ts/pull/556) for teams.net.

Extends tenant-based issuer validation in `TeamsValidationSettings.GetValidIssuersForTenant` to also accept the Azure AD v1 issuer format (`https://sts.windows.net/{tenantId}/`) in addition to the v2 issuer (`{LoginEndpoint}/{tenantId}/`).

## Motivation

Some valid Microsoft Entra tokens are issued with the AAD v1 issuer (`sts.windows.net`) instead of the v2-style `login.microsoftonline.com/.../v2.0` issuer. Without this change, tenant-based validation rejects otherwise-valid v1 tokens.

See: https://learn.microsoft.com/en-us/entra/identity-platform/access-tokens

## Changes

- `Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/TeamsValidationSettings.cs`: `GetValidIssuersForTenant` now returns both the v2 (cloud-specific login endpoint) and v1 (`sts.windows.net`) issuers for the configured tenant.
- `Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/Extensions/TeamsValidationSettingsTests.cs`: updated `GetValidIssuersForTenant_UsesCloudLoginEndpoint` to expect both issuers and added `GetValidIssuersForTenant_IncludesV1StsIssuer`.

### Notes on scope

- `Libraries/Microsoft.Teams.Apps/` doesn't contain JWT/issuer validation logic; the inbound auth pipeline lives in the AspNetCore plugin.
- `core/` already handles this — `Microsoft.Teams.Core/Hosting/JwtExtensions.ValidateTeamsIssuer` already accepts both v1 (`sts.windows.net/{tid}/`) and v2 (`login.microsoftonline.com/{tid}/v2.0`) issuers, so no change is needed there. See https://github.com/microsoft/teams.net/blob/main/core/src/Microsoft.Teams.Core/Hosting/JwtExtensions.cs#L159-L162.

## Test plan

- `dotnet test Tests/Microsoft.Teams.Plugins.AspNetCore.Tests --filter "FullyQualifiedName~TeamsValidationSettings"` — all 10 tests pass on net8.0 and net10.0.
- `dotnet build Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore` — succeeds with 0 warnings / 0 errors.
