### PR TITLE
feat: SuggestedActionSubmit handler for 2.1

### DIFF
--- a/core/core.slnx
+++ b/core/core.slnx
@@ -26,6 +26,7 @@
     <Project Path="samples/Quoting/Quoting.csproj" />
     <Project Path="samples/SsoBot/SsoBot.csproj" />
     <Project Path="samples/StreamingBot/StreamingBot.csproj" />
+    <Project Path="samples/SuggestedActionBot/SuggestedActionBot.csproj" />
     <Project Path="samples/TabApp/TabApp.csproj" />
     <Project Path="samples/TargetedMessages/TargetedMessages.csproj" />
     <Project Path="samples/TeamsBot/TeamsBot.csproj" Id="94a35050-6826-446f-9b29-863f2bbc75b7" />

--- a/core/samples/SuggestedActionBot/Program.cs
+++ b/core/samples/SuggestedActionBot/Program.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Nodes;
+
+using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Handlers;
+using Microsoft.Teams.Apps.Schema;
+
+WebApplicationBuilder webAppBuilder = WebApplication.CreateSlimBuilder(args);
+webAppBuilder.Services.AddTeamsBotApplication();
+WebApplication webApp = webAppBuilder.Build();
+
+TeamsBotApplication teamsApp = webApp.UseTeamsBotApplication();
+
+// Reply to any user message with two Action.Submit suggested-action chips.
+teamsApp.OnMessage(async (context, cancellationToken) =>
+{
+    var reply = new MessageActivity("Approve or reject the request:")
+    {
+        SuggestedActions = new SuggestedActions()
+        {
+            To = [context.Activity.From?.Id!],
+            Actions = [
+                new SuggestedAction(ActionType.Submit, "Approve") { Value = new JsonObject { ["vote"] = "approve" } },
+                new SuggestedAction(ActionType.Submit, "Reject") { Value = new JsonObject { ["vote"] = "reject" } },
+            ]
+        }
+    };
+
+    await context.SendActivityAsync(reply, cancellationToken);
+});
+
+// Handle the resulting suggestedActions/submit invoke when the user clicks a chip.
+teamsApp.OnSuggestedActionSubmit(async (context, cancellationToken) =>
+{
+    var serializedValue = context.Activity.Value is { } value
+        ? value.ToJsonString()
+        : "<none>";
+
+    context.Log.Info($"[SUGGESTED_ACTION_SUBMIT] value={serializedValue}");
+    await context.SendActivityAsync(
+        new MessageActivity($"Got suggestedActions/submit with value: {serializedValue}"),
+        cancellationToken);
+
+    return new InvokeResponse(200);
+});
+
+webApp.Run();

--- a/core/samples/SuggestedActionBot/Program.cs
+++ b/core/samples/SuggestedActionBot/Program.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Text.Json.Nodes;
-
 using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Handlers;
 using Microsoft.Teams.Apps.Schema;
@@ -22,8 +20,8 @@ teamsApp.OnMessage(async (context, cancellationToken) =>
         {
             To = [context.Activity.From?.Id!],
             Actions = [
-                new SuggestedAction(ActionType.Submit, "Approve") { Value = new JsonObject { ["vote"] = "approve" } },
-                new SuggestedAction(ActionType.Submit, "Reject") { Value = new JsonObject { ["vote"] = "reject" } },
+                new SuggestedAction(ActionType.Submit, "Approve", new { vote = "approve" }),
+                new SuggestedAction(ActionType.Submit, "Reject", new { vote = "reject" }),
             ]
         }
     };

--- a/core/samples/SuggestedActionBot/Properties/launchSettings.TEMPLATE.json
+++ b/core/samples/SuggestedActionBot/Properties/launchSettings.TEMPLATE.json
@@ -1,0 +1,19 @@
+{
+  "profiles": {
+    "SuggestedActionBot": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:3978",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "Logging__LogLevel__Microsoft.Teams": "Trace",
+        "Logging__LogLevel__System.Net.Http.HttpClient": "Warning",
+        "AzureAd__Instance": "",
+        "AzureAd__ClientId": "",
+        "AzureAd__TenantId": "",
+        "AzureAd__ClientCredentials__0__SourceType": "ClientSecret",
+        "AzureAd__ClientCredentials__0__ClientSecret": ""
+      }
+    }
+  }
+}

--- a/core/samples/SuggestedActionBot/SuggestedActionBot.csproj
+++ b/core/samples/SuggestedActionBot/SuggestedActionBot.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<NoWarn>$(NoWarn);ExperimentalTeamsSuggestedAction</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Microsoft.Teams.Apps\Microsoft.Teams.Apps.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/core/samples/SuggestedActionBot/appsettings.json
+++ b/core/samples/SuggestedActionBot/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.Teams": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/core/samples/TeamsBot/Program.cs
+++ b/core/samples/TeamsBot/Program.cs
@@ -40,8 +40,8 @@ teamsApp.OnMessage("(?i)^help$", async (context, cancellationToken) =>
         {
             To = [context.Activity.From?.Id!],
             Actions = [
-                    new SuggestedAction(ActionType.IMBack, "hello") { Value = "hello" },
-                    new SuggestedAction(ActionType.IMBack, "feedback") { Value = "feedback" },
+                    new SuggestedAction(ActionType.IMBack, "hello"),
+                    new SuggestedAction(ActionType.IMBack, "feedback"),
                  ]
         })
         .Build();
@@ -261,9 +261,9 @@ teamsApp.OnMessage("(?i)^suggested$", async (context, cancellationToken) =>
     {
         To = [context.Activity.From?.Id!],
         Actions = [
-            new SuggestedAction(ActionType.IMBack, "Option 1") { Value = "You chose option 1" },
-            new SuggestedAction(ActionType.IMBack, "Option 2") { Value = "You chose option 2" },
-            new SuggestedAction(ActionType.IMBack, "Option 3") { Value = "You chose option 3" }
+            new SuggestedAction(ActionType.IMBack, "Option 1", "You chose option 1"),
+            new SuggestedAction(ActionType.IMBack, "Option 2", "You chose option 2"),
+            new SuggestedAction(ActionType.IMBack, "Option 3", "You chose option 3")
         ]
     };
 

--- a/core/src/Microsoft.Teams.Apps/Handlers/InvokeHandler.Activity.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/InvokeHandler.Activity.cs
@@ -210,6 +210,13 @@ public static class InvokeNames
     /// </summary>
     public const string MessageSubmitAction = "message/submitAction";
 
+    /// <summary>
+    /// Suggested action submit invoke name.
+    /// Sent when the user clicks a suggested action of type <c>Action.Submit</c>.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.Experimental("ExperimentalTeamsSuggestedAction")]
+    public const string SuggestedActionSubmit = "suggestedActions/submit";
+
     //TODO : review
     /*
     /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Handlers/SuggestedActionSubmitHandler.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/SuggestedActionSubmitHandler.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma warning disable ExperimentalTeamsSuggestedAction
+
+using Microsoft.Teams.Apps.Routing;
+using Microsoft.Teams.Apps.Schema;
+
+namespace Microsoft.Teams.Apps.Handlers;
+
+/// <summary>
+/// Delegate for handling <c>suggestedActions/submit</c> invoke activities.
+/// Sent when the user clicks a suggested action of type <c>Action.Submit</c>.
+/// The structured payload authored on the suggested action is delivered via <see cref="InvokeActivity.Value"/>.
+/// </summary>
+/// <param name="context">The context for the invoke activity, providing access to the activity data and bot application.</param>
+/// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+/// <returns>A task that represents the asynchronous operation. The task result contains the invoke response.</returns>
+[System.Diagnostics.CodeAnalysis.Experimental("ExperimentalTeamsSuggestedAction")]
+public delegate Task<InvokeResponse> SuggestedActionSubmitHandler(Context<InvokeActivity> context, CancellationToken cancellationToken = default);
+
+/// <summary>
+/// Extension methods for registering suggested action submit invoke handlers.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.Experimental("ExperimentalTeamsSuggestedAction")]
+public static class SuggestedActionSubmitExtensions
+{
+    /// <summary>
+    /// Registers a handler for <c>suggestedActions/submit</c> invoke activities.
+    /// Triggered when the user clicks a suggested action of type <c>Action.Submit</c>.
+    /// Cannot be combined with <see cref="InvokeExtensions.OnInvoke"/>.
+    /// </summary>
+    /// <param name="app">The Teams bot application.</param>
+    /// <param name="handler">The handler to register.</param>
+    /// <returns>The updated Teams bot application.</returns>
+    public static TeamsBotApplication OnSuggestedActionSubmit(this TeamsBotApplication app, SuggestedActionSubmitHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(app, nameof(app));
+        app.Router.Register(new Route<InvokeActivity>
+        {
+            Name = string.Join("/", TeamsActivityType.Invoke, InvokeNames.SuggestedActionSubmit),
+            Selector = activity => activity.Name == InvokeNames.SuggestedActionSubmit,
+            HandlerWithReturn = async (ctx, cancellationToken) =>
+            {
+                return await handler(ctx, cancellationToken).ConfigureAwait(false);
+            }
+        });
+
+        return app;
+    }
+}

--- a/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
+++ b/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
@@ -164,7 +164,7 @@ public class OAuthFlow
             ConnectionName = _connectionName,
             Buttons =
             [
-                new SuggestedAction(ActionType.SignIn, options.SignInButtonText) { Value = signInResource.SignInLink }
+                new SuggestedAction(ActionType.SignIn, options.SignInButtonText, signInResource.SignInLink)
             ],
             TokenExchangeResource = signInResource.TokenExchangeResource,
             TokenPostResource = signInResource.TokenPostResource

--- a/core/src/Microsoft.Teams.Apps/Schema/SuggestedAction.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/SuggestedAction.cs
@@ -130,4 +130,11 @@ public static class ActionType
     /// Initiates a phone call.
     /// </summary>
     public const string Call = "call";
+
+    /// <summary>
+    /// Suggested action of type Action.Submit. The action's Value is delivered to the bot
+    /// as a <c>suggestedActions/submit</c> invoke without sending a chat-visible message.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.Experimental("ExperimentalTeamsSuggestedAction")]
+    public const string Submit = "Action.Submit";
 }

--- a/core/src/Microsoft.Teams.Apps/Schema/SuggestedAction.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/SuggestedAction.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Teams.Apps.Schema;
@@ -22,12 +24,17 @@ public class SuggestedAction
     /// </summary>
     /// <param name="type">The type of action. See <see cref="ActionType"/> for common values.</param>
     /// <param name="title">The text description displayed on the button.</param>
-    /// <param name="value">The value sent when the button is clicked. Defaults to <paramref name="title"/> when not specified.</param>
-    public SuggestedAction(string type, string title, string? value = null)
+    /// <param name="value">The value sent when the button is clicked. Accepts strings, anonymous objects, or <see cref="JsonNode"/> instances. Defaults to <paramref name="title"/> when not specified.</param>
+    public SuggestedAction(string type, string title, object? value = null)
     {
         Type = type;
         Title = title;
-        Value = value ?? title;
+        Value = value switch
+        {
+            null => JsonValue.Create(title),
+            JsonNode n => n,
+            _ => JsonSerializer.SerializeToNode(value)
+        };
     }
 
     /// <summary>
@@ -66,7 +73,7 @@ public class SuggestedAction
     /// The content of this property depends on the action type.
     /// </summary>
     [JsonPropertyName("value")]
-    public object? Value { get; set; }
+    public JsonNode? Value { get; set; }
 
     /// <summary>
     /// Gets or sets the channel-specific data associated with this action.

--- a/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionSubmitHandlerTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionSubmitHandlerTests.cs
@@ -77,7 +77,7 @@ public class SuggestedActionSubmitHandlerTests
             SuggestedActions = new SuggestedActions()
         };
         activity.SuggestedActions.AddAction(
-            new SuggestedAction(ActionType.Submit, "Approve") { Value = new JsonObject { ["vote"] = "approve" } }
+            new SuggestedAction(ActionType.Submit, "Approve", new { vote = "approve" })
         );
 
         string json = activity.ToJson();

--- a/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionSubmitHandlerTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionSubmitHandlerTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma warning disable ExperimentalTeamsSuggestedAction
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Teams.Apps.Handlers;
+using Microsoft.Teams.Apps.Routing;
+using Microsoft.Teams.Apps.Schema;
+using Microsoft.Teams.Core.Schema;
+
+namespace Microsoft.Teams.Apps.UnitTests;
+
+public class SuggestedActionSubmitHandlerTests
+{
+    [Fact]
+    public void InvokeNames_SuggestedActionSubmit_HasExpectedValue()
+    {
+        Assert.Equal("suggestedActions/submit", InvokeNames.SuggestedActionSubmit);
+    }
+
+    [Fact]
+    public void ActionType_Submit_HasExpectedValue()
+    {
+        Assert.Equal("Action.Submit", ActionType.Submit);
+    }
+
+    [Fact]
+    public void Register_SuggestedActionSubmitRoute_Succeeds()
+    {
+        Router router = new(NullLogger.Instance);
+        router.Register(new Route<InvokeActivity>
+        {
+            Name = string.Join("/", TeamsActivityType.Invoke, InvokeNames.SuggestedActionSubmit),
+            Selector = activity => activity.Name == InvokeNames.SuggestedActionSubmit,
+        });
+
+        Assert.Single(router.GetRoutes());
+    }
+
+    [Fact]
+    public void SuggestedActionSubmit_RouteSelector_MatchesCorrectInvokeName()
+    {
+        var activity = new InvokeActivity(InvokeNames.SuggestedActionSubmit)
+        {
+            Value = new JsonObject { ["vote"] = "approve" }
+        };
+
+        bool matches = activity.Name == InvokeNames.SuggestedActionSubmit;
+        Assert.True(matches);
+    }
+
+    [Fact]
+    public void SuggestedActionSubmit_RouteSelector_DoesNotMatchOtherInvoke()
+    {
+        var activity = new InvokeActivity(InvokeNames.AdaptiveCardAction);
+
+        bool matches = activity.Name == InvokeNames.SuggestedActionSubmit;
+        Assert.False(matches);
+    }
+
+    [Fact]
+    public void SuggestedActionSubmit_InvokeActivity_ValueRoundTrips()
+    {
+        var payload = new { vote = "approve", reason = "looks good" };
+        var activity = new InvokeActivity(InvokeNames.SuggestedActionSubmit)
+        {
+            Value = JsonSerializer.SerializeToNode(payload)
+        };
+
+        Assert.NotNull(activity.Value);
+        Assert.Equal("approve", activity.Value!["vote"]!.GetValue<string>());
+        Assert.Equal("looks good", activity.Value["reason"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void OutgoingMessage_WithActionSubmitSuggestedAction_SerializesToSpecShape()
+    {
+        var activity = new MessageActivity("Approve or reject:")
+        {
+            SuggestedActions = new SuggestedActions()
+        };
+        activity.SuggestedActions.AddAction(
+            new SuggestedAction(ActionType.Submit, "Approve") { Value = new JsonObject { ["vote"] = "approve" } }
+        );
+
+        string json = activity.ToJson();
+        using var doc = JsonDocument.Parse(json);
+
+        var action = doc.RootElement.GetProperty("suggestedActions").GetProperty("actions")[0];
+        Assert.Equal("Action.Submit", action.GetProperty("type").GetString());
+        Assert.Equal("Approve", action.GetProperty("title").GetString());
+        Assert.Equal("approve", action.GetProperty("value").GetProperty("vote").GetString());
+    }
+
+    [Fact]
+    public void InvokeActivity_FromCoreActivity_ParsesSuggestedActionSubmit()
+    {
+        string json = """
+        {
+          "type": "invoke",
+          "name": "suggestedActions/submit",
+          "value": { "vote": "reject" }
+        }
+        """;
+
+        CoreActivity coreActivity = CoreActivity.FromJsonString(json);
+        InvokeActivity activity = InvokeActivity.FromActivity(coreActivity);
+
+        Assert.Equal("suggestedActions/submit", activity.Name);
+        Assert.NotNull(activity.Value);
+        Assert.Equal("reject", activity.Value!["vote"]!.GetValue<string>());
+    }
+}

--- a/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionSubmitHandlerTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionSubmitHandlerTests.cs
@@ -22,12 +22,6 @@ public class SuggestedActionSubmitHandlerTests
     }
 
     [Fact]
-    public void ActionType_Submit_HasExpectedValue()
-    {
-        Assert.Equal("Action.Submit", ActionType.Submit);
-    }
-
-    [Fact]
     public void Register_SuggestedActionSubmitRoute_Succeeds()
     {
         Router router = new(NullLogger.Instance);

--- a/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionsTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionsTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#pragma warning disable ExperimentalTeamsSuggestedAction
+
 using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Core.Schema;
 
@@ -20,6 +22,7 @@ public class SuggestedActionsTests
         Assert.Equal("downloadFile", ActionType.DownloadFile);
         Assert.Equal("signin", ActionType.SignIn);
         Assert.Equal("call", ActionType.Call);
+        Assert.Equal("Action.Submit", ActionType.Submit);
     }
 
     [Fact]

--- a/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionsTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionsTests.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ExperimentalTeamsSuggestedAction
 
+using System.Text.Json.Nodes;
 using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Core.Schema;
 
@@ -121,7 +122,7 @@ public class SuggestedActionsTests
             SuggestedActions = new SuggestedActions()
         };
         activity.SuggestedActions.AddRecipients("user1");
-        activity.SuggestedActions.AddAction(new SuggestedAction(ActionType.IMBack, "Option 1") { Value = "opt1" });
+        activity.SuggestedActions.AddAction(new SuggestedAction(ActionType.IMBack, "Option 1", "opt1"));
 
         string json = activity.ToJson();
 
@@ -211,7 +212,7 @@ public class SuggestedActionsTests
     public void MessageActivity_WithSuggestedActions()
     {
         var suggestedActions = new SuggestedActions()
-            .AddAction(new SuggestedAction(ActionType.IMBack, "Option 1") { Value = "opt1" });
+            .AddAction(new SuggestedAction(ActionType.IMBack, "Option 1", "opt1"));
 
         var activity = TeamsActivity.CreateBuilder()
             .WithType(TeamsActivityType.Message)
@@ -234,8 +235,8 @@ public class SuggestedActionsTests
         activity.SuggestedActions = new SuggestedActions();
         activity.SuggestedActions.AddRecipients("user1");
         activity.SuggestedActions.AddActions(
-            new SuggestedAction(ActionType.OpenUrl, "Open") { Value = "https://example.com" },
-            new SuggestedAction(ActionType.IMBack, "Say Hi") { Value = "hi" }
+            new SuggestedAction(ActionType.OpenUrl, "Open", "https://example.com"),
+            new SuggestedAction(ActionType.IMBack, "Say Hi", "hi")
         );
 
         string json = activity.ToJson();


### PR DESCRIPTION
## Summary

Ports the `suggestedActions/submit` invoke support from Libraries/ (#464) to core/:

- `InvokeNames.SuggestedActionSubmit` constant and `ActionType.Submit`
- `OnSuggestedActionSubmit()` handler extension on `TeamsBotApplication`
- `SuggestedActionBot` sample
- Unit tests

All new API surface marked `[Experimental("ExperimentalTeamsSuggestedAction")]`.

## Test plan

- [x] `dotnet build core.slnx` — clean
- [x] `dotnet test core.slnx` — 755/755 pass on both net8.0 and net10.0
- [x] E2E verified against Teams client

<img width="671" height="289" alt="image" src="https://github.com/user-attachments/assets/2959f3c9-f194-4e1f-9e06-9cdf6bbb86d0" />
