### PR TITLE
ci: run Build & Test & Lint on docs-only PRs

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -5,16 +5,8 @@ on:
   workflow_dispatch:
   pull_request:
     branches: ['main']
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'Assets/**'
   push:
     branches: ['main']
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'Assets/**'
   merge_group:
 
 permissions: read-all


### PR DESCRIPTION
## Summary

- Removes the `paths-ignore` filter from the `pull_request` and `push` triggers of `Build & Test & Lint`.
- Why: the workflow's check is a required status check. When `paths-ignore` filtered out every file in a PR (e.g. a docs-only change), the workflow was skipped, the required check never posted, and the PR could not merge.
- Trade-off: docs-only PRs now run the full build. The alternative (a sibling always-pass workflow that posts the required check name) adds more moving parts than it saves for this repo's PR volume.
- This is also a hygiene improvement now that the merge queue is enabled — required-check-not-posting failure modes are even more annoying inside the queue.

## Test plan

- [x] Confirm CI runs on this PR
- [ ] After merge, open a docs-only PR and confirm the check posts and the PR is mergeable