### PR TITLE
Security hardening: gate DevTools WebSocket behind same-origin check

### DIFF
--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore.DevTools/DevToolsPlugin.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore.DevTools/DevToolsPlugin.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -54,10 +55,28 @@ public class DevToolsPlugin : IAspNetCorePlugin
 
     public IApplicationBuilder Configure(IApplicationBuilder builder)
     {
-        builder.UseWebSockets(new WebSocketOptions()
+        // Reject cross-origin WebSocket upgrades. The DevTools UI is always
+        // loaded same-origin, so Origin must equal request Host; absent
+        // Origin is rejected. Headers are inspected directly so this
+        // middleware does not require UseWebSockets to run first.
+        builder.Use(async (context, next) =>
         {
-            AllowedOrigins = { "*" }
+            var upgrade = context.Request.Headers["Upgrade"].ToString();
+            if (string.Equals(upgrade, "websocket", StringComparison.OrdinalIgnoreCase))
+            {
+                var origin = context.Request.Headers["Origin"].ToString();
+                var expectedOrigin = $"{context.Request.Scheme}://{context.Request.Host}";
+                if (string.IsNullOrEmpty(origin) ||
+                    !string.Equals(origin, expectedOrigin, StringComparison.OrdinalIgnoreCase))
+                {
+                    context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    return;
+                }
+            }
+            await next(context);
         });
+
+        builder.UseWebSockets();
 
         builder.UseStaticFiles(new StaticFileOptions()
         {


### PR DESCRIPTION
## Summary

Replaces the DevTools WebSocket `WebSocketOptions.AllowedOrigins = { "*" }` policy with a same-origin middleware that rejects upgrades whose `Origin` header does not match the request `Host` (and rejects absent `Origin`).

## Why

The DevTools UI is always loaded from the same origin as the bot server, so legitimate clients send an `Origin` matching `Host`. Allowing any origin permitted any web page open in the developer's browser during local dev to open `ws://localhost:<port>/devtools/sockets` and inject or sniff DevTools traffic. Same-origin policy closes this without affecting the DevTools UI's own use of the endpoint.

## What this does not change

- No public API change.
- No behavior change for the DevTools UI in normal use (it always loads same-origin).
- DevTools is already environment-guarded (cannot start in `Production`), so this change tightens dev-mode behavior only.

## Implementation note

The Origin check inspects the `Upgrade` and `Origin` request headers directly rather than using `context.WebSockets.IsWebSocketRequest`, so the middleware does not depend on `UseWebSockets()` having registered `IHttpWebSocketFeature` first.

## Validation

- Full solution `dotnet build` and `dotnet test -f net10.0` clean.
- `Samples.Echo` with DevTools enabled:
  - Same-origin upgrade (`Origin: http://localhost:3978`) → 101 Switching Protocols
  - Cross-origin upgrade (`Origin: https://attacker.example`) → 403 Forbidden
  - Missing `Origin` → 403 Forbidden
  - Plain GET `/devtools/` → 200 (UI still serves)

## Scope note: core/ (2.1)

`core/` does not register a similar WebSocket origin policy; the equivalent DevTools surface there does not currently exist. This PR scopes to `Libraries/`.