### PR TITLE
Add Async suffixes and agentic identity for proactive messaging

### DIFF
--- a/core/samples/Threading/Program.cs
+++ b/core/samples/Threading/Program.cs
@@ -17,6 +17,10 @@ teamsApp.OnMessage(async (context, cancellationToken) =>
     string conversationId = context.Activity.Conversation!.Id;
     string messageId = context.Activity.Id!;
 
+    // Store the agentic identity from the inbound activity's Recipient (the bot).
+    // Required for proactive messaging when running with agentic identities.
+    AgenticIdentity? agenticIdentity = context.Activity.Recipient?.GetAgenticIdentity();
+
     // When inside a thread, conversationId contains ;messageid=<rootId>.
     // Extract the root ID for threading; for top-level messages, use activity.id.
     string[] threadParts = conversationId.Split(";messageid=");
@@ -45,7 +49,7 @@ teamsApp.OnMessage(async (context, cancellationToken) =>
     // ============================================
     if (text.Contains("test proactive"))
     {
-        await teamsApp.Reply(conversationId, threadRootId, "This is a proactive threaded reply using teamsApp.Reply().", cancellationToken);
+        await teamsApp.Reply(conversationId, threadRootId, "This is a proactive threaded reply using teamsApp.Reply().", agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
         return;
     }
 
@@ -55,7 +59,7 @@ teamsApp.OnMessage(async (context, cancellationToken) =>
     if (text.Contains("test manual"))
     {
         string threadId = Conversation.ToThreadedConversationId(conversationId, threadRootId);
-        await teamsApp.Send(threadId, "This was sent using ToThreadedConversationId() + teamsApp.Send() for manual control.", cancellationToken: cancellationToken);
+        await teamsApp.Send(threadId, "This was sent using ToThreadedConversationId() + teamsApp.Send() for manual control.", agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
         return;
     }
 

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -56,7 +56,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="text">The text to send.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Send(string text, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> SendAsync(string text, CancellationToken cancellationToken = default)
         => SendActivityAsync(text, cancellationToken);
 
     /// <summary>
@@ -65,7 +65,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="activity">The activity to send.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Send(TeamsActivity activity, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> SendAsync(TeamsActivity activity, CancellationToken cancellationToken = default)
         => SendActivityAsync(activity, cancellationToken);
 
     /// <summary>
@@ -74,7 +74,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="text">The text to send.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Reply(string text, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> ReplyAsync(string text, CancellationToken cancellationToken = default)
     {
         TeamsActivity reply = new TeamsActivityBuilder()
             .WithConversationReference(Activity)
@@ -89,7 +89,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="activity">The activity to send.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Reply(TeamsActivity activity, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> ReplyAsync(TeamsActivity activity, CancellationToken cancellationToken = default)
     {
         TeamsActivity reply = new TeamsActivityBuilder(activity)
             .WithConversationReference(Activity)
@@ -103,8 +103,28 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="text">Reserved for future use; currently ignored.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Typing(string? text = null, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> TypingAsync(string? text = null, CancellationToken cancellationToken = default)
         => SendTypingActivityAsync(cancellationToken);
+
+    /// <inheritdoc cref="SendAsync(string, CancellationToken)"/>
+    public Task<SendActivityResponse?> Send(string text, CancellationToken cancellationToken = default)
+        => SendAsync(text, cancellationToken);
+
+    /// <inheritdoc cref="SendAsync(TeamsActivity, CancellationToken)"/>
+    public Task<SendActivityResponse?> Send(TeamsActivity activity, CancellationToken cancellationToken = default)
+        => SendAsync(activity, cancellationToken);
+
+    /// <inheritdoc cref="ReplyAsync(string, CancellationToken)"/>
+    public Task<SendActivityResponse?> Reply(string text, CancellationToken cancellationToken = default)
+        => ReplyAsync(text, cancellationToken);
+
+    /// <inheritdoc cref="ReplyAsync(TeamsActivity, CancellationToken)"/>
+    public Task<SendActivityResponse?> Reply(TeamsActivity activity, CancellationToken cancellationToken = default)
+        => ReplyAsync(activity, cancellationToken);
+
+    /// <inheritdoc cref="TypingAsync(string?, CancellationToken)"/>
+    public Task<SendActivityResponse?> Typing(string? text = null, CancellationToken cancellationToken = default)
+        => TypingAsync(text, cancellationToken);
 
     // ==================== Core Send Methods ====================
 
@@ -160,7 +180,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="options">OAuth options including connection name and card text.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The existing user token if found, or null if the sign-in flow was initiated.</returns>
-    public Task<string?> SignIn(OAuthOptions? options = null, CancellationToken cancellationToken = default)
+    public Task<string?> SignInAsync(OAuthOptions? options = null, CancellationToken cancellationToken = default)
     {
         OAuthFlow flow = ResolveOAuthFlow(options?.ConnectionName);
         return flow.SignInAsync(this, options, cancellationToken);
@@ -171,11 +191,19 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// </summary>
     /// <param name="connectionName">The connection name to sign out from. If null, uses the default registered connection.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
-    public Task SignOut(string? connectionName = null, CancellationToken cancellationToken = default)
+    public Task SignOutAsync(string? connectionName = null, CancellationToken cancellationToken = default)
     {
         OAuthFlow flow = ResolveOAuthFlow(connectionName);
         return flow.SignOutAsync(this, cancellationToken);
     }
+
+    /// <inheritdoc cref="SignInAsync(OAuthOptions?, CancellationToken)"/>
+    public Task<string?> SignIn(OAuthOptions? options = null, CancellationToken cancellationToken = default)
+        => SignInAsync(options, cancellationToken);
+
+    /// <inheritdoc cref="SignOutAsync(string?, CancellationToken)"/>
+    public Task SignOut(string? connectionName = null, CancellationToken cancellationToken = default)
+        => SignOutAsync(connectionName, cancellationToken);
 
     /// <summary>
     /// Whether the activity sender has a valid cached token.

--- a/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
@@ -10,6 +10,7 @@ using Microsoft.Teams.Apps.Routing;
 using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Core;
 using Microsoft.Teams.Core.Hosting;
+using Microsoft.Teams.Core.Schema;
 
 namespace Microsoft.Teams.Apps;
 
@@ -151,20 +152,32 @@ public class TeamsBotApplication : BotApplication
     /// <param name="conversationId">The conversation ID to send to. For channel threads, include <c>;messageid=</c>.</param>
     /// <param name="text">The text to send.</param>
     /// <param name="serviceUrl">The service URL. If null, uses the last-seen service URL from an incoming activity.</param>
+    /// <param name="agenticIdentity">The agentic identity for user-delegated token acquisition. Extract from the inbound activity's <c>Recipient</c> via <see cref="ConversationAccount.GetAgenticIdentity"/>.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Send(string conversationId, string text, Uri? serviceUrl = null, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> SendAsync(string conversationId, string text, Uri? serviceUrl = null, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
     {
         Uri resolvedUrl = serviceUrl ?? _lastServiceUrl
             ?? throw new InvalidOperationException("No service URL available. Either pass a serviceUrl parameter or ensure the bot has received at least one activity.");
 
-        TeamsActivity activity = new TeamsActivityBuilder()
+        TeamsActivityBuilder builder = new TeamsActivityBuilder()
             .WithType(TeamsActivityType.Message)
             .WithServiceUrl(resolvedUrl)
             .WithChannelId("msteams")
-            .WithConversation(new Core.Schema.Conversation { Id = conversationId })
-            .WithText(text)
-            .Build();
+            .WithConversation(new Conversation { Id = conversationId })
+            .WithText(text);
+
+        if (agenticIdentity is not null)
+        {
+            builder.WithFrom(new ConversationAccount
+            {
+                AgenticAppId = agenticIdentity.AgenticAppId,
+                AgenticUserId = agenticIdentity.AgenticUserId,
+                AgenticAppBlueprintId = agenticIdentity.AgenticAppBlueprintId,
+            });
+        }
+
+        TeamsActivity activity = builder.Build();
 
         return SendActivityAsync(activity, cancellationToken: cancellationToken);
     }
@@ -176,11 +189,20 @@ public class TeamsBotApplication : BotApplication
     /// <param name="conversationId">The conversation ID.</param>
     /// <param name="messageId">The thread root message ID.</param>
     /// <param name="text">The text to send.</param>
+    /// <param name="agenticIdentity">The agentic identity for user-delegated token acquisition. Extract from the inbound activity's <c>Recipient</c> via <see cref="ConversationAccount.GetAgenticIdentity"/>.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> Reply(string conversationId, string messageId, string text, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> ReplyAsync(string conversationId, string messageId, string text, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
     {
-        string threadedConversationId = Core.Schema.Conversation.ToThreadedConversationId(conversationId, messageId);
-        return Send(threadedConversationId, text, cancellationToken: cancellationToken);
+        string threadedConversationId = Conversation.ToThreadedConversationId(conversationId, messageId);
+        return SendAsync(threadedConversationId, text, agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
     }
+
+    /// <inheritdoc cref="SendAsync(string, string, Uri?, AgenticIdentity?, CancellationToken)"/>
+    public Task<SendActivityResponse?> Send(string conversationId, string text, Uri? serviceUrl = null, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
+        => SendAsync(conversationId, text, serviceUrl, agenticIdentity, cancellationToken);
+
+    /// <inheritdoc cref="ReplyAsync(string, string, string, AgenticIdentity?, CancellationToken)"/>
+    public Task<SendActivityResponse?> Reply(string conversationId, string messageId, string text, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
+        => ReplyAsync(conversationId, messageId, text, agenticIdentity, cancellationToken);
 }


### PR DESCRIPTION
## Summary
- Add `Async`-suffixed methods to `Context` (`SendAsync`, `ReplyAsync`, `TypingAsync`, `SignInAsync`, `SignOutAsync`) and `TeamsBotApplication` (`SendAsync`, `ReplyAsync`), keeping original names as redirects for backward compatibility.
- Proactive `Send`/`Reply` on `TeamsBotApplication` now accept an `AgenticIdentity?` parameter (matching the pattern in `ConversationClient`), so user-delegated token acquisition works when running with agentic identities.
- Threading sample updated to extract `AgenticIdentity` from the inbound activity's `Recipient` and pass it to proactive calls.

Stacked on #489.

## Test plan
- [ ] Verify `test proactive` and `test manual` commands work with agentic identities
- [ ] Verify reactive `test reply` and `test send` still work (no change in behavior)
- [ ] Verify existing callers using `Send`/`Reply` without `agenticIdentity` still compile and work

🤖 Generated with [Claude Code](https://claude.com/claude-code)