### PR TITLE
Set versionHeightOffset to -2 in core version.json files

### DIFF
--- a/core/src/Microsoft.Teams.Apps/version.json
+++ b/core/src/Microsoft.Teams.Apps/version.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "2.1.0-alpha.{height}",
+  "versionHeightOffset": -2,
   "publicReleaseRefSpec": [
     "^refs/heads/releases/core$"
   ],

--- a/core/version.json
+++ b/core/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "1.0",
-  "versionHeightOffset": -1,
+  "versionHeightOffset": -2,
   "pathFilters": ["."],
   "publicReleaseRefSpec": [
     "^refs/heads/releases/core$"


### PR DESCRIPTION
## Summary
- Set `versionHeightOffset` to `-2` in `core/version.json` (was `-1`).
- Add `versionHeightOffset: -2` to `core/src/Microsoft.Teams.Apps/version.json` (field was absent).

## Test plan
- [x] Verify Nerdbank.GitVersioning resolves the expected version height on `main` builds.
- [x] Verify Core package versions produced by CI reflect the new offset.