### PR TITLE
Fix MergedOptions[500] Authority warning from Microsoft.Identity.Web

### DIFF
--- a/core/src/Microsoft.Teams.Core/Hosting/AddBotApplicationExtensions.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/AddBotApplicationExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -150,9 +151,33 @@ public static class AddBotApplicationExtensions
                 .AddInMemoryTokenCaches()
                 .AddAgentIdentities();
 
+        ArgumentNullException.ThrowIfNull(botConfig.MsalConfigurationSection);
+
         if (!string.IsNullOrWhiteSpace(botConfig.ClientId))
         {
-            services.Configure<MicrosoftIdentityApplicationOptions>(botConfig.SectionName, botConfig.MsalConfigurationSection!);
+            string sectionKey = botConfig.MsalConfigurationSection.Key;
+            IConfigurationSection section = botConfig.MsalConfigurationSection;
+
+            services.Configure<MicrosoftIdentityApplicationOptions>(sectionKey, options =>
+            {
+                section.Bind(options);
+
+                // Default Instance when only TenantId is configured.
+                if (string.IsNullOrEmpty(options.Instance) && !string.IsNullOrEmpty(options.TenantId))
+                {
+                    options.Instance = "https://login.microsoftonline.com/";
+                }
+
+                // MicrosoftEntraApplicationOptions.Authority is a computed property that
+                // returns Instance/TenantId/v2.0 when _authority is null.  MergedOptions
+                // then sees Authority alongside Instance+TenantId and emits a warning
+                // (event 500).  Setting Authority to empty prevents the computed value
+                // from propagating while Instance+TenantId remain available for MSAL.
+                if (!string.IsNullOrEmpty(options.Instance) && !string.IsNullOrEmpty(options.TenantId))
+                {
+                    options.Authority = string.Empty;
+                }
+            });
         }
         return services;
     }


### PR DESCRIPTION
> [!NOTE]
> Stacked on #484

## Summary

Fixes the `Microsoft.Identity.Web.MergedOptions[500]` warning:
> Authority 'https://login.microsoftonline.com/{tenantId}/v2.0' is being ignored because Instance and/or TenantId are already configured.

### Root cause

`MicrosoftEntraApplicationOptions.Authority` is a **computed property**:
```csharp
public override string? Authority
{
    get { return _authority ?? $"{Instance?.TrimEnd('/')}/{TenantId}/v2.0"; }
    set { _authority = value; }
}
```

When the config section binds `Instance` + `TenantId` without an explicit `Authority`, the backing field `_authority` stays null, so the getter auto-computes Authority from Instance+TenantId. `MergedOptions.UpdateMergedOptionsFromMicrosoftIdentityApplicationOptions` then copies all three values into the merged options, and `ParseAuthorityIfNecessary` emits the warning (event 500) because it sees Authority alongside Instance+TenantId.

### Fix

- **Suppress computed Authority**: After binding the config section, explicitly set `Authority = string.Empty`. This overrides `_authority` from null to empty, so the `!string.IsNullOrEmpty()` check in `UpdateMergedOptionsFromMicrosoftIdentityApplicationOptions` skips it. Instance + TenantId remain intact for MSAL cloud detection.
- **Default Instance**: When only `TenantId` + `ClientId` are configured (no `Instance`), default Instance to `https://login.microsoftonline.com/`. This makes `AzureAd__Instance` optional in config.

## Test plan

- [ ] Run CoreBot with `AzureAd__Instance` + `AzureAd__TenantId` configured — verify warning is gone
- [ ] Run CoreBot with only `AzureAd__TenantId` + `AzureAd__ClientId` (no Instance) — verify bot authenticates correctly
- [ ] Verify token acquisition works for both app-only and agentic flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)