### PR TITLE
Add proactive threading helpers to core (port of #425)

### DIFF
--- a/core/core.slnx
+++ b/core/core.slnx
@@ -27,6 +27,7 @@
     <Project Path="samples/TabApp/TabApp.csproj" />
     <Project Path="samples/TeamsBot/TeamsBot.csproj" Id="94a35050-6826-446f-9b29-863f2bbc75b7" />
     <Project Path="samples/TeamsChannelBot/TeamsChannelBot.csproj" />
+    <Project Path="samples/Threading/Threading.csproj" />
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path="../.azdo/ci.yaml" />

--- a/core/samples/Threading/Program.cs
+++ b/core/samples/Threading/Program.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Handlers;
+using Microsoft.Teams.Core.Schema;
+
+WebApplicationBuilder webAppBuilder = WebApplication.CreateSlimBuilder(args);
+webAppBuilder.Services.AddTeamsBotApplication();
+WebApplication webApp = webAppBuilder.Build();
+
+TeamsBotApplication teamsApp = webApp.UseTeamsBotApplication();
+
+teamsApp.OnMessage(async (context, cancellationToken) =>
+{
+    string text = (context.Activity.Text ?? "").ToLowerInvariant();
+    string conversationId = context.Activity.Conversation!.Id;
+    string messageId = context.Activity.Id!;
+
+    // When inside a thread, conversationId contains ;messageid=<rootId>.
+    // Extract the root ID for threading; for top-level messages, use activity.id.
+    string[] threadParts = conversationId.Split(";messageid=");
+    string threadRootId = threadParts.Length > 1 ? threadParts[1] : messageId;
+
+    // ============================================
+    // context.Reply() — reactive in-thread reply (sets ReplyToId)
+    // ============================================
+    if (text.Contains("test reply"))
+    {
+        await context.Reply("This is a reactive reply (in-thread, ReplyToId set).", cancellationToken);
+        return;
+    }
+
+    // ============================================
+    // context.Send() — reactive send to same conversation
+    // ============================================
+    if (text.Contains("test send"))
+    {
+        await context.Send("This is a reactive send (same conversation as the inbound).", cancellationToken);
+        return;
+    }
+
+    // ============================================
+    // teamsApp.Reply() — proactive threaded reply
+    // ============================================
+    if (text.Contains("test proactive"))
+    {
+        await teamsApp.Reply(conversationId, threadRootId, "This is a proactive threaded reply using teamsApp.Reply().", cancellationToken);
+        return;
+    }
+
+    // ============================================
+    // ToThreadedConversationId() + teamsApp.Send() — advanced manual control
+    // ============================================
+    if (text.Contains("test manual"))
+    {
+        string threadId = Conversation.ToThreadedConversationId(conversationId, threadRootId);
+        await teamsApp.Send(threadId, "This was sent using ToThreadedConversationId() + teamsApp.Send() for manual control.", cancellationToken: cancellationToken);
+        return;
+    }
+
+    // ============================================
+    // Help / Default
+    // ============================================
+    if (text.Contains("help"))
+    {
+        await context.Reply(
+            "**Threading Test Bot**\n\n" +
+            "**Commands:**\n" +
+            "- `test reply` - context.Reply() reactive threaded reply\n" +
+            "- `test send` - context.Send() to same thread without quoting\n" +
+            "- `test proactive` - teamsApp.Reply() proactive threaded reply\n" +
+            "- `test manual` - ToThreadedConversationId() + teamsApp.Send() for advanced control",
+            cancellationToken);
+        return;
+    }
+
+    await context.Send("Say \"help\" for available commands.", cancellationToken);
+});
+
+webApp.Run();

--- a/core/samples/Threading/Program.cs
+++ b/core/samples/Threading/Program.cs
@@ -17,6 +17,10 @@ teamsApp.OnMessage(async (context, cancellationToken) =>
     string conversationId = context.Activity.Conversation!.Id;
     string messageId = context.Activity.Id!;
 
+    // Store the agentic identity from the inbound activity's Recipient (the bot).
+    // Required for proactive messaging when running with agentic identities.
+    AgenticIdentity? agenticIdentity = context.Activity.Recipient?.GetAgenticIdentity();
+
     // When inside a thread, conversationId contains ;messageid=<rootId>.
     // Extract the root ID for threading; for top-level messages, use activity.id.
     string[] threadParts = conversationId.Split(";messageid=");
@@ -45,7 +49,7 @@ teamsApp.OnMessage(async (context, cancellationToken) =>
     // ============================================
     if (text.Contains("test proactive"))
     {
-        await teamsApp.Reply(conversationId, threadRootId, "This is a proactive threaded reply using teamsApp.Reply().", cancellationToken);
+        await teamsApp.Reply(conversationId, threadRootId, "This is a proactive threaded reply using teamsApp.Reply().", agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
         return;
     }
 
@@ -55,7 +59,7 @@ teamsApp.OnMessage(async (context, cancellationToken) =>
     if (text.Contains("test manual"))
     {
         string threadId = Conversation.ToThreadedConversationId(conversationId, threadRootId);
-        await teamsApp.Send(threadId, "This was sent using ToThreadedConversationId() + teamsApp.Send() for manual control.", cancellationToken: cancellationToken);
+        await teamsApp.Send(threadId, "This was sent using ToThreadedConversationId() + teamsApp.Send() for manual control.", agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
         return;
     }
 

--- a/core/samples/Threading/Program.cs
+++ b/core/samples/Threading/Program.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Handlers;
+using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Core.Schema;
 
 WebApplicationBuilder webAppBuilder = WebApplication.CreateSlimBuilder(args);
@@ -27,39 +28,39 @@ teamsApp.OnMessage(async (context, cancellationToken) =>
     string threadRootId = threadParts.Length > 1 ? threadParts[1] : messageId;
 
     // ============================================
-    // context.Reply() — reactive in-thread reply (sets ReplyToId)
+    // context.ReplyAsync() — reactive in-thread reply (sets ReplyToId)
     // ============================================
     if (text.Contains("test reply"))
     {
-        await context.Reply("This is a reactive reply (in-thread, ReplyToId set).", cancellationToken);
+        await context.ReplyAsync("This is a reactive reply (in-thread, ReplyToId set).", cancellationToken);
         return;
     }
 
     // ============================================
-    // context.Send() — reactive send to same conversation
+    // context.SendActivityAsync() — reactive send to same conversation
     // ============================================
     if (text.Contains("test send"))
     {
-        await context.Send("This is a reactive send (same conversation as the inbound).", cancellationToken);
+        await context.SendActivityAsync("This is a reactive send (same conversation as the inbound).", cancellationToken);
         return;
     }
 
     // ============================================
-    // teamsApp.Reply() — proactive threaded reply
+    // teamsApp.ReplyAsync() — proactive threaded reply
     // ============================================
     if (text.Contains("test proactive"))
     {
-        await teamsApp.Reply(conversationId, threadRootId, "This is a proactive threaded reply using teamsApp.Reply().", agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
+        await teamsApp.ReplyAsync(conversationId, threadRootId, "This is a proactive threaded reply using teamsApp.ReplyAsync().", agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
         return;
     }
 
     // ============================================
-    // ToThreadedConversationId() + teamsApp.Send() — advanced manual control
+    // ConversationExtensions.ToThreadedConversationId() + teamsApp.SendAsync() — advanced manual control
     // ============================================
     if (text.Contains("test manual"))
     {
-        string threadId = Conversation.ToThreadedConversationId(conversationId, threadRootId);
-        await teamsApp.Send(threadId, "This was sent using ToThreadedConversationId() + teamsApp.Send() for manual control.", agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
+        string threadId = ConversationExtensions.ToThreadedConversationId(conversationId, threadRootId);
+        await teamsApp.SendAsync(threadId, "This was sent using ToThreadedConversationId() + teamsApp.SendAsync() for manual control.", agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
         return;
     }
 
@@ -68,18 +69,21 @@ teamsApp.OnMessage(async (context, cancellationToken) =>
     // ============================================
     if (text.Contains("help"))
     {
-        await context.Reply(
+        MessageActivity helpMessage = new(
             "**Threading Test Bot**\n\n" +
             "**Commands:**\n" +
-            "- `test reply` - context.Reply() reactive threaded reply\n" +
-            "- `test send` - context.Send() to same thread without quoting\n" +
-            "- `test proactive` - teamsApp.Reply() proactive threaded reply\n" +
-            "- `test manual` - ToThreadedConversationId() + teamsApp.Send() for advanced control",
-            cancellationToken);
+            "- `test reply` - context.ReplyAsync() reactive in-thread reply\n" +
+            "- `test send` - context.SendActivityAsync() send to the same conversation\n" +
+            "- `test proactive` - teamsApp.ReplyAsync() proactive threaded reply\n" +
+            "- `test manual` - ToThreadedConversationId() + teamsApp.SendAsync() for advanced control")
+        {
+            TextFormat = TextFormats.Markdown
+        };
+        await context.ReplyAsync(helpMessage, cancellationToken);
         return;
     }
 
-    await context.Send("Say \"help\" for available commands.", cancellationToken);
+    await context.SendActivityAsync("Say \"help\" for available commands.", cancellationToken);
 });
 
 webApp.Run();

--- a/core/samples/Threading/README.md
+++ b/core/samples/Threading/README.md
@@ -6,18 +6,19 @@ A bot that demonstrates reactive and proactive threading in Microsoft Teams chan
 
 | Command | Behavior |
 |---------|----------|
-| `test reply` | `context.Reply()` — reactive in-thread reply (sets `ReplyToId`) |
-| `test send` | `context.Send()` — reactive send to the same conversation as the inbound activity |
-| `test proactive` | `teamsApp.Reply()` — proactive threaded reply via `;messageid=` |
-| `test manual` | `Conversation.ToThreadedConversationId()` + `teamsApp.Send()` — advanced manual control |
+| `test reply` | `context.ReplyAsync()` — reactive in-thread reply (sets `ReplyToId`) |
+| `test send` | `context.SendActivityAsync()` — reactive send to the same conversation as the inbound activity |
+| `test proactive` | `teamsApp.ReplyAsync()` — proactive threaded reply via `;messageid=` |
+| `test manual` | `ConversationExtensions.ToThreadedConversationId()` + `teamsApp.SendAsync()` — advanced manual control |
 | `help` | Shows available commands |
 
 ## Notes
 
-- `test reply` and `test send` use the inbound conversation reference. Both are visible to the user; `test reply` additionally sets `ReplyToId` so the Teams client renders it as a reply. The visual quote chrome (`<blockquote>` markup) is owned by the upcoming Quoted Replies API and is not part of this sample.
+- `test reply` and `test send` use the inbound conversation reference. Both are visible to the user; `test reply` additionally sets `ReplyToId` so the Teams client renders it as a reply.
 - `test proactive` constructs a threaded conversation ID via `;messageid=<rootId>` and sends to that thread. It exercises the `ToThreadedConversationId` validator (non-zero numeric `messageId`).
-- `test manual` does the same as `test proactive` using `Conversation.ToThreadedConversationId()` + `teamsApp.Send()` directly.
+- `test manual` does the same as `test proactive` using `ConversationExtensions.ToThreadedConversationId()` + `teamsApp.SendAsync()` directly.
 - `test proactive` and `test manual` may return a service error in conversation types that do not currently support threading (e.g. meetings, group chats).
+- **Personal / 1:1 chats**: `test proactive` and `test manual` currently return `BadArgument: Failed to decrypt conversation id` from the service until the relevant ECS rollout is complete. Channel scopes work today.
 
 ## Run
 

--- a/core/samples/Threading/README.md
+++ b/core/samples/Threading/README.md
@@ -1,0 +1,26 @@
+# Example: Threading
+
+A bot that demonstrates reactive and proactive threading in Microsoft Teams channels.
+
+## Commands
+
+| Command | Behavior |
+|---------|----------|
+| `test reply` | `context.Reply()` — reactive in-thread reply (sets `ReplyToId`) |
+| `test send` | `context.Send()` — reactive send to the same conversation as the inbound activity |
+| `test proactive` | `teamsApp.Reply()` — proactive threaded reply via `;messageid=` |
+| `test manual` | `Conversation.ToThreadedConversationId()` + `teamsApp.Send()` — advanced manual control |
+| `help` | Shows available commands |
+
+## Notes
+
+- `test reply` and `test send` use the inbound conversation reference. Both are visible to the user; `test reply` additionally sets `ReplyToId` so the Teams client renders it as a reply. The visual quote chrome (`<blockquote>` markup) is owned by the upcoming Quoted Replies API and is not part of this sample.
+- `test proactive` constructs a threaded conversation ID via `;messageid=<rootId>` and sends to that thread. It exercises the `ToThreadedConversationId` validator (non-zero numeric `messageId`).
+- `test manual` does the same as `test proactive` using `Conversation.ToThreadedConversationId()` + `teamsApp.Send()` directly.
+- `test proactive` and `test manual` may return a service error in conversation types that do not currently support threading (e.g. meetings, group chats).
+
+## Run
+
+```bash
+dotnet run
+```

--- a/core/samples/Threading/Threading.csproj
+++ b/core/samples/Threading/Threading.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Microsoft.Teams.Apps\Microsoft.Teams.Apps.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/core/samples/Threading/appsettings.json
+++ b/core/samples/Threading/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.Teams": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -58,7 +58,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="text">The text to send.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Send(string text, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> SendAsync(string text, CancellationToken cancellationToken = default)
         => SendActivityAsync(text, cancellationToken);
 
     /// <summary>
@@ -67,7 +67,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="activity">The activity to send.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Send(TeamsActivity activity, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> SendAsync(TeamsActivity activity, CancellationToken cancellationToken = default)
         => SendActivityAsync(activity, cancellationToken);
 
     /// <summary>
@@ -78,8 +78,8 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="text">The text to send.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Reply(string text, CancellationToken cancellationToken = default)
-        => Reply(new MessageActivity(text), cancellationToken);
+    public Task<SendActivityResponse?> ReplyAsync(string text, CancellationToken cancellationToken = default)
+        => ReplyAsync(new MessageActivity(text), cancellationToken);
 
     /// <summary>
     /// Sends an activity to the conversation. When the inbound activity has an id, the response
@@ -89,7 +89,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="activity">The activity to send.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Reply(TeamsActivity activity, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> ReplyAsync(TeamsActivity activity, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
 #pragma warning disable ExperimentalTeamsQuotedReplies
@@ -107,7 +107,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="text">Reserved for future use; currently ignored.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Typing(string? text = null, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> TypingAsync(string? text = null, CancellationToken cancellationToken = default)
         => SendTypingActivityAsync(cancellationToken);
 
     /// <summary>
@@ -141,6 +141,26 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
         }
         return SendActivityAsync(activity, cancellationToken);
     }
+
+    /// <inheritdoc cref="SendAsync(string, CancellationToken)"/>
+    public Task<SendActivityResponse?> Send(string text, CancellationToken cancellationToken = default)
+        => SendAsync(text, cancellationToken);
+
+    /// <inheritdoc cref="SendAsync(TeamsActivity, CancellationToken)"/>
+    public Task<SendActivityResponse?> Send(TeamsActivity activity, CancellationToken cancellationToken = default)
+        => SendAsync(activity, cancellationToken);
+
+    /// <inheritdoc cref="ReplyAsync(string, CancellationToken)"/>
+    public Task<SendActivityResponse?> Reply(string text, CancellationToken cancellationToken = default)
+        => ReplyAsync(text, cancellationToken);
+
+    /// <inheritdoc cref="ReplyAsync(TeamsActivity, CancellationToken)"/>
+    public Task<SendActivityResponse?> Reply(TeamsActivity activity, CancellationToken cancellationToken = default)
+        => ReplyAsync(activity, cancellationToken);
+
+    /// <inheritdoc cref="TypingAsync(string?, CancellationToken)"/>
+    public Task<SendActivityResponse?> Typing(string? text = null, CancellationToken cancellationToken = default)
+        => TypingAsync(text, cancellationToken);
 
     // ==================== Core Send Methods ====================
 
@@ -196,7 +216,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="options">OAuth options including connection name and card text.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The existing user token if found, or null if the sign-in flow was initiated.</returns>
-    public Task<string?> SignIn(OAuthOptions? options = null, CancellationToken cancellationToken = default)
+    public Task<string?> SignInAsync(OAuthOptions? options = null, CancellationToken cancellationToken = default)
     {
         OAuthFlow flow = ResolveOAuthFlow(options?.ConnectionName);
         return flow.SignInAsync(this, options, cancellationToken);
@@ -207,11 +227,19 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// </summary>
     /// <param name="connectionName">The connection name to sign out from. If null, uses the default registered connection.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
-    public Task SignOut(string? connectionName = null, CancellationToken cancellationToken = default)
+    public Task SignOutAsync(string? connectionName = null, CancellationToken cancellationToken = default)
     {
         OAuthFlow flow = ResolveOAuthFlow(connectionName);
         return flow.SignOutAsync(this, cancellationToken);
     }
+
+    /// <inheritdoc cref="SignInAsync(OAuthOptions?, CancellationToken)"/>
+    public Task<string?> SignIn(OAuthOptions? options = null, CancellationToken cancellationToken = default)
+        => SignInAsync(options, cancellationToken);
+
+    /// <inheritdoc cref="SignOutAsync(string?, CancellationToken)"/>
+    public Task SignOut(string? connectionName = null, CancellationToken cancellationToken = default)
+        => SignOutAsync(connectionName, cancellationToken);
 
     /// <summary>
     /// Whether the activity sender has a valid cached token.

--- a/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
@@ -194,7 +194,7 @@ public class TeamsBotApplication : BotApplication
     /// <returns>The response from the send operation.</returns>
     public Task<SendActivityResponse?> ReplyAsync(string conversationId, string messageId, string text, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
     {
-        string threadedConversationId = Conversation.ToThreadedConversationId(conversationId, messageId);
+        string threadedConversationId = ConversationExtensions.ToThreadedConversationId(conversationId, messageId);
         return SendAsync(threadedConversationId, text, agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
     }
 

--- a/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
@@ -180,7 +180,7 @@ public class TeamsBotApplication : BotApplication
     /// <returns>The response from the send operation.</returns>
     public Task<SendActivityResponse?> Reply(string conversationId, string messageId, string text, CancellationToken cancellationToken = default)
     {
-        string threadedConversationId = $"{conversationId};messageid={messageId}";
+        string threadedConversationId = Core.Schema.Conversation.ToThreadedConversationId(conversationId, messageId);
         return Send(threadedConversationId, text, cancellationToken: cancellationToken);
     }
 }

--- a/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
@@ -10,6 +10,7 @@ using Microsoft.Teams.Apps.Routing;
 using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Core;
 using Microsoft.Teams.Core.Hosting;
+using Microsoft.Teams.Core.Schema;
 
 namespace Microsoft.Teams.Apps;
 
@@ -151,20 +152,32 @@ public class TeamsBotApplication : BotApplication
     /// <param name="conversationId">The conversation ID to send to. For channel threads, include <c>;messageid=</c>.</param>
     /// <param name="text">The text to send.</param>
     /// <param name="serviceUrl">The service URL. If null, uses the last-seen service URL from an incoming activity.</param>
+    /// <param name="agenticIdentity">The agentic identity for user-delegated token acquisition. Extract from the inbound activity's <c>Recipient</c> via <see cref="ConversationAccount.GetAgenticIdentity"/>.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Send(string conversationId, string text, Uri? serviceUrl = null, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> SendAsync(string conversationId, string text, Uri? serviceUrl = null, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
     {
         Uri resolvedUrl = serviceUrl ?? _lastServiceUrl
             ?? throw new InvalidOperationException("No service URL available. Either pass a serviceUrl parameter or ensure the bot has received at least one activity.");
 
-        TeamsActivity activity = new TeamsActivityBuilder()
+        TeamsActivityBuilder builder = new TeamsActivityBuilder()
             .WithType(TeamsActivityType.Message)
             .WithServiceUrl(resolvedUrl)
             .WithChannelId("msteams")
-            .WithConversation(new Core.Schema.Conversation { Id = conversationId })
-            .WithText(text)
-            .Build();
+            .WithConversation(new Conversation { Id = conversationId })
+            .WithText(text);
+
+        if (agenticIdentity is not null)
+        {
+            builder.WithFrom(new ConversationAccount
+            {
+                AgenticAppId = agenticIdentity.AgenticAppId,
+                AgenticUserId = agenticIdentity.AgenticUserId,
+                AgenticAppBlueprintId = agenticIdentity.AgenticAppBlueprintId,
+            });
+        }
+
+        TeamsActivity activity = builder.Build();
 
         return SendActivityAsync(activity, cancellationToken: cancellationToken);
     }
@@ -176,11 +189,20 @@ public class TeamsBotApplication : BotApplication
     /// <param name="conversationId">The conversation ID.</param>
     /// <param name="messageId">The thread root message ID.</param>
     /// <param name="text">The text to send.</param>
+    /// <param name="agenticIdentity">The agentic identity for user-delegated token acquisition. Extract from the inbound activity's <c>Recipient</c> via <see cref="ConversationAccount.GetAgenticIdentity"/>.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Reply(string conversationId, string messageId, string text, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> ReplyAsync(string conversationId, string messageId, string text, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
     {
-        string threadedConversationId = Core.Schema.Conversation.ToThreadedConversationId(conversationId, messageId);
-        return Send(threadedConversationId, text, cancellationToken: cancellationToken);
+        string threadedConversationId = Conversation.ToThreadedConversationId(conversationId, messageId);
+        return SendAsync(threadedConversationId, text, agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
     }
+
+    /// <inheritdoc cref="SendAsync(string, string, Uri?, AgenticIdentity?, CancellationToken)"/>
+    public Task<SendActivityResponse?> Send(string conversationId, string text, Uri? serviceUrl = null, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
+        => SendAsync(conversationId, text, serviceUrl, agenticIdentity, cancellationToken);
+
+    /// <inheritdoc cref="ReplyAsync(string, string, string, AgenticIdentity?, CancellationToken)"/>
+    public Task<SendActivityResponse?> Reply(string conversationId, string messageId, string text, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
+        => ReplyAsync(conversationId, messageId, text, agenticIdentity, cancellationToken);
 }

--- a/core/src/Microsoft.Teams.Core/Schema/Conversation.cs
+++ b/core/src/Microsoft.Teams.Core/Schema/Conversation.cs
@@ -22,4 +22,41 @@ public class Conversation(string id = "")
     /// </summary>
     [JsonExtensionData]
     public ExtendedPropertiesDictionary Properties { get; set; } = [];
+
+    /// <summary>
+    /// The thread root portion of the conversation ID, with any <c>;messageid=</c> suffix stripped.
+    /// </summary>
+    [JsonIgnore]
+    public string ThreadId
+    {
+        get
+        {
+            var parts = Id.Split(';');
+            return parts.Length > 1 ? parts[0] : Id;
+        }
+    }
+
+    /// <summary>
+    /// Construct a threaded conversation ID by appending <c>;messageid={messageId}</c>
+    /// to the conversation ID. This is the format APX uses to route messages
+    /// to a specific thread in a channel.
+    /// </summary>
+    /// <param name="conversationId">the conversation to thread into (e.g. <c>19:abc@thread.skype</c>)</param>
+    /// <param name="messageId">the thread root message ID (must be a non-zero numeric string)</param>
+    /// <returns>the threaded conversation ID (e.g. <c>19:abc@thread.skype;messageid=123</c>)</returns>
+    public static string ToThreadedConversationId(string conversationId, string messageId)
+    {
+        if (string.IsNullOrEmpty(conversationId))
+        {
+            throw new ArgumentException("conversationId must be a non-empty string", nameof(conversationId));
+        }
+
+        if (string.IsNullOrEmpty(messageId) || !ulong.TryParse(messageId, out var parsed) || parsed == 0)
+        {
+            throw new ArgumentException($"Invalid messageId \"{messageId}\": must be a non-zero numeric value", nameof(messageId));
+        }
+
+        var baseId = conversationId.Split(';')[0];
+        return $"{baseId};messageid={messageId}";
+    }
 }

--- a/core/src/Microsoft.Teams.Core/Schema/Conversation.cs
+++ b/core/src/Microsoft.Teams.Core/Schema/Conversation.cs
@@ -22,41 +22,4 @@ public class Conversation(string id = "")
     /// </summary>
     [JsonExtensionData]
     public ExtendedPropertiesDictionary Properties { get; set; } = [];
-
-    /// <summary>
-    /// The thread root portion of the conversation ID, with any <c>;messageid=</c> suffix stripped.
-    /// </summary>
-    [JsonIgnore]
-    public string ThreadId
-    {
-        get
-        {
-            var parts = Id.Split(';');
-            return parts.Length > 1 ? parts[0] : Id;
-        }
-    }
-
-    /// <summary>
-    /// Construct a threaded conversation ID by appending <c>;messageid={messageId}</c>
-    /// to the conversation ID. This is the format APX uses to route messages
-    /// to a specific thread in a channel.
-    /// </summary>
-    /// <param name="conversationId">the conversation to thread into (e.g. <c>19:abc@thread.skype</c>)</param>
-    /// <param name="messageId">the thread root message ID (must be a non-zero numeric string)</param>
-    /// <returns>the threaded conversation ID (e.g. <c>19:abc@thread.skype;messageid=123</c>)</returns>
-    public static string ToThreadedConversationId(string conversationId, string messageId)
-    {
-        if (string.IsNullOrEmpty(conversationId))
-        {
-            throw new ArgumentException("conversationId must be a non-empty string", nameof(conversationId));
-        }
-
-        if (string.IsNullOrEmpty(messageId) || !ulong.TryParse(messageId, out var parsed) || parsed == 0)
-        {
-            throw new ArgumentException($"Invalid messageId \"{messageId}\": must be a non-zero numeric value", nameof(messageId));
-        }
-
-        var baseId = conversationId.Split(';')[0];
-        return $"{baseId};messageid={messageId}";
-    }
 }

--- a/core/src/Microsoft.Teams.Core/Schema/ConversationExtensions.cs
+++ b/core/src/Microsoft.Teams.Core/Schema/ConversationExtensions.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Teams.Core.Schema;
+
+/// <summary>
+/// Conversation ID helpers for threaded messaging.
+/// </summary>
+public static class ConversationExtensions
+{
+    /// <summary>
+    /// The thread root portion of the conversation ID, with any <c>;messageid=</c> suffix stripped.
+    /// </summary>
+    public static string ThreadId(this Conversation conversation)
+    {
+        ArgumentNullException.ThrowIfNull(conversation);
+        var parts = conversation.Id.Split(';');
+        return parts.Length > 1 ? parts[0] : conversation.Id;
+    }
+
+    /// <summary>
+    /// Construct a threaded conversation ID by appending <c>;messageid={messageId}</c>
+    /// to the conversation ID. This is the format APX uses to route messages
+    /// to a specific thread in a channel.
+    /// </summary>
+    /// <param name="conversationId">the conversation to thread into (e.g. <c>19:abc@thread.skype</c>)</param>
+    /// <param name="messageId">the thread root message ID (must be a non-zero numeric string)</param>
+    /// <returns>the threaded conversation ID (e.g. <c>19:abc@thread.skype;messageid=123</c>)</returns>
+    public static string ToThreadedConversationId(string conversationId, string messageId)
+    {
+        if (string.IsNullOrEmpty(conversationId))
+        {
+            throw new ArgumentException("conversationId must be a non-empty string", nameof(conversationId));
+        }
+
+        if (string.IsNullOrEmpty(messageId) || !ulong.TryParse(messageId, out var parsed) || parsed == 0)
+        {
+            throw new ArgumentException($"Invalid messageId \"{messageId}\": must be a non-zero numeric value", nameof(messageId));
+        }
+
+        var baseId = conversationId.Split(';')[0];
+        return $"{baseId};messageid={messageId}";
+    }
+}

--- a/core/test/Microsoft.Teams.Apps.UnitTests/TeamsBotApplicationTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/TeamsBotApplicationTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Teams.Apps.Api.Clients;
+using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Hosting;
+using Moq;
+
+namespace Microsoft.Teams.Apps.UnitTests;
+
+public class TeamsBotApplicationTests
+{
+    [Fact]
+    public async Task Reply_Proactive_ThrowsOnInvalidMessageId()
+    {
+        TeamsBotApplication app = CreateApp();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            app.Reply("19:abc@thread.skype", "not-a-number", "hello"));
+    }
+
+    [Fact]
+    public async Task Reply_Proactive_ThrowsOnZeroMessageId()
+    {
+        TeamsBotApplication app = CreateApp();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            app.Reply("19:abc@thread.skype", "0", "hello"));
+    }
+
+    [Fact]
+    public async Task Reply_Proactive_ThrowsOnEmptyConversationId()
+    {
+        TeamsBotApplication app = CreateApp();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            app.Reply("", "1680000000000", "hello"));
+    }
+
+    private static TeamsBotApplication CreateApp()
+    {
+        Mock<UserTokenClient> mockUserTokenClient = new(
+            new HttpClient(),
+            new Mock<IConfiguration>().Object,
+            NullLogger<UserTokenClient>.Instance);
+
+        Mock<ConversationClient> mockConversationClient = new(
+            new HttpClient(),
+            NullLogger<ConversationClient>.Instance);
+
+        ApiClient apiClient = new(
+            new HttpClient(),
+            mockConversationClient.Object,
+            mockUserTokenClient.Object);
+
+        return new TeamsBotApplication(
+            mockConversationClient.Object,
+            mockUserTokenClient.Object,
+            apiClient,
+            new HttpContextAccessor(),
+            NullLogger<TeamsBotApplication>.Instance,
+            new BotApplicationOptions { AppId = "test-app-id" });
+    }
+}

--- a/core/test/Microsoft.Teams.Apps.UnitTests/TeamsBotApplicationTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/TeamsBotApplicationTests.cs
@@ -19,7 +19,7 @@ public class TeamsBotApplicationTests
         TeamsBotApplication app = CreateApp();
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
-            app.Reply("19:abc@thread.skype", "not-a-number", "hello"));
+            app.ReplyAsync("19:abc@thread.skype", "not-a-number", "hello"));
     }
 
     [Fact]
@@ -28,7 +28,7 @@ public class TeamsBotApplicationTests
         TeamsBotApplication app = CreateApp();
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
-            app.Reply("19:abc@thread.skype", "0", "hello"));
+            app.ReplyAsync("19:abc@thread.skype", "0", "hello"));
     }
 
     [Fact]
@@ -37,7 +37,7 @@ public class TeamsBotApplicationTests
         TeamsBotApplication app = CreateApp();
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
-            app.Reply("", "1680000000000", "hello"));
+            app.ReplyAsync("", "1680000000000", "hello"));
     }
 
     private static TeamsBotApplication CreateApp()

--- a/core/test/Microsoft.Teams.Core.UnitTests/Schema/ConversationTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Schema/ConversationTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Teams.Core.Schema;
+
+namespace Microsoft.Teams.Core.UnitTests.Schema;
+
+public class ConversationTests
+{
+    [Fact]
+    public void ToThreadedConversationId_ConstructsThreadedConversationId()
+    {
+        var result = Conversation.ToThreadedConversationId("19:abc@thread.skype", "1680000000000");
+        Assert.Equal("19:abc@thread.skype;messageid=1680000000000", result);
+    }
+
+    [Fact]
+    public void ToThreadedConversationId_WorksWithDifferentConversationIdFormats()
+    {
+        var result = Conversation.ToThreadedConversationId("19:meeting_abc@thread.v2", "999");
+        Assert.Equal("19:meeting_abc@thread.v2;messageid=999", result);
+    }
+
+    [Fact]
+    public void ToThreadedConversationId_ThrowsOnEmptyConversationId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("", "123"));
+    }
+
+    [Fact]
+    public void ToThreadedConversationId_ThrowsOnNullConversationId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId(null!, "123"));
+    }
+
+    [Fact]
+    public void ToThreadedConversationId_ThrowsOnEmptyMessageId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", ""));
+    }
+
+    [Fact]
+    public void ToThreadedConversationId_ThrowsOnZeroMessageId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", "0"));
+    }
+
+    [Fact]
+    public void ToThreadedConversationId_ThrowsOnNonNumericMessageId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", "abc"));
+    }
+
+    [Fact]
+    public void ToThreadedConversationId_ThrowsOnNegativeMessageId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", "-1"));
+    }
+
+    [Fact]
+    public void ToThreadedConversationId_ThrowsOnDecimalMessageId()
+    {
+        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", "1.5"));
+    }
+
+    [Fact]
+    public void ToThreadedConversationId_StripsExistingMessageIdAndReplacesWithThreadRoot()
+    {
+        var result = Conversation.ToThreadedConversationId("19:abc@thread.skype;messageid=111", "222");
+        Assert.Equal("19:abc@thread.skype;messageid=222", result);
+    }
+
+    [Fact]
+    public void ThreadId_StripsMessageIdSuffix()
+    {
+        var conv = new Conversation("19:abc@thread.skype;messageid=1680000000000");
+        Assert.Equal("19:abc@thread.skype", conv.ThreadId);
+    }
+
+    [Fact]
+    public void ThreadId_ReturnsIdWhenNoSuffix()
+    {
+        var conv = new Conversation("19:abc@thread.skype");
+        Assert.Equal("19:abc@thread.skype", conv.ThreadId);
+    }
+}

--- a/core/test/Microsoft.Teams.Core.UnitTests/Schema/ConversationTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Schema/ConversationTests.cs
@@ -10,63 +10,63 @@ public class ConversationTests
     [Fact]
     public void ToThreadedConversationId_ConstructsThreadedConversationId()
     {
-        var result = Conversation.ToThreadedConversationId("19:abc@thread.skype", "1680000000000");
+        var result = ConversationExtensions.ToThreadedConversationId("19:abc@thread.skype", "1680000000000");
         Assert.Equal("19:abc@thread.skype;messageid=1680000000000", result);
     }
 
     [Fact]
     public void ToThreadedConversationId_WorksWithDifferentConversationIdFormats()
     {
-        var result = Conversation.ToThreadedConversationId("19:meeting_abc@thread.v2", "999");
+        var result = ConversationExtensions.ToThreadedConversationId("19:meeting_abc@thread.v2", "999");
         Assert.Equal("19:meeting_abc@thread.v2;messageid=999", result);
     }
 
     [Fact]
     public void ToThreadedConversationId_ThrowsOnEmptyConversationId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("", "123"));
+        Assert.Throws<ArgumentException>(() => ConversationExtensions.ToThreadedConversationId("", "123"));
     }
 
     [Fact]
     public void ToThreadedConversationId_ThrowsOnNullConversationId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId(null!, "123"));
+        Assert.Throws<ArgumentException>(() => ConversationExtensions.ToThreadedConversationId(null!, "123"));
     }
 
     [Fact]
     public void ToThreadedConversationId_ThrowsOnEmptyMessageId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", ""));
+        Assert.Throws<ArgumentException>(() => ConversationExtensions.ToThreadedConversationId("19:abc@thread.skype", ""));
     }
 
     [Fact]
     public void ToThreadedConversationId_ThrowsOnZeroMessageId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", "0"));
+        Assert.Throws<ArgumentException>(() => ConversationExtensions.ToThreadedConversationId("19:abc@thread.skype", "0"));
     }
 
     [Fact]
     public void ToThreadedConversationId_ThrowsOnNonNumericMessageId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", "abc"));
+        Assert.Throws<ArgumentException>(() => ConversationExtensions.ToThreadedConversationId("19:abc@thread.skype", "abc"));
     }
 
     [Fact]
     public void ToThreadedConversationId_ThrowsOnNegativeMessageId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", "-1"));
+        Assert.Throws<ArgumentException>(() => ConversationExtensions.ToThreadedConversationId("19:abc@thread.skype", "-1"));
     }
 
     [Fact]
     public void ToThreadedConversationId_ThrowsOnDecimalMessageId()
     {
-        Assert.Throws<ArgumentException>(() => Conversation.ToThreadedConversationId("19:abc@thread.skype", "1.5"));
+        Assert.Throws<ArgumentException>(() => ConversationExtensions.ToThreadedConversationId("19:abc@thread.skype", "1.5"));
     }
 
     [Fact]
     public void ToThreadedConversationId_StripsExistingMessageIdAndReplacesWithThreadRoot()
     {
-        var result = Conversation.ToThreadedConversationId("19:abc@thread.skype;messageid=111", "222");
+        var result = ConversationExtensions.ToThreadedConversationId("19:abc@thread.skype;messageid=111", "222");
         Assert.Equal("19:abc@thread.skype;messageid=222", result);
     }
 
@@ -74,13 +74,13 @@ public class ConversationTests
     public void ThreadId_StripsMessageIdSuffix()
     {
         var conv = new Conversation("19:abc@thread.skype;messageid=1680000000000");
-        Assert.Equal("19:abc@thread.skype", conv.ThreadId);
+        Assert.Equal("19:abc@thread.skype", conv.ThreadId());
     }
 
     [Fact]
     public void ThreadId_ReturnsIdWhenNoSuffix()
     {
         var conv = new Conversation("19:abc@thread.skype");
-        Assert.Equal("19:abc@thread.skype", conv.ThreadId);
+        Assert.Equal("19:abc@thread.skype", conv.ThreadId());
     }
 }


### PR DESCRIPTION
## Summary
- Adds `Microsoft.Teams.Core.Schema.ConversationExtensions` with a `ThreadId(this Conversation)` extension method and a `ToThreadedConversationId(conversationId, messageId)` static validator (rejects non-numeric / zero `messageId`, strips any existing `;messageid=` suffix). Ported from `Libraries/Microsoft.Teams.Api/Conversation.cs`, where they live as instance/static members on `Conversation`; on core they live as a separate extension class so `Conversation` stays a pure POCO.
- Replaces the inline `$"{conversationId};messageid={messageId}"` interpolation in proactive `TeamsBotApplication.ReplyAsync` with the validating helper.
- Adds `core/samples/Threading/` modeled on `Samples/Samples.Threading/` to exercise reactive (`context.ReplyAsync` / `context.SendActivityAsync`) and proactive (`teamsApp.ReplyAsync` / `ConversationExtensions.ToThreadedConversationId` + `teamsApp.SendAsync`) paths.
- Includes #493 (Rido), stacked on this PR: adds `Async`-suffixed methods to `Context` (`SendAsync`, `ReplyAsync`, `TypingAsync`, `SignInAsync`, `SignOutAsync`) and `TeamsBotApplication` (`SendAsync`, `ReplyAsync`) with the original names kept as backward-compat redirects; proactive `Send`/`Reply` accept an optional `AgenticIdentity?` for user-delegated token acquisition.

## Scope notes
- **`Context.ReplyAsync`** inherits the post-QR (PR #477) behavior on `main`: delegates to `Quote(Activity.Id, ...)` when the inbound activity has an id, producing a `<blockquote>`-rendered quoted reply. This PR doesn't change that delegation.
- **Personal / 1:1 chats**: `test proactive` and `test manual` currently fail at the service with `BadArgument: Failed to decrypt conversation id` until the relevant ECS rollout completes. Channel scopes work today. `core/samples/Threading/README.md` documents this caveat.

## Test plan
- [x] Unit: 12 `ConversationTests` (validator + `ThreadId` extension method)
- [x] Unit: 3 `TeamsBotApplicationTests` (validator propagates from proactive `ReplyAsync`)
- [x] Local CI: core-ci pipeline (325 tests on net8.0 + net10.0) + root build-test-lint / ci.yaml (813 tests + `dotnet pack`); 0 errors
- [x] E2E in Teams: 6 turns covering `test reply`, `test send`, `test proactive`, `test manual`, `help` across an existing thread, a new thread, and channel root — all returned 201 with correct routing (`;messageid=<rootId>` preserved/created appropriately, `ReplyToId` set on reactive paths only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)