### PR TITLE
fix(core): log JWT bearer challenges to surface silent 401s

### DIFF
--- a/core/src/Microsoft.Teams.Core/Hosting/JwtExtensions.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/JwtExtensions.cs
@@ -256,6 +256,14 @@ namespace Microsoft.Teams.Core.Hosting
                         GetLogger(context.HttpContext, logger).ForbiddenForScheme(schemeName);
                         return Task.CompletedTask;
                     },
+                    OnChallenge = context =>
+                    {
+                        ILogger log = GetLogger(context.HttpContext, logger);
+                        string failureMessage = context.AuthenticateFailure?.Message
+                            ?? (string.IsNullOrEmpty(context.ErrorDescription) ? "no failure details" : context.ErrorDescription);
+                        log.JwtChallengeIssued(schemeName, failureMessage);
+                        return Task.CompletedTask;
+                    },
                     OnAuthenticationFailed = context =>
                     {
                         ILogger log = GetLogger(context.HttpContext, logger);

--- a/core/src/Microsoft.Teams.Core/Log.cs
+++ b/core/src/Microsoft.Teams.Core/Log.cs
@@ -112,4 +112,7 @@ internal static partial class Log
 
     [LoggerMessage(EventId = 56, Level = LogLevel.Warning, Message = "Using bypass authentication scheme succeeded for scheme: {Scheme}. This is INSECURE and should only be used for development.")]
     public static partial void BypassAuthenticationSucceeded(this ILogger logger, string scheme);
+
+    [LoggerMessage(EventId = 57, Level = LogLevel.Warning, Message = "JWT challenge issued for scheme {Scheme}: returning 401 (likely missing or malformed Authorization header). FailureMessage={FailureMessage}")]
+    public static partial void JwtChallengeIssued(this ILogger logger, string scheme, string failureMessage);
 }


### PR DESCRIPTION
## Summary
- Add an `OnChallenge` handler to `JwtBearerEvents` in `JwtExtensions.cs`. Previously, when the JWT bearer middleware rejected a request (missing or malformed Authorization header), the framework returned 401 with no log entry, and `BotApplication.ProcessAsync`'s info-level `ActivityReceived` never fired.
- Add a new `JwtChallengeIssued` `LoggerMessage` at warn level (EventId 57) carrying the failure message.
- Cross-SDK consistency fix: same diagnostic gap exists in teams.ts and teams.py (companion PRs filed against those repos).

## Test plan
- [x] `dotnet build core/src/Microsoft.Teams.Core/Microsoft.Teams.Core.csproj` (0 warnings, 0 errors)
- [x] `dotnet test core/test/Microsoft.Teams.Core.UnitTests` on net8.0 and net10.0 (96/96 each)
- [ ] Reviewer eyeball: confirm log message wording and EventId choice (57)