### PR TITLE
Add tag refs to nbgv publicReleaseRefSpec

### DIFF
--- a/version.json
+++ b/version.json
@@ -4,7 +4,8 @@
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$",
-    "^refs/heads/releases/v\\d+(?:\\.\\d+)?$"
+    "^refs/heads/releases/v\\d+(?:\\.\\d+)?$",
+    "^refs/tags/v\\d+(?:\\.\\d+(?:\\.\\d+)?)?$"
   ],
   "cloudBuild": {
     "buildNumber": {


### PR DESCRIPTION
## Summary
- CD pipeline triggered from a `v*` tag was producing `2.0.7.1` instead of `2.0.7` because Nerdbank.GitVersioning did not treat tag refs as public releases
- Adds `^refs/tags/v\d+(?:\.\d+(?:\.\d+)?)?$` to `publicReleaseRefSpec` in `version.json` so builds from tags like `v2.0.7` get a clean three-part NuGet version

## Test plan
- [ ] Trigger CD publish pipeline from a `v*` tag and confirm the produced NuGet package version is `2.0.x` (no trailing `.1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)