### PR TITLE
core: drop Apps & Apps.BotBuilder InternalsVisibleTo from Microsoft.Teams.Core

### DIFF
--- a/core/src/Microsoft.Teams.Core/ConversationClient.cs
+++ b/core/src/Microsoft.Teams.Core/ConversationClient.cs
@@ -27,7 +27,12 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
 
     internal const string ConversationHttpClientName = "BotConversationClient";
 
-    internal BotHttpClient BotHttpClient => _botHttpClient;
+    /// <summary>
+    /// Gets the underlying <see cref="Http.BotHttpClient"/> used to issue authenticated requests to the conversation service.
+    /// Exposed so consumers can reuse the same auth-bound HTTP pipeline for channel- or platform-specific endpoints
+    /// not modeled directly on <see cref="ConversationClient"/>.
+    /// </summary>
+    public BotHttpClient BotHttpClient => _botHttpClient;
 
     /// <summary>
     /// Gets the default custom headers that will be included in all requests.

--- a/core/src/Microsoft.Teams.Core/GlobalSuppressions.cs
+++ b/core/src/Microsoft.Teams.Core/GlobalSuppressions.cs
@@ -8,3 +8,9 @@ using System.Diagnostics.CodeAnalysis;
     Justification = "Required for serialization",
     Scope = "namespaceanddescendants",
     Target = "~N:Microsoft.Teams.Core")]
+
+[assembly: SuppressMessage("Design",
+    "CA1054:URI-like parameters should not be strings",
+    Justification = "Callers build interpolated URLs with query strings and Uri-escaped segments; string parameters are the natural shape for this HTTP plumbing.",
+    Scope = "type",
+    Target = "~T:Microsoft.Teams.Core.Http.BotHttpClient")]

--- a/core/src/Microsoft.Teams.Core/Hosting/AddBotApplicationExtensions.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/AddBotApplicationExtensions.cs
@@ -103,8 +103,11 @@ public static class AddBotApplicationExtensions
     /// <param name="services">The service collection to add services to.</param>
     /// <param name="botConfig">The configuration containing Azure AD settings.</param>
     /// <returns>The service collection for method chaining.</returns>
-    internal static IServiceCollection AddBotApplication<TApp>(this IServiceCollection services, BotConfig botConfig) where TApp : BotApplication
+    public static IServiceCollection AddBotApplication<TApp>(this IServiceCollection services, BotConfig botConfig) where TApp : BotApplication
     {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(botConfig);
+
         services.AddSingleton<BotApplicationOptions>(sp =>
         {
             IConfiguration config = sp.GetRequiredService<IConfiguration>();
@@ -157,7 +160,17 @@ public static class AddBotApplicationExtensions
     private static IServiceCollection AddUserTokenClient(this IServiceCollection services, BotConfig botConfig) =>
         services.AddBotClient<UserTokenClient>(UserTokenClient.UserTokenHttpClientName, botConfig);
 
-    internal static IServiceCollection AddBotClient<TClient>(
+    /// <summary>
+    /// Registers a typed <see cref="HttpClient"/> for <typeparamref name="TClient"/> wired to bot authentication using
+    /// an already-resolved <see cref="BotConfig"/>. Use this overload when registering multiple bot clients that should
+    /// share a single resolved configuration.
+    /// </summary>
+    /// <typeparam name="TClient">The client class to register the named <see cref="HttpClient"/> for.</typeparam>
+    /// <param name="services">The service collection to add services to.</param>
+    /// <param name="httpClientName">The named <see cref="HttpClient"/> registration to associate with <typeparamref name="TClient"/>.</param>
+    /// <param name="botConfig">The resolved bot configuration containing tenant, client, and scope settings.</param>
+    /// <returns>The service collection for method chaining.</returns>
+    public static IServiceCollection AddBotClient<TClient>(
         this IServiceCollection services,
         string httpClientName,
         BotConfig botConfig) where TClient : class

--- a/core/src/Microsoft.Teams.Core/Hosting/BotConfig.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/BotConfig.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Teams.Core.Hosting;
 /// It supports multiple authentication modes: client secrets, system-assigned managed identities,
 /// user-assigned managed identities, and federated identity credentials (FIC).
 /// </remarks>
-internal sealed class BotConfig
+public sealed class BotConfig
 {
     /// <summary>
     /// Identifier used to specify system-assigned managed identity authentication.

--- a/core/src/Microsoft.Teams.Core/Http/BotHttpClient.cs
+++ b/core/src/Microsoft.Teams.Core/Http/BotHttpClient.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Teams.Core.Http;
 /// </summary>
 /// <param name="httpClient">The HTTP client instance used to send requests.</param>
 /// <param name="logger">The logger instance used for logging. Optional.</param>
-internal class BotHttpClient(HttpClient httpClient, ILogger? logger = null)
+public class BotHttpClient(HttpClient httpClient, ILogger? logger = null)
 {
     private const string UserAgent = "teams.net/" + ThisAssembly.NuGetPackageVersion;
 

--- a/core/src/Microsoft.Teams.Core/Http/BotRequestOptions.cs
+++ b/core/src/Microsoft.Teams.Core/Http/BotRequestOptions.cs
@@ -10,7 +10,7 @@ using CustomHeaders = Dictionary<string, string>;
 /// <summary>
 /// Options for configuring a bot HTTP request.
 /// </summary>
-internal record BotRequestOptions
+public record BotRequestOptions
 {
     /// <summary>
     /// Gets the agentic identity for authentication.

--- a/core/src/Microsoft.Teams.Core/Microsoft.Teams.Core.csproj
+++ b/core/src/Microsoft.Teams.Core/Microsoft.Teams.Core.csproj
@@ -10,8 +10,6 @@
 	<ItemGroup>
 		<InternalsVisibleTo Include="Microsoft.Teams.Apps.UnitTests" />
 		<InternalsVisibleTo Include="Microsoft.Teams.Core.UnitTests" />
-		<InternalsVisibleTo Include="Microsoft.Teams.Apps" />
-		<InternalsVisibleTo Include="Microsoft.Teams.Apps.BotBuilder" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.22" />

--- a/core/src/Microsoft.Teams.Core/Schema/CoreActivity.cs
+++ b/core/src/Microsoft.Teams.Core/Schema/CoreActivity.cs
@@ -151,7 +151,7 @@ public class CoreActivity
     /// </summary>
     /// <param name="type">The activity type. Defaults to "message".</param>
     [JsonConstructor]
-    internal CoreActivity(string type = ActivityType.Message)
+    public CoreActivity(string type = ActivityType.Message)
     {
         Type = type;
     }


### PR DESCRIPTION
## Summary
- Removes `<InternalsVisibleTo Include="Microsoft.Teams.Apps" />` and `<InternalsVisibleTo Include="Microsoft.Teams.Apps.BotBuilder" />` from `Microsoft.Teams.Core.csproj` so external SDK consumers see the same surface our own consumer projects do.
- Promotes the seven symbols Apps / Apps.BotBuilder were reaching across the friend boundary for: `BotHttpClient`, `BotRequestOptions`, `BotConfig`, `AddBotApplication<TApp>(IServiceCollection, BotConfig)`, `AddBotClient<TClient>`, `ConversationClient.BotHttpClient`, and the `CoreActivity(string)` `[JsonConstructor]` overload (needed for the source generator running in Apps).
- Adds an assembly-level CA1054 suppression scoped to `BotHttpClient` — string URL parameters are intentional given how callers compose interpolated, query-bearing, `Uri`-escaped URLs.

The two unit-test projects (`Microsoft.Teams.Apps.UnitTests`, `Microsoft.Teams.Core.UnitTests`) keep their friend grants, so the remaining internal plumbing they depend on (`TurnMiddleware`, `BotClientOptions`, `BotAuthenticationHandler`, `MsalConfigurationExtensions`, the `*HttpClientName` constants, `UserTokenClient.AgenticIdentity`, `JwtExtensions.AddBotAuthorization`, `GetLoggerFromServices`, the internal `CoreActivityBuilder` ctors, and `BotConfig.MsalConfigurationSection`) stays internal.

## Test plan
- [x] `dotnet build core/core.slnx -c Debug` clean across `net8.0` and `net10.0`
- [x] `Microsoft.Teams.Core.UnitTests` — 92 passing per TFM
- [x] `Microsoft.Teams.Apps.UnitTests` — 177 passing per TFM
- [x] `Microsoft.Teams.Apps.BotBuilder.UnitTests` — 41 passing (net10.0)
- [ ] Smoke a sample app end-to-end before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)