### PR TITLE
feat: type SuggestedAction.Value as JsonNode

### DIFF
--- a/core/samples/SuggestedActionBot/Program.cs
+++ b/core/samples/SuggestedActionBot/Program.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Text.Json.Nodes;
-
 using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Handlers;
 using Microsoft.Teams.Apps.Schema;
@@ -22,8 +20,8 @@ teamsApp.OnMessage(async (context, cancellationToken) =>
         {
             To = [context.Activity.From?.Id!],
             Actions = [
-                new SuggestedAction(ActionType.Submit, "Approve") { Value = new JsonObject { ["vote"] = "approve" } },
-                new SuggestedAction(ActionType.Submit, "Reject") { Value = new JsonObject { ["vote"] = "reject" } },
+                new SuggestedAction(ActionType.Submit, "Approve", new { vote = "approve" }),
+                new SuggestedAction(ActionType.Submit, "Reject", new { vote = "reject" }),
             ]
         }
     };

--- a/core/samples/TeamsBot/Program.cs
+++ b/core/samples/TeamsBot/Program.cs
@@ -40,8 +40,8 @@ teamsApp.OnMessage("(?i)^help$", async (context, cancellationToken) =>
         {
             To = [context.Activity.From?.Id!],
             Actions = [
-                    new SuggestedAction(ActionType.IMBack, "hello") { Value = "hello" },
-                    new SuggestedAction(ActionType.IMBack, "feedback") { Value = "feedback" },
+                    new SuggestedAction(ActionType.IMBack, "hello"),
+                    new SuggestedAction(ActionType.IMBack, "feedback"),
                  ]
         })
         .Build();
@@ -261,9 +261,9 @@ teamsApp.OnMessage("(?i)^suggested$", async (context, cancellationToken) =>
     {
         To = [context.Activity.From?.Id!],
         Actions = [
-            new SuggestedAction(ActionType.IMBack, "Option 1") { Value = "You chose option 1" },
-            new SuggestedAction(ActionType.IMBack, "Option 2") { Value = "You chose option 2" },
-            new SuggestedAction(ActionType.IMBack, "Option 3") { Value = "You chose option 3" }
+            new SuggestedAction(ActionType.IMBack, "Option 1", "You chose option 1"),
+            new SuggestedAction(ActionType.IMBack, "Option 2", "You chose option 2"),
+            new SuggestedAction(ActionType.IMBack, "Option 3", "You chose option 3")
         ]
     };
 

--- a/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
+++ b/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
@@ -164,7 +164,7 @@ public class OAuthFlow
             ConnectionName = _connectionName,
             Buttons =
             [
-                new SuggestedAction(ActionType.SignIn, options.SignInButtonText) { Value = signInResource.SignInLink }
+                new SuggestedAction(ActionType.SignIn, options.SignInButtonText, signInResource.SignInLink)
             ],
             TokenExchangeResource = signInResource.TokenExchangeResource,
             TokenPostResource = signInResource.TokenPostResource

--- a/core/src/Microsoft.Teams.Apps/Schema/SuggestedAction.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/SuggestedAction.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Teams.Apps.Schema;
@@ -22,12 +24,17 @@ public class SuggestedAction
     /// </summary>
     /// <param name="type">The type of action. See <see cref="ActionType"/> for common values.</param>
     /// <param name="title">The text description displayed on the button.</param>
-    /// <param name="value">The value sent when the button is clicked. Defaults to <paramref name="title"/> when not specified.</param>
-    public SuggestedAction(string type, string title, string? value = null)
+    /// <param name="value">The value sent when the button is clicked. Accepts strings, anonymous objects, or <see cref="JsonNode"/> instances. Defaults to <paramref name="title"/> when not specified.</param>
+    public SuggestedAction(string type, string title, object? value = null)
     {
         Type = type;
         Title = title;
-        Value = value ?? title;
+        Value = value switch
+        {
+            null => JsonValue.Create(title),
+            JsonNode n => n,
+            _ => JsonSerializer.SerializeToNode(value)
+        };
     }
 
     /// <summary>
@@ -66,7 +73,7 @@ public class SuggestedAction
     /// The content of this property depends on the action type.
     /// </summary>
     [JsonPropertyName("value")]
-    public object? Value { get; set; }
+    public JsonNode? Value { get; set; }
 
     /// <summary>
     /// Gets or sets the channel-specific data associated with this action.

--- a/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionSubmitHandlerTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionSubmitHandlerTests.cs
@@ -77,7 +77,7 @@ public class SuggestedActionSubmitHandlerTests
             SuggestedActions = new SuggestedActions()
         };
         activity.SuggestedActions.AddAction(
-            new SuggestedAction(ActionType.Submit, "Approve") { Value = new JsonObject { ["vote"] = "approve" } }
+            new SuggestedAction(ActionType.Submit, "Approve", new { vote = "approve" })
         );
 
         string json = activity.ToJson();

--- a/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionsTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionsTests.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ExperimentalTeamsSuggestedAction
 
+using System.Text.Json.Nodes;
 using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Core.Schema;
 
@@ -121,7 +122,7 @@ public class SuggestedActionsTests
             SuggestedActions = new SuggestedActions()
         };
         activity.SuggestedActions.AddRecipients("user1");
-        activity.SuggestedActions.AddAction(new SuggestedAction(ActionType.IMBack, "Option 1") { Value = "opt1" });
+        activity.SuggestedActions.AddAction(new SuggestedAction(ActionType.IMBack, "Option 1", "opt1"));
 
         string json = activity.ToJson();
 
@@ -211,7 +212,7 @@ public class SuggestedActionsTests
     public void MessageActivity_WithSuggestedActions()
     {
         var suggestedActions = new SuggestedActions()
-            .AddAction(new SuggestedAction(ActionType.IMBack, "Option 1") { Value = "opt1" });
+            .AddAction(new SuggestedAction(ActionType.IMBack, "Option 1", "opt1"));
 
         var activity = TeamsActivity.CreateBuilder()
             .WithType(TeamsActivityType.Message)
@@ -234,8 +235,8 @@ public class SuggestedActionsTests
         activity.SuggestedActions = new SuggestedActions();
         activity.SuggestedActions.AddRecipients("user1");
         activity.SuggestedActions.AddActions(
-            new SuggestedAction(ActionType.OpenUrl, "Open") { Value = "https://example.com" },
-            new SuggestedAction(ActionType.IMBack, "Say Hi") { Value = "hi" }
+            new SuggestedAction(ActionType.OpenUrl, "Open", "https://example.com"),
+            new SuggestedAction(ActionType.IMBack, "Say Hi", "hi")
         );
 
         string json = activity.ToJson();


### PR DESCRIPTION
> [!NOTE]
> Stacked on #528

## Summary
- Change `SuggestedAction.Value` from `object?` to `JsonNode?`, aligning with `InvokeActivity.Value` and `EventActivity.Value`
- Constructor now accepts `object?` and serializes to `JsonNode` internally — consumers can pass anonymous objects, strings, or `JsonNode` instances directly
- Eliminates the need for `JsonObject` construction in consumer code

**Before:**
```csharp
new SuggestedAction(ActionType.Submit, "Approve") { Value = new JsonObject { ["vote"] = "approve" } }
```

**After:**
```csharp
new SuggestedAction(ActionType.Submit, "Approve", new { vote = "approve" })
```

## Test plan
- [x] All 21 SuggestedAction tests pass (both net8.0 and net10.0)
- [x] Samples (SuggestedActionBot, TeamsBot) build clean
- [x] OAuthFlow builds clean
- [ ] Verify serialization round-trip in integration environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)