### PR TITLE
Make core packages compliant with Microsoft NuGet authoring requirements

### DIFF
--- a/core/src/Directory.Build.props
+++ b/core/src/Directory.Build.props
@@ -6,6 +6,7 @@
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <RepositoryUrl>https://github.com/microsoft/teams.net</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
+        <PackageProjectUrl>https://microsoft.github.io/teams-sdk</PackageProjectUrl>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <PackageIcon>bot_icon.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -22,7 +23,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-        <None Include="(MSBuildThisFileDirectory)../../../../bot_icon.png" Pack="true" PackagePath="/" />
+        <None Include="$(MSBuildThisFileDirectory)../bot_icon.png" Pack="true" PackagePath="/" />
         <None Include="README.md" Pack="true" PackagePath="/" />
     </ItemGroup>
     <ItemGroup>

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/Microsoft.Teams.Apps.BotBuilder.csproj
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/Microsoft.Teams.Apps.BotBuilder.csproj
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Apps.BotBuilder</PackageId>
     <PackageDescription>Bridge to support smooth migration from BotFramework SDK into Teams SDK.</PackageDescription>
-    <PackageTags>microsoft;teams;msteams;copilot;ai;adaptive-cards;apps;bots</PackageTags>
+    <PackageTags>microsoft;teams;msteams;copilot;apps;bots</PackageTags>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/Microsoft.Teams.Apps.BotBuilder.csproj
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/Microsoft.Teams.Apps.BotBuilder.csproj
@@ -1,4 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved.-->
+<!-- Licensed under the MIT License.-->
+
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
@@ -8,7 +11,8 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Apps.BotBuilder</PackageId>
-    <Description>Bridge to support smooth migration from BotFramework SDK into Teams SDK.</Description>
+    <PackageDescription>Bridge to support smooth migration from BotFramework SDK into Teams SDK.</PackageDescription>
+    <PackageTags>microsoft;teams;msteams;copilot;ai;adaptive-cards;apps;bots</PackageTags>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/core/src/Microsoft.Teams.Apps/Microsoft.Teams.Apps.csproj
+++ b/core/src/Microsoft.Teams.Apps/Microsoft.Teams.Apps.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Apps</PackageId>
     <PackageDescription>Create Microsoft Teams Bot Applications with ease.</PackageDescription>
-    <PackageTags>microsoft;teams;msteams;copilot;ai;adaptive-cards;apps;bots</PackageTags>
+    <PackageTags>microsoft;teams;msteams;copilot;apps;bots</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/src/Microsoft.Teams.Apps/Microsoft.Teams.Apps.csproj
+++ b/core/src/Microsoft.Teams.Apps/Microsoft.Teams.Apps.csproj
@@ -1,4 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved.-->
+<!-- Licensed under the MIT License.-->
+
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
@@ -9,7 +12,8 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Apps</PackageId>
-    <Description>Create Microsoft Teams Bot Applications with ease.</Description>
+    <PackageDescription>Create Microsoft Teams Bot Applications with ease.</PackageDescription>
+    <PackageTags>microsoft;teams;msteams;copilot;ai;adaptive-cards;apps;bots</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/src/Microsoft.Teams.Apps/version.json
+++ b/core/src/Microsoft.Teams.Apps/version.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "2.1.0-preview.{height}",
+  "versionHeightOffset": -3,
   "publicReleaseRefSpec": [
     "^refs/heads/releases/core$"
   ],

--- a/core/src/Microsoft.Teams.Core/Microsoft.Teams.Core.csproj
+++ b/core/src/Microsoft.Teams.Core/Microsoft.Teams.Core.csproj
@@ -14,7 +14,7 @@
 	<PropertyGroup>
 		<PackageId>Microsoft.Teams.Core</PackageId>
 		<PackageDescription>BotApplication and CoreActivity to support Microsoft Teams development.</PackageDescription>
-		<PackageTags>microsoft;teams;msteams;copilot;ai;adaptive-cards;apps;bots</PackageTags>
+		<PackageTags>microsoft;teams;msteams;copilot;apps;bots</PackageTags>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/core/src/Microsoft.Teams.Core/Microsoft.Teams.Core.csproj
+++ b/core/src/Microsoft.Teams.Core/Microsoft.Teams.Core.csproj
@@ -1,4 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved.-->
+<!-- Licensed under the MIT License.-->
+
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
@@ -10,7 +13,8 @@
 
 	<PropertyGroup>
 		<PackageId>Microsoft.Teams.Core</PackageId>
-		<Description>BotApplication and CoreActivity to support Microsoft Teams development.</Description>
+		<PackageDescription>BotApplication and CoreActivity to support Microsoft Teams development.</PackageDescription>
+		<PackageTags>microsoft;teams;msteams;copilot;ai;adaptive-cards;apps;bots</PackageTags>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/core/version.json
+++ b/core/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "1.0",
-  "versionHeightOffset": -3,
+  "versionHeightOffset": -6,
   "pathFilters": ["."],
   "publicReleaseRefSpec": [
     "^refs/heads/releases/core$"


### PR DESCRIPTION
## Summary
- Brings the three core packages (`Microsoft.Teams.Core`, `Microsoft.Teams.Apps`, `Microsoft.Teams.Apps.BotBuilder`) into compliance with the Microsoft NuGet package authoring requirements.
- Adds `PackageProjectUrl`, fixes a broken `PackageIcon` packing path in `core/src/Directory.Build.props`, renames `Description` → `PackageDescription`, adds `PackageTags`, and adds MIT license/copyright header comments to each csproj.
- Also bumps `versionHeightOffset` in `core/version.json` and `core/src/Microsoft.Teams.Apps/version.json`.

### Compliance gaps addressed
| Requirement | Before | After |
| --- | --- | --- |
| `PackageProjectUrl` | missing | `https://microsoft.github.io/teams-sdk` |
| `PackageIcon` packing | broken path (`(MSBuildThisFileDirectory)../../../../bot_icon.png`) | `$(MSBuildThisFileDirectory)../bot_icon.png` |
| `PackageDescription` | used `Description` | `PackageDescription` |
| `PackageTags` | missing | `microsoft;teams;msteams;copilot;ai;adaptive-cards;apps;bots` |
| License header | missing | MIT header comment in each csproj |

### Known follow-up (not in this PR)
- `core/bot_icon.png` is 75x75; the authoring spec recommends 100x100 (with clean downscaling to 32/48/64/128).
- Strong-name signing (`SignAssembly` + `key.snk`) — not adopted in core yet, matches existing core stance.

## Test plan
- [ ] `dotnet pack` the three core projects locally and inspect the produced `.nupkg` to confirm `bot_icon.png` and `README.md` are packed at the root and the metadata fields render correctly.
- [ ] Verify the icon shows up on the nuget.org preview / `nuget.exe verify` step in CI.
- [ ] CI build passes on the branch.