### PR TITLE
Refactor ApiClient DI registration and add AddBotHttpClient

### DIFF
--- a/core/core.slnx
+++ b/core/core.slnx
@@ -50,6 +50,7 @@
     <Project Path="test/Microsoft.Teams.Apps.BotBuilder.UnitTests/Microsoft.Teams.Apps.BotBuilder.UnitTests.csproj" Id="17f5e8eb-ccb0-40e6-9630-a9d936d6ccde" />
     <Project Path="test/Microsoft.Teams.Apps.UnitTests/Microsoft.Teams.Apps.UnitTests.csproj" Id="16f5e8eb-ccb0-40e6-9630-a9d936d6ccde" />
     <Project Path="test/Microsoft.Teams.Core.UnitTests/Microsoft.Teams.Core.UnitTests.csproj" Id="8e6790ed-0352-45f6-b3dc-0c4c3bcab038" />
+    <Project Path="test/TeamsApisDemo/TeamsApisDemo.csproj" Id="1446b240-c778-4fc6-a389-a655d789444c" />
   </Folder>
   <Project Path="src/Microsoft.Teams.Apps.BotBuilder/Microsoft.Teams.Apps.BotBuilder.csproj" />
   <Project Path="src/Microsoft.Teams.Apps/Microsoft.Teams.Apps.csproj" Id="0e993a63-8a1a-4cdf-8a29-cc8c59bd6c30" />

--- a/core/samples/CustomHosting/Program.cs
+++ b/core/samples/CustomHosting/Program.cs
@@ -6,7 +6,6 @@ using Microsoft.Teams.Apps;
 using Microsoft.Teams.Core.Hosting;
 
 WebApplicationBuilder webAppBuilder = WebApplication.CreateSlimBuilder(args);
-
 // TODO: Show how to setup multiple Teams Bot applications (like how it was done in PABot)
 webAppBuilder.Services.AddTeamsBotApplication<MyTeamsBotApp>();
 WebApplication webApp = webAppBuilder.Build();

--- a/core/samples/TargetedMessages/Program.cs
+++ b/core/samples/TargetedMessages/Program.cs
@@ -60,7 +60,7 @@ teamsApp.OnMessage("(?i)^test update$", async (context, cancellationToken) =>
         try
         {
             MessageActivity updated = new($"✏️ Updated at {DateTime.UtcNow:HH:mm:ss}");
-            await context.Api.Conversations.Activities.UpdateTargetedAsync(conversationId, messageId, updated, cancellationToken);
+            await context.Api.Conversations.Activities.UpdateTargetedAsync(conversationId, messageId, updated, cancellationToken: cancellationToken);
         }
         catch (Exception ex)
         {

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ApiClient.cs
@@ -84,7 +84,7 @@ public class ApiClient
         UserTokenClient = userTokenClient;
         Bots = new BotClient(userTokenClient);
         Users = new UserClient(userTokenClient);
-
+        
         // ServiceUrl-dependent sub-clients require ForServiceUrl() before use
         ServiceUrl = null!;
         Conversations = null!;
@@ -100,7 +100,7 @@ public class ApiClient
     /// <param name="conversationClient">The core conversation client for conversation/activity/member operations.</param>
     /// <param name="userTokenClient">The core user token client for sign-in and token operations.</param>
     /// <param name="logger">Optional logger.</param>
-    public ApiClient(Uri serviceUrl, HttpClient httpClient, CoreConversationClient conversationClient, CoreUserTokenClient userTokenClient, ILogger? logger = null)
+    internal ApiClient(Uri serviceUrl, HttpClient httpClient, CoreConversationClient conversationClient, CoreUserTokenClient userTokenClient, ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(serviceUrl);
         ArgumentNullException.ThrowIfNull(httpClient);
@@ -121,7 +121,7 @@ public class ApiClient
     /// <summary>
     /// Creates a copy of an existing <see cref="ApiClient"/> with the same configuration.
     /// </summary>
-    public ApiClient(ApiClient client)
+    internal ApiClient(ApiClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
 

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ApiClient.cs
@@ -73,7 +73,7 @@ public class ApiClient
     /// <param name="userTokenClient">The core user token client for sign-in and token operations.</param>
     /// <param name="logger">Optional logger.</param>
     [ActivatorUtilitiesConstructor]
-    public ApiClient(HttpClient httpClient, CoreConversationClient conversationClient, CoreUserTokenClient userTokenClient, ILogger? logger = null)
+    internal ApiClient(HttpClient httpClient, CoreConversationClient conversationClient, CoreUserTokenClient userTokenClient, ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(httpClient);
         ArgumentNullException.ThrowIfNull(conversationClient);

--- a/core/src/Microsoft.Teams.Apps/TeamsBotApplication.HostingExtensions.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsBotApplication.HostingExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Teams.Apps.Api.Clients;
+using Microsoft.Teams.Core;
 using Microsoft.Teams.Core.Hosting;
 
 namespace Microsoft.Teams.Apps;
@@ -112,7 +113,15 @@ public static class TeamsBotApplicationHostingExtensions
         services.AddSingleton(teamsOptions);
 
         services.AddBotApplication<TApp>(botConfig);
-        services.AddBotClient<ApiClient>(nameof(ApiClient), botConfig);
+        services.AddBotHttpClient(nameof(ApiClient), botConfig);
+        services.AddSingleton(sp =>
+        {
+            var factory = sp.GetRequiredService<IHttpClientFactory>();
+            var httpClient = factory.CreateClient(nameof(ApiClient));
+            var conversationClient = sp.GetRequiredService<ConversationClient>();
+            var userTokenClient = sp.GetRequiredService<UserTokenClient>();
+            return new ApiClient(httpClient, conversationClient, userTokenClient);
+        });
         return services;
     }
 

--- a/core/src/Microsoft.Teams.Core/Hosting/AddBotApplicationExtensions.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/AddBotApplicationExtensions.cs
@@ -239,6 +239,37 @@ public static class AddBotApplicationExtensions
     }
 
     /// <summary>
+    /// Registers a named <see cref="HttpClient"/> wired to bot authentication
+    /// using an already-resolved <see cref="BotConfig"/>, without binding it to a typed client.
+    /// Use this when the client type will be registered separately via a factory.
+    /// </summary>
+    /// <param name="services">The service collection to add services to.</param>
+    /// <param name="httpClientName">The logical name for this <see cref="HttpClient"/> registration.</param>
+    /// <param name="botConfig">The resolved bot configuration containing tenant and client settings.</param>
+    /// <returns>The service collection for method chaining.</returns>
+    public static IServiceCollection AddBotHttpClient(
+        this IServiceCollection services,
+        string httpClientName,
+        BotConfig botConfig)
+    {
+        ArgumentNullException.ThrowIfNull(botConfig);
+        if (!string.IsNullOrWhiteSpace(botConfig.ClientId))
+        {
+            services.AddHttpClient(httpClientName)
+                .AddHttpMessageHandler(sp => new BotAuthenticationHandler(
+                    sp.GetRequiredService<IAuthorizationHeaderProvider>(),
+                    sp.GetRequiredService<ILogger<BotAuthenticationHandler>>(),
+                    botConfig.SectionName,
+                    sp.GetService<IOptionsMonitor<ManagedIdentityOptions>>()));
+        }
+        else
+        {
+            services.AddHttpClient(httpClientName);
+        }
+        return services;
+    }
+
+    /// <summary>
     /// Resolves a service from the service collection before the host is built,
     /// preferring a direct instance and falling back to building a temporary
     /// <see cref="ServiceProvider"/> when the service is registered via factory or type.

--- a/core/test/TeamsApisDemo/Program.cs
+++ b/core/test/TeamsApisDemo/Program.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Schema;
+
+IConfiguration configuration = new ConfigurationBuilder()
+           .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
+           .AddJsonFile("appsettings.json")
+           .AddEnvironmentVariables()
+           .Build();
+
+ServiceCollection services = new ServiceCollection();
+services.AddSingleton(configuration);
+services.AddLogging(c => {
+    c.AddConfiguration(configuration);
+    c.AddConsole();
+});
+services.AddTeamsBotApplication();
+services.AddControllers();
+var provider = services.BuildServiceProvider();
+var teamsBotApplication = provider.GetRequiredService<TeamsBotApplication>();
+Console.WriteLine($"Running Teams Bot Application for appId '{teamsBotApplication.AppId}' with version '{TeamsBotApplication.Version}'.");
+
+
+var smba = new Uri("https://smba.trafficmanager.net/amer");
+var membersClient = teamsBotApplication.Api.ForServiceUrl(smba).Conversations.Members;
+
+string cid = "19%3ALydFnezGKSkhYoiLNP6kZ8AuXQr36EDAkvG9CNJSPKc1%40thread.tacv2";
+var paged = await membersClient.GetPagedAsync(cid, 52);
+
+List<TeamsConversationAccount?> members = [..paged.Members];
+
+while (!string.IsNullOrEmpty(paged.ContinuationToken))
+{
+    Console.WriteLine("Getting next page of members...");
+    paged = await membersClient.GetPagedAsync(cid, 52, paged.ContinuationToken);
+    members.AddRange(paged.Members);
+}
+
+Console.WriteLine(members.Count);

--- a/core/test/TeamsApisDemo/Program.cs
+++ b/core/test/TeamsApisDemo/Program.cs
@@ -20,7 +20,6 @@ services.AddLogging(c => {
     c.AddConsole();
 });
 services.AddTeamsBotApplication();
-services.AddControllers();
 var provider = services.BuildServiceProvider();
 var teamsBotApplication = provider.GetRequiredService<TeamsBotApplication>();
 Console.WriteLine($"Running Teams Bot Application for appId '{teamsBotApplication.AppId}' with version '{TeamsBotApplication.Version}'.");

--- a/core/test/TeamsApisDemo/Program.cs
+++ b/core/test/TeamsApisDemo/Program.cs
@@ -16,7 +16,7 @@ IConfiguration configuration = new ConfigurationBuilder()
 ServiceCollection services = new ServiceCollection();
 services.AddSingleton(configuration);
 services.AddLogging(c => {
-    c.AddConfiguration(configuration);
+    c.AddConfiguration(configuration.GetSection("Logging"));
     c.AddConsole();
 });
 services.AddTeamsBotApplication();
@@ -28,6 +28,7 @@ Console.WriteLine($"Running Teams Bot Application for appId '{teamsBotApplicatio
 var smba = new Uri("https://smba.trafficmanager.net/amer");
 var membersClient = teamsBotApplication.Api.ForServiceUrl(smba).Conversations.Members;
 
+int pages = 1;
 string cid = "19%3ALydFnezGKSkhYoiLNP6kZ8AuXQr36EDAkvG9CNJSPKc1%40thread.tacv2";
 var paged = await membersClient.GetPagedAsync(cid, 52);
 
@@ -38,6 +39,8 @@ while (!string.IsNullOrEmpty(paged.ContinuationToken))
     Console.WriteLine("Getting next page of members...");
     paged = await membersClient.GetPagedAsync(cid, 52, paged.ContinuationToken);
     members.AddRange(paged.Members);
+    pages++;
 }
 
-Console.WriteLine(members.Count);
+Console.WriteLine("\n*****************\n");
+Console.WriteLine($"Total members: {members.Count} in {pages} pages.");

--- a/core/test/TeamsApisDemo/TeamsApisDemo.csproj
+++ b/core/test/TeamsApisDemo/TeamsApisDemo.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Teams.Apps\Microsoft.Teams.Apps.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/core/test/TeamsApisDemo/appsettings.json
+++ b/core/test/TeamsApisDemo/appsettings.json
@@ -1,10 +1,9 @@
 {
   "Logging": {
-    "Console": {
-      "LogLevel": {
-        "Default": "Warning",
-        "Microsoft.Teams": "Trace"
-      }
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.Teams": "Debug",
+      "System.Net.Http": "Information"
     }
-    }
+  }
 }

--- a/core/test/TeamsApisDemo/appsettings.json
+++ b/core/test/TeamsApisDemo/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "Console": {
+      "LogLevel": {
+        "Default": "Warning",
+        "Microsoft.Teams": "Trace"
+      }
+    }
+    }
+}


### PR DESCRIPTION
This pull request refactors how the `ApiClient` is registered and resolved in dependency injection, aiming to improve flexibility and separation of concerns in the bot application's service setup. The changes introduce a new method for registering named `HttpClient` instances, decouple `ApiClient` registration from its HTTP client setup, and make the `ApiClient` constructor internal to restrict its usage.

**Dependency Injection and Service Registration Improvements:**

* Added a new extension method `AddBotHttpClient` in `AddBotApplicationExtensions.cs` to register a named `HttpClient` for bot authentication separately from typed client registration. This allows more flexible and modular service setups.
* Updated `AddTeamsBotApplication` in `TeamsBotApplication.HostingExtensions.cs` to use `AddBotHttpClient` for registering the `ApiClient`'s HTTP client, and switched to registering `ApiClient` via a factory that manually resolves its dependencies.

**Constructor Visibility and Dependency Management:**

* Changed the `ApiClient` constructor from `public` to `internal` to restrict direct instantiation and encourage usage through dependency injection.

**Minor Code Improvements:**

* Added a missing `Microsoft.Teams.Core` using directive in `TeamsBotApplication.HostingExtensions.cs` for improved clarity and dependency management.
* Minor code style update: made the `cancellationToken` parameter explicit in a sample method call for clarity.