### PR TITLE
Validate serviceurl claim matches activity ServiceUrl

### DIFF
--- a/core/src/Microsoft.Teams.Core/BotApplication.cs
+++ b/core/src/Microsoft.Teams.Core/BotApplication.cs
@@ -206,6 +206,22 @@ public class BotApplication
             throw new InvalidDataException($"ServiceUrl in activity ({activity.ServiceUrl}) does not match serviceUrl claim ({serviceUrlFromClaims}).");
         };
 
+        KeyValuePair<string, object?> activityTypeTag = new(Telemetry.Tags.ActivityType, activity.Type);
+        Telemetry.ActivitiesReceived.Add(1, activityTypeTag);
+
+        using Activity? span = Telemetry.Source.StartActivity(Telemetry.Spans.Turn, ActivityKind.Internal);
+        if (span is not null)
+        {
+            span.SetTag(Telemetry.Tags.ActivityType, activity.Type);
+            span.SetTag(Telemetry.Tags.ActivityId, activity.Id);
+            span.SetTag(Telemetry.Tags.ConversationId, activity.Conversation?.Id);
+            span.SetTag(Telemetry.Tags.ChannelId, activity.ChannelId);
+            span.SetTag(Telemetry.Tags.BotId, AppId);
+            span.SetTag(Telemetry.Tags.ServiceUrl, activity.ServiceUrl?.ToString());
+        }
+
+        long startTimestamp = Stopwatch.GetTimestamp();
+
         // TODO: Replace with structured scope data, ensure it works with OpenTelemetry and other logging providers
         using (_logger.BeginActivityScope(activity.Type, activity.Id, activity.ServiceUrl, correlationVector))
         {

--- a/core/src/Microsoft.Teams.Core/BotApplication.cs
+++ b/core/src/Microsoft.Teams.Core/BotApplication.cs
@@ -201,7 +201,7 @@ public class BotApplication
         }
 
         string serviceUrlFromClaims = httpContext.User.Claims.FirstOrDefault(c => c.Type == "serviceurl")?.Value ?? string.Empty;
-        if (!string.IsNullOrEmpty(serviceUrlFromClaims) && !serviceUrlFromClaims.Equals(activity.ServiceUrl?.ToString(), StringComparison.OrdinalIgnoreCase))
+        if (!string.IsNullOrEmpty(serviceUrlFromClaims) && !serviceUrlFromClaims.Equals(activity.ServiceUrl?.ToString(), StringComparison.Ordinal))
         {
             throw new InvalidDataException($"ServiceUrl in activity ({activity.ServiceUrl}) does not match serviceUrl claim ({serviceUrlFromClaims}).");
         };

--- a/core/src/Microsoft.Teams.Core/BotApplication.cs
+++ b/core/src/Microsoft.Teams.Core/BotApplication.cs
@@ -203,8 +203,10 @@ public class BotApplication
         string serviceUrlFromClaims = httpContext.User.Claims.FirstOrDefault(c => c.Type == "serviceurl")?.Value ?? string.Empty;
         if (!string.IsNullOrEmpty(serviceUrlFromClaims) && !serviceUrlFromClaims.Equals(activity.ServiceUrl?.ToString(), StringComparison.Ordinal))
         {
-            throw new InvalidDataException($"ServiceUrl in activity ({activity.ServiceUrl}) does not match serviceUrl claim ({serviceUrlFromClaims}).");
-        };
+            _logger.LogServiceUrlClaimMismatch(activity.ServiceUrl, serviceUrlFromClaims);
+            throw new InvalidDataException("ServiceUrl in activity payload does not match serviceurl JWT claim.");
+            //$"ServiceUrl in activity ({activity.ServiceUrl}) does not match serviceUrl claim ({serviceUrlFromClaims})."
+        }
 
         KeyValuePair<string, object?> activityTypeTag = new(Telemetry.Tags.ActivityType, activity.Type);
         Telemetry.ActivitiesReceived.Add(1, activityTypeTag);

--- a/core/src/Microsoft.Teams.Core/BotApplication.cs
+++ b/core/src/Microsoft.Teams.Core/BotApplication.cs
@@ -199,6 +199,12 @@ public class BotApplication
             _logger.ReceivedActivityJson(activity.ToJson());
         }
 
+        string serviceUrlFromClaims = httpContext.User.Claims.FirstOrDefault(c => c.Type == "serviceurl")?.Value ?? string.Empty;
+        if (!string.IsNullOrEmpty(serviceUrlFromClaims) && !serviceUrlFromClaims.Equals(activity.ServiceUrl?.ToString(), StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException($"ServiceUrl in activity ({activity.ServiceUrl}) does not match serviceUrl claim ({serviceUrlFromClaims}).");
+        };
+
         // TODO: Replace with structured scope data, ensure it works with OpenTelemetry and other logging providers
         using (_logger.BeginActivityScope(activity.Type, activity.Id, activity.ServiceUrl, correlationVector))
         {

--- a/core/src/Microsoft.Teams.Core/Log.cs
+++ b/core/src/Microsoft.Teams.Core/Log.cs
@@ -40,6 +40,9 @@ internal static partial class Log
     [LoggerMessage(EventId = 7, Level = LogLevel.Information, Message = "Finished processing activity: Id={Id}")]
     public static partial void ActivityProcessingFinished(this ILogger logger, string? id);
 
+    [LoggerMessage(EventId = 8, Level = LogLevel.Debug, Message = "ServiceUrl in activity ({ActivityServiceUrl}) does not match serviceUrl claim ({ClaimServiceUrl}).")]
+    public static partial void LogServiceUrlClaimMismatch(this ILogger logger, Uri? activityServiceUrl, string claimServiceUrl);
+
     // ── ConversationClient ──────────────────────────────────────────────
 
     [LoggerMessage(EventId = 10, Level = LogLevel.Information, Message = "Truncating conversation ID for 'agents' channel to comply with length restrictions.")]

--- a/core/test/Microsoft.Teams.Core.UnitTests/BotApplicationTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/BotApplicationTests.cs
@@ -168,10 +168,9 @@ public class BotApplicationTests
         CoreActivity activity = new()
         {
             Type = ActivityType.Message,
-            ServiceUrl = new Uri("https://test.service.url/")
+            ServiceUrl = new Uri("https://test.service.url/"),
+            Conversation = new("conv123")
         };
-
-        activity.Conversation = new("conv123");
         SendActivityResponse? result = await botApp.SendActivityAsync(activity);
 
         Assert.NotNull(result);

--- a/core/test/Microsoft.Teams.Core.UnitTests/BotApplicationTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/BotApplicationTests.cs
@@ -216,36 +216,7 @@ public class BotApplicationTests
 
         Assert.True(onActivityCalled);
     }
-
-    [Fact]
-    public async Task ProcessAsync_ServiceUrlClaimMatchesActivity_CaseInsensitive_ProcessesSuccessfully()
-    {
-        BotApplication botApp = CreateBotApplication();
-
-        CoreActivity activity = new()
-        {
-            Type = ActivityType.Message,
-            Id = "act123",
-            ServiceUrl = new Uri("https://smba.trafficmanager.net/teams/")
-        };
-
-        DefaultHttpContext httpContext = CreateHttpContextWithActivity(activity);
-        httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
-        [
-            new Claim("serviceurl", "HTTPS://SMBA.TRAFFICMANAGER.NET/teams/")
-        ]));
-
-        bool onActivityCalled = false;
-        botApp.OnActivity = (act, ct) =>
-        {
-            onActivityCalled = true;
-            return Task.CompletedTask;
-        };
-
-        await botApp.ProcessAsync(httpContext);
-
-        Assert.True(onActivityCalled);
-    }
+       
 
     [Fact]
     public async Task ProcessAsync_ServiceUrlClaimMismatch_ThrowsInvalidDataException()
@@ -263,6 +234,32 @@ public class BotApplicationTests
         httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
         [
             new Claim("serviceurl", "https://evil.example.com/")
+        ]));
+
+        botApp.OnActivity = (act, ct) => Task.CompletedTask;
+
+        InvalidDataException exception = await Assert.ThrowsAsync<InvalidDataException>(() =>
+            botApp.ProcessAsync(httpContext));
+
+        Assert.Contains("does not match", exception.Message);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ServiceUrlClaimMismatchCase_ThrowsInvalidDataException()
+    {
+        BotApplication botApp = CreateBotApplication();
+
+        CoreActivity activity = new()
+        {
+            Type = ActivityType.Message,
+            Id = "act123",
+            ServiceUrl = new Uri("https://smba.trafficmanager.net/teams/")
+        };
+
+        DefaultHttpContext httpContext = CreateHttpContextWithActivity(activity);
+        httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("serviceurl", "https://SMBA.trafficmanager.net/teams/")
         ]));
 
         botApp.OnActivity = (act, ct) => Task.CompletedTask;

--- a/core/test/Microsoft.Teams.Core.UnitTests/BotApplicationTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/BotApplicationTests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.IO;
 using System.Net;
+using System.Security.Claims;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
@@ -183,6 +185,119 @@ public class BotApplicationTests
 
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
             botApp.SendActivityAsync(null!));
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ServiceUrlClaimMatchesActivity_ProcessesSuccessfully()
+    {
+        BotApplication botApp = CreateBotApplication();
+
+        CoreActivity activity = new()
+        {
+            Type = ActivityType.Message,
+            Id = "act123",
+            ServiceUrl = new Uri("https://smba.trafficmanager.net/teams/")
+        };
+
+        DefaultHttpContext httpContext = CreateHttpContextWithActivity(activity);
+        httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("serviceurl", "https://smba.trafficmanager.net/teams/")
+        ]));
+
+        bool onActivityCalled = false;
+        botApp.OnActivity = (act, ct) =>
+        {
+            onActivityCalled = true;
+            return Task.CompletedTask;
+        };
+
+        await botApp.ProcessAsync(httpContext);
+
+        Assert.True(onActivityCalled);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ServiceUrlClaimMatchesActivity_CaseInsensitive_ProcessesSuccessfully()
+    {
+        BotApplication botApp = CreateBotApplication();
+
+        CoreActivity activity = new()
+        {
+            Type = ActivityType.Message,
+            Id = "act123",
+            ServiceUrl = new Uri("https://smba.trafficmanager.net/teams/")
+        };
+
+        DefaultHttpContext httpContext = CreateHttpContextWithActivity(activity);
+        httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("serviceurl", "HTTPS://SMBA.TRAFFICMANAGER.NET/teams/")
+        ]));
+
+        bool onActivityCalled = false;
+        botApp.OnActivity = (act, ct) =>
+        {
+            onActivityCalled = true;
+            return Task.CompletedTask;
+        };
+
+        await botApp.ProcessAsync(httpContext);
+
+        Assert.True(onActivityCalled);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ServiceUrlClaimMismatch_ThrowsInvalidDataException()
+    {
+        BotApplication botApp = CreateBotApplication();
+
+        CoreActivity activity = new()
+        {
+            Type = ActivityType.Message,
+            Id = "act123",
+            ServiceUrl = new Uri("https://smba.trafficmanager.net/teams/")
+        };
+
+        DefaultHttpContext httpContext = CreateHttpContextWithActivity(activity);
+        httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("serviceurl", "https://evil.example.com/")
+        ]));
+
+        botApp.OnActivity = (act, ct) => Task.CompletedTask;
+
+        InvalidDataException exception = await Assert.ThrowsAsync<InvalidDataException>(() =>
+            botApp.ProcessAsync(httpContext));
+
+        Assert.Contains("does not match", exception.Message);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_NoServiceUrlClaim_ProcessesSuccessfully()
+    {
+        BotApplication botApp = CreateBotApplication();
+
+        CoreActivity activity = new()
+        {
+            Type = ActivityType.Message,
+            Id = "act123",
+            ServiceUrl = new Uri("https://smba.trafficmanager.net/teams/")
+        };
+
+        DefaultHttpContext httpContext = CreateHttpContextWithActivity(activity);
+        // No serviceurl claim set — default ClaimsPrincipal has no claims
+
+        bool onActivityCalled = false;
+        botApp.OnActivity = (act, ct) =>
+        {
+            onActivityCalled = true;
+            return Task.CompletedTask;
+        };
+
+        await botApp.ProcessAsync(httpContext);
+
+        Assert.True(onActivityCalled);
     }
 
     private static BotApplicationOptions CreateOptions(string appId) =>


### PR DESCRIPTION
Add validation to ensure the "serviceurl" claim in user claims matches the activity's ServiceUrl (case-insensitive) in BotApplication. Throw InvalidDataException on mismatch. Add unit tests covering matching, case-insensitivity, mismatches, and absence of the claim.