### PR TITLE
Reject unauthenticated requests when no credentials are configured

### DIFF
--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/HostApplicationBuilder.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/HostApplicationBuilder.cs
@@ -143,10 +143,17 @@ public static class HostApplicationBuilderExtensions
         {
             options.AddPolicy(TeamsTokenAuthConstants.AuthorizationPolicy, policy =>
             {
-                if (skipAuth || string.IsNullOrEmpty(settings.ClientId))
+                if (skipAuth)
                 {
                     // bypass authentication
                     policy.RequireAssertion(_ => true);
+                }
+                else if (string.IsNullOrEmpty(settings.ClientId))
+                {
+                    // No credentials configured: reject all requests. Pass
+                    // skipAuth: true to AddTeams(...) to opt into the bypass
+                    // for local development without credentials.
+                    policy.RequireAssertion(_ => false);
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

`AddTeamsTokenAuthentication` currently engages the `RequireAssertion(_ => true)` bypass policy whenever `skipAuth: true` is passed **or** the configured `ClientId` is empty. That means an empty `ClientId` silently disables auth for any deployment that forgot to set credentials, with no opt-in.

This change splits the condition: `skipAuth: true` still bypasses, but a missing `ClientId` without `skipAuth` now fails closed (`RequireAssertion(_ => false)`). Callers that intentionally want unauthenticated local development pass `skipAuth: true` to `AddTeams(...)`.

Aligns with the equivalent change in TypeScript (microsoft/teams.ts#506) and Python (microsoft/teams.py#360).

## Test plan

- [ ] Existing test suite passes
- [ ] Add a test asserting requests are rejected (401/403) when `ClientId` is empty and `skipAuth` is not set
- [ ] Add a test asserting requests still bypass when `skipAuth: true` is explicitly passed with empty `ClientId`
- [ ] Manual: run a sample with no credentials configured and confirm requests now fail closed unless `skipAuth: true` is set