### PR TITLE
Mark reactions API as GA across Libraries and core

### DIFF
--- a/Libraries/Microsoft.Teams.Api/Activities/Message/MessageReactionActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Message/MessageReactionActivity.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#pragma warning disable ExperimentalTeamsReactions
-
 using System.Text.Json.Serialization;
 
 using Microsoft.Teams.Common;
@@ -83,4 +81,3 @@ public class MessageReactionActivity() : Activity(ActivityType.MessageReaction)
         return this;
     }
 }
-#pragma warning restore ExperimentalTeamsReactions

--- a/Libraries/Microsoft.Teams.Api/Clients/ConversationClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/ConversationClient.cs
@@ -13,18 +13,14 @@ public class ConversationClient : Client
     public readonly string ServiceUrl;
     public readonly ActivityClient Activities;
     public readonly MemberClient Members;
-    #pragma warning disable ExperimentalTeamsReactions
     public readonly ReactionClient Reactions;
-    #pragma warning restore ExperimentalTeamsReactions
 
     public ConversationClient(string serviceUrl, CancellationToken cancellationToken = default) : base(cancellationToken)
     {
         ServiceUrl = serviceUrl;
         Activities = new ActivityClient(serviceUrl, _http, cancellationToken);
         Members = new MemberClient(serviceUrl, _http, cancellationToken);
-        #pragma warning disable ExperimentalTeamsReactions
         Reactions = new ReactionClient(serviceUrl, _http, cancellationToken);
-        #pragma warning restore ExperimentalTeamsReactions
     }
 
     public ConversationClient(string serviceUrl, IHttpClient client, CancellationToken cancellationToken = default) : base(client, cancellationToken)
@@ -32,9 +28,7 @@ public class ConversationClient : Client
         ServiceUrl = serviceUrl;
         Activities = new ActivityClient(serviceUrl, _http, cancellationToken);
         Members = new MemberClient(serviceUrl, _http, cancellationToken);
-        #pragma warning disable ExperimentalTeamsReactions
         Reactions = new ReactionClient(serviceUrl, _http, cancellationToken);
-        #pragma warning restore ExperimentalTeamsReactions
     }
 
     public ConversationClient(string serviceUrl, IHttpClientOptions options, CancellationToken cancellationToken = default) : base(options, cancellationToken)
@@ -42,9 +36,7 @@ public class ConversationClient : Client
         ServiceUrl = serviceUrl;
         Activities = new ActivityClient(serviceUrl, _http, cancellationToken);
         Members = new MemberClient(serviceUrl, _http, cancellationToken);
-        #pragma warning disable ExperimentalTeamsReactions
         Reactions = new ReactionClient(serviceUrl, _http, cancellationToken);
-        #pragma warning restore ExperimentalTeamsReactions
     }
 
     public ConversationClient(string serviceUrl, IHttpClientFactory factory, CancellationToken cancellationToken = default) : base(factory, cancellationToken)
@@ -52,9 +44,7 @@ public class ConversationClient : Client
         ServiceUrl = serviceUrl;
         Activities = new ActivityClient(serviceUrl, _http, cancellationToken);
         Members = new MemberClient(serviceUrl, _http, cancellationToken);
-        #pragma warning disable ExperimentalTeamsReactions
         Reactions = new ReactionClient(serviceUrl, _http, cancellationToken);
-        #pragma warning restore ExperimentalTeamsReactions
     }
 
     public async Task<ConversationResource> CreateAsync(CreateRequest request, CancellationToken cancellationToken = default)

--- a/Libraries/Microsoft.Teams.Api/Clients/ReactionClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/ReactionClient.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
-
 using Microsoft.Teams.Api.Messages;
 using Microsoft.Teams.Common.Http;
 
@@ -11,7 +9,6 @@ namespace Microsoft.Teams.Api.Clients;
 /// <summary>
 /// Client for working with app message reactions for a given conversation/activity.
 /// </summary>
-[Experimental("ExperimentalTeamsReactions")]
 public class ReactionClient : Client
 {
     public readonly string ServiceUrl;

--- a/Libraries/Microsoft.Teams.Api/Messages/Message.cs
+++ b/Libraries/Microsoft.Teams.Api/Messages/Message.cs
@@ -130,7 +130,5 @@ public class Message
     /// </summary>
     [JsonPropertyName("reactions")]
     [JsonPropertyOrder(16)]
-    #pragma warning disable ExperimentalTeamsReactions
     public IList<Reaction>? Reactions { get; set; }
-    #pragma warning restore ExperimentalTeamsReactions
 }

--- a/Libraries/Microsoft.Teams.Api/Messages/Reaction.cs
+++ b/Libraries/Microsoft.Teams.Api/Messages/Reaction.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 using Microsoft.Teams.Common;
@@ -11,7 +10,6 @@ namespace Microsoft.Teams.Api.Messages;
 /// <summary>
 /// The type of reaction given to the message.
 /// </summary>
-[Experimental("ExperimentalTeamsReactions")]
 [JsonConverter(typeof(JsonConverter<ReactionType>))]
 public class ReactionType(string value) : StringEnum(value)
 {
@@ -55,7 +53,6 @@ public class ReactionType(string value) : StringEnum(value)
 /// <summary>
 /// Message Reaction
 /// </summary>
-[Experimental("ExperimentalTeamsReactions")]
 public class Reaction
 {
     /// <summary>

--- a/Samples/Samples.Reactions/Samples.Reactions.csproj
+++ b/Samples/Samples.Reactions/Samples.Reactions.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <NoWarn>$(NoWarn);ExperimentalTeamsReactions</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Tests/Microsoft.Teams.Api.Tests/Microsoft.Teams.Api.Tests.csproj
+++ b/Tests/Microsoft.Teams.Api.Tests/Microsoft.Teams.Api.Tests.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
-    <NoWarn>$(NoWarn);ExperimentalTeamsReactions;ExperimentalTeamsTargeted;ExperimentalTeamsQuotedReplies</NoWarn>
+    <NoWarn>$(NoWarn);ExperimentalTeamsTargeted;ExperimentalTeamsQuotedReplies</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Microsoft.Teams.Apps.Tests/Microsoft.Teams.Apps.Tests.csproj
+++ b/Tests/Microsoft.Teams.Apps.Tests/Microsoft.Teams.Apps.Tests.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <NoWarn>$(NoWarn);CS0618;ExperimentalTeamsReactions;ExperimentalTeamsTargeted;ExperimentalTeamsQuotedReplies</NoWarn>
+        <NoWarn>$(NoWarn);CS0618;ExperimentalTeamsTargeted;ExperimentalTeamsQuotedReplies</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/core/samples/TeamsBot/TeamsBot.csproj
+++ b/core/samples/TeamsBot/TeamsBot.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<NoWarn>$(NoWarn);ExperimentalTeamsTargeted;ExperimentalTeamsReactions</NoWarn>
+		<NoWarn>$(NoWarn);ExperimentalTeamsTargeted</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs
@@ -31,7 +31,6 @@ public class ConversationApiClient
     /// <summary>
     /// Client for reaction operations.
     /// </summary>
-    [Experimental("ExperimentalTeamsReactions")]
     public ReactionClient Reactions { get; }
 
     internal ConversationApiClient(Uri serviceUrl, CoreConversationClient client)
@@ -40,9 +39,7 @@ public class ConversationApiClient
         _client = client;
         Activities = new ActivityClient(serviceUrl, client);
         Members = new MemberClient(serviceUrl, client);
-#pragma warning disable ExperimentalTeamsReactions // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         Reactions = new ReactionClient(serviceUrl, client);
-#pragma warning restore ExperimentalTeamsReactions // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ReactionClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ReactionClient.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Teams.Core.Schema;
 using CoreConversationClient = Microsoft.Teams.Core.ConversationClient;
 
@@ -11,7 +10,6 @@ namespace Microsoft.Teams.Apps.Api.Clients;
 /// Client for managing reactions on activities in a conversation.
 /// Delegates to the core <see cref="CoreConversationClient"/>.
 /// </summary>
-[Experimental("ExperimentalTeamsReactions")]
 public class ReactionClient
 {
     private readonly CoreConversationClient _client;

--- a/core/test/IntegrationTests/IntegrationTests.csproj
+++ b/core/test/IntegrationTests/IntegrationTests.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-	<NoWarn>$(NoWarn);ExperimentalTeamsTargeted;ExperimentalTeamsReactions</NoWarn>
+	<NoWarn>$(NoWarn);ExperimentalTeamsTargeted</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Removes the `[Experimental("ExperimentalTeamsReactions")]` attributes from `ReactionClient`, `ReactionType`, `Reaction`, and the `Reactions` property on `ConversationApiClient`/`ConversationClient`, across both `Libraries/` and `core/`. Also removes the corresponding `#pragma warning disable/restore` blocks and `NoWarn` entries in test and sample `.csproj` files.

The reactions feature is in sync across all three SDKs and the Teams service — no longer preview.

## Scope

**Attributes removed (5):**
- `Libraries/Microsoft.Teams.Api/Clients/ReactionClient.cs`
- `Libraries/Microsoft.Teams.Api/Messages/Reaction.cs` (`ReactionType` and `Reaction`)
- `core/src/Microsoft.Teams.Apps/Api/Clients/ReactionClient.cs`
- `core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs` (`Reactions` property)

**Suppressions removed (8 inline pragma locations + 5 NoWarn entries in .csproj files):**
- `Libraries/Microsoft.Teams.Api/Clients/ConversationClient.cs` (5 sites)
- `Libraries/Microsoft.Teams.Api/Messages/Message.cs`
- `Libraries/Microsoft.Teams.Api/Activities/Message/MessageReactionActivity.cs` (file-level)
- `core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs`
- `.csproj` NoWarn: `Samples/Samples.Reactions`, `core/test/IntegrationTests`, `core/samples/TeamsBot`, `Tests/Microsoft.Teams.Api.Tests`, `Tests/Microsoft.Teams.Apps.Tests`

The `Samples.Reactions/Program.cs` already demonstrates add → wait → delete cycle, so no sample change is needed here.

## Cross-SDK coordination

Part of the cross-SDK Reactions-GA pass. Sibling PRs:
- microsoft/teams.ts — Mark reactions API as GA
- microsoft/teams.py — Mark reactions API as GA
- microsoft/teams-sdk — drop .NET opt-in tip from the reactions guide

## Test plan

- [x] `dotnet build Microsoft.Teams.sln --configuration Release` — 0 errors
- [x] `dotnet build core.slnx --configuration Release` — 0 errors
- [x] `dotnet test Microsoft.Teams.sln` — all suites pass (Apps 146+146, Api 422, Common 63, AI 17, Graph 3, McpClient 9, AspNetCore 25+25 net8/net10)
- [x] `dotnet test core.slnx` — all suites pass (Apps.UnitTests 213+213, Core.UnitTests 101+101, BotBuilder.UnitTests 41)

## Versioning

No `version.json` change in this PR. Bump happens as part of the release flow per RELEASE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)