### PR TITLE
Hardcode auth scopes in BotAuthenticationHandler

### DIFF
--- a/core/src/Microsoft.Teams.Core/Hosting/AddBotApplicationExtensions.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/AddBotApplicationExtensions.cs
@@ -201,12 +201,10 @@ public static class AddBotApplicationExtensions
     {
         if (!string.IsNullOrWhiteSpace(botConfig.ClientId))
         {
-            string scope = botConfig.Scope;
             services.AddHttpClient<TClient>(httpClientName)
                 .AddHttpMessageHandler(sp => new BotAuthenticationHandler(
                     sp.GetRequiredService<IAuthorizationHeaderProvider>(),
                     sp.GetRequiredService<ILogger<BotAuthenticationHandler>>(),
-                    scope,
                     botConfig.SectionName,
                     sp.GetService<IOptions<ManagedIdentityOptions>>()));
         }

--- a/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
@@ -29,7 +29,7 @@ internal sealed class BotAuthenticationHandler(
     IOptions<ManagedIdentityOptions>? managedIdentityOptions = null) : DelegatingHandler
 {
     private const string AgenticScope = "https://botapi.skype.com/.default";
-    private const string AppScope = "https://api.botframework.com/.default";
+    private const string BotAppScope = "https://api.botframework.com/.default";
 
     private readonly IAuthorizationHeaderProvider _authorizationHeaderProvider = authorizationHeaderProvider ?? throw new ArgumentNullException(nameof(authorizationHeaderProvider));
     private readonly ILogger<BotAuthenticationHandler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -108,8 +108,8 @@ internal sealed class BotAuthenticationHandler(
             }
         }
 
-        _logAppOnlyToken(_logger, AppScope, null);
-        string appToken = await _authorizationHeaderProvider.CreateAuthorizationHeaderForAppAsync(AppScope, options, cancellationToken).ConfigureAwait(false);
+        _logAppOnlyToken(_logger, BotAppScope, null);
+        string appToken = await _authorizationHeaderProvider.CreateAuthorizationHeaderForAppAsync(BotAppScope, options, cancellationToken).ConfigureAwait(false);
 
 
         return appToken;

--- a/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
@@ -20,19 +20,19 @@ namespace Microsoft.Teams.Core.Hosting;
 /// </remarks>
 /// <param name="authorizationHeaderProvider">The authorization header provider for acquiring tokens.</param>
 /// <param name="logger">The logger instance.</param>
-/// <param name="scope">The scope for the token request.</param>
 /// <param name="authenticationOptionsName">The name of the MSAL configuration options to use for token acquisition. Defaults to "AzureAd".</param>
 /// <param name="managedIdentityOptions">Optional managed identity options. When set, tokens are acquired via the IMDS endpoint as the configured managed identity instead of via the app-credentials flow.</param>
 internal sealed class BotAuthenticationHandler(
     IAuthorizationHeaderProvider authorizationHeaderProvider,
     ILogger<BotAuthenticationHandler> logger,
-    string scope,
     string? authenticationOptionsName = null,
     IOptions<ManagedIdentityOptions>? managedIdentityOptions = null) : DelegatingHandler
 {
+    private const string AgenticScope = "https://botapi.skype.com/.default";
+    private const string AppScope = "https://api.botframework.com/.default";
+
     private readonly IAuthorizationHeaderProvider _authorizationHeaderProvider = authorizationHeaderProvider ?? throw new ArgumentNullException(nameof(authorizationHeaderProvider));
     private readonly ILogger<BotAuthenticationHandler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    private readonly string _scope = scope ?? throw new ArgumentNullException(nameof(scope));
     private readonly IOptions<ManagedIdentityOptions>? _managedIdentityOptions = managedIdentityOptions;
     private static readonly Action<ILogger, string, Exception?> _logAgenticToken =
         LoggerMessage.Define<string>(LogLevel.Debug, new(2), "Acquiring agentic token for AgenticAppId {AgenticAppId}");
@@ -103,13 +103,13 @@ internal sealed class BotAuthenticationHandler(
             else
             {
                 options.WithAgentUserIdentity(agenticIdentity.AgenticAppId, agenticUserGuid);
-                string token = await _authorizationHeaderProvider.CreateAuthorizationHeaderAsync([_scope], options, null, cancellationToken).ConfigureAwait(false);
+                string token = await _authorizationHeaderProvider.CreateAuthorizationHeaderAsync([AgenticScope], options, null, cancellationToken).ConfigureAwait(false);
                 return token;
             }
         }
 
-        _logAppOnlyToken(_logger, _scope, null);
-        string appToken = await _authorizationHeaderProvider.CreateAuthorizationHeaderForAppAsync(_scope, options, cancellationToken).ConfigureAwait(false);
+        _logAppOnlyToken(_logger, AppScope, null);
+        string appToken = await _authorizationHeaderProvider.CreateAuthorizationHeaderForAppAsync(AppScope, options, cancellationToken).ConfigureAwait(false);
 
 
         return appToken;


### PR DESCRIPTION
> [!NOTE]
> Stacked on #484

## Summary
- Remove `scope` parameter from `BotAuthenticationHandler` constructor
- Agentic identities always use `https://botapi.skype.com/.default`
- Non-agentic (app-only) always uses `https://api.botframework.com/.default`

## Test plan
- [ ] Verify app-only token acquisition uses the correct scope
- [ ] Verify agentic token acquisition uses the correct scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)