### PR TITLE
ci: add merge_group trigger to Build & Test & Lint

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -15,6 +15,7 @@ on:
       - '**/*.md'
       - 'docs/**'
       - 'Assets/**'
+  merge_group:
 
 permissions: read-all
 


### PR DESCRIPTION
## Summary

- Adds `merge_group:` to the `on:` triggers of `.github/workflows/build-test-lint.yml` so the workflow runs on `gh-readonly-queue/*` refs created by GitHub's merge queue.
- No behavior change until a merge queue is enabled on the `main` ruleset; the trigger is dormant otherwise.
- Prereq for turning on "Require merge queue" — without this, the required `Build & Test & Lint` check would never report on queued PRs and the queue would stall.

## Test plan

- [x] Confirm CI still runs as expected on this PR (pull_request trigger unchanged)
- [ ] After merge, enable "Require merge queue" on the `main` ruleset and verify the workflow fires against the queue's temporary refs