### PR TITLE
Close Incoming Connection ASAP

### DIFF
--- a/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
@@ -124,14 +124,18 @@ public class TeamsBotApplication : BotApplication
 
             Context<TeamsActivity> defaultContext = new(this, teamsActivity);
 
+            HttpContext? httpContext = httpContextAccessor.HttpContext;
             if (teamsActivity.Type != TeamsActivityType.Invoke)
             {
+                if (httpContext is not null)
+                {
+                    await httpContext.Response.CompleteAsync().ConfigureAwait(false);
+                }
                 await Router.DispatchAsync(defaultContext, cancellationToken).ConfigureAwait(false);
             }
             else // invokes
             {
                 InvokeResponse invokeResponse = await Router.DispatchWithReturnAsync(defaultContext, cancellationToken).ConfigureAwait(false);
-                HttpContext? httpContext = httpContextAccessor.HttpContext;
                 if (httpContext is not null && invokeResponse is not null)
                 {
                     httpContext.Response.StatusCode = invokeResponse.Status;

--- a/core/src/Microsoft.Teams.Core/ConversationClient.cs
+++ b/core/src/Microsoft.Teams.Core/ConversationClient.cs
@@ -77,6 +77,8 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
 
         string body = activity.ToJson();
 
+        logger.SendingActivity(url);
+
         return await _botHttpClient.SendAsync<SendActivityResponse>(
             HttpMethod.Post,
             url,

--- a/core/src/Microsoft.Teams.Core/ConversationClient.cs
+++ b/core/src/Microsoft.Teams.Core/ConversationClient.cs
@@ -77,7 +77,7 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
 
         string body = activity.ToJson();
 
-        logger.SendingActivity(url);
+        logger?.SendingActivity(url);
 
         return await _botHttpClient.SendAsync<SendActivityResponse>(
             HttpMethod.Post,

--- a/core/src/Microsoft.Teams.Core/ConversationClient.cs
+++ b/core/src/Microsoft.Teams.Core/ConversationClient.cs
@@ -65,7 +65,7 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
 
         if (activity.ChannelId == "agents")
         {
-            logger.TruncatingConversationId();
+            logger?.TruncatingConversationId();
             string convId = "acf"; //conversationId.Length > 100 ? conversationId[..100] : conversationId;
             url = $"{activity.ServiceUrl.ToString().TrimEnd('/')}/v3/conversations/{Uri.EscapeDataString(convId)}/activities/";
         }

--- a/core/src/Microsoft.Teams.Core/Log.cs
+++ b/core/src/Microsoft.Teams.Core/Log.cs
@@ -45,6 +45,9 @@ internal static partial class Log
     [LoggerMessage(EventId = 10, Level = LogLevel.Information, Message = "Truncating conversation ID for 'agents' channel to comply with length restrictions.")]
     public static partial void TruncatingConversationId(this ILogger logger);
 
+    [LoggerMessage(EventId = 16, Level = LogLevel.Information, Message = "Sending activity to {Url}")]
+    public static partial void SendingActivity(this ILogger logger, string url);
+
     [LoggerMessage(EventId = 11, Level = LogLevel.Trace, Message = "Updating activity at {Url}: {Activity}")]
     public static partial void UpdatingActivity(this ILogger logger, string url, string activity);
 

--- a/core/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
@@ -173,6 +173,79 @@ public class ConversationClientTests
     }
 
     [Fact]
+    public async Task SendActivityAsync_WithAgentsChannelId_UsesTruncatedConversationId()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        Mock<HttpMessageHandler> mockHttpMessageHandler = new();
+        mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{\"id\":\"activity123\"}")
+            });
+
+        HttpClient httpClient = new(mockHttpMessageHandler.Object);
+        ConversationClient conversationClient = new(httpClient);
+
+        CoreActivity activity = new()
+        {
+            Type = ActivityType.Message,
+            ChannelId = "agents",
+            ServiceUrl = new Uri("https://test.service.url/"),
+            Conversation = new("conv123")
+        };
+
+        await conversationClient.SendActivityAsync(activity);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("https://test.service.url/v3/conversations/acf/activities/", capturedRequest.RequestUri?.ToString());
+    }
+
+    [Fact]
+    public async Task SendActivityAsync_WithAgentsChannelIdAndIsTargeted_AppendsQueryString()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        Mock<HttpMessageHandler> mockHttpMessageHandler = new();
+        mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{\"id\":\"activity123\"}")
+            });
+
+        HttpClient httpClient = new(mockHttpMessageHandler.Object);
+        ConversationClient conversationClient = new(httpClient);
+
+#pragma warning disable ExperimentalTeamsTargeted
+        CoreActivity activity = new()
+        {
+            Type = ActivityType.Message,
+            ChannelId = "agents",
+            ServiceUrl = new Uri("https://test.service.url/"),
+            Conversation = new("conv123"),
+            Recipient = new ConversationAccount { IsTargeted = true }
+        };
+#pragma warning restore ExperimentalTeamsTargeted
+
+        await conversationClient.SendActivityAsync(activity);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("https://test.service.url/v3/conversations/acf/activities/?isTargetedActivity=true", capturedRequest.RequestUri?.ToString());
+    }
+
+    [Fact]
     public async Task SendActivityAsync_WithIsTargeted_AppendsQueryString()
     {
         HttpRequestMessage? capturedRequest = null;


### PR DESCRIPTION
We can close the incoming connection for non invoke activities

```text
dbug: Microsoft.AspNetCore.Server.Kestrel.Connections[39]
      Connection id "0HNLHQGJ6JS86" accepted.
dbug: Microsoft.AspNetCore.Server.Kestrel.Connections[1]
      Connection id "0HNLHQGJ6JS86" started.
info: Microsoft.Teams.Apps.TeamsBotApplication[3]
      Activity received: Type=message Id=1778775403709 ServiceUrl=https://smba.trafficmanager.net/amer/3f3d1cea-7a18-41af-872b-cfbbd5140984/ MSCV=bPuSShts/U6fY94S5jauZA.1.1.1.1412444336.1.1
dbug: Microsoft.AspNetCore.Server.Kestrel.Connections[9]
      Connection id "0HNLHQGJ6JS86" completed keep alive response.
info: Microsoft.Teams.Apps.TeamsBotApplication[0]
      Dispatching 'message' activity to route 'message/^/(\w+)(.*)$'.
info: Microsoft.Teams.Core.ConversationClient[16]
      Sending activity to https://smba.trafficmanager.net/amer/3f3d1cea-7a18-41af-872b-cfbbd5140984/v3/conversations/a%3A1ij7Mk7bnoSE8Ail2iMwWH4okEmR9RTwCDkmQf2KCweSQbjhGuIEO2Xw9Cj32Vq-rG_dzDRzC9XmQhV7QxRWP7ucqqlhIz96ugGhR65vxRtyi6B-fsi2U4siGPtkZW8ux/activities/
info: Microsoft.Teams.Apps.TeamsBotApplication[7]
      Finished processing activity: Id=1778775403709
```