### PR TITLE
Enable MSAL agentic token caching in BotAuthenticationHandler

### DIFF
--- a/core/docs/agentic-token-caching-investigation.md
+++ b/core/docs/agentic-token-caching-investigation.md
@@ -1,0 +1,193 @@
+# Agentic Token Caching Investigation
+
+> **Date**: 2026-06-03
+> **Context**: AppInsights trace `d38cdd6867ffdb64` from A365TeamsAgent shows 4 HTTP calls to `login.microsoftonline.com` per single incoming message, adding ~1s of latency.
+
+## Problem Statement
+
+When processing a single agentic message, `BotAuthenticationHandler` acquires tokens for `https://botapi.skype.com/.default` via the agentic (User FIC / ROPC) flow. MSAL goes to the Entra network endpoint **on every outbound HTTP request**, even though the token is still valid. The in-memory cache is never consulted for the final token exchange.
+
+In a single message turn with 2 outbound calls (typing + reply), AppInsights shows:
+
+| Call | Target | Duration | Token Source |
+|------|--------|----------|-------------|
+| Typing indicator | `login.microsoftonline.com` | 272ms | IdentityProvider |
+| Reply message | `login.microsoftonline.com` | 246ms | IdentityProvider |
+
+The intermediate `api://AzureAdTokenExchange/.default` tokens (FIC client credentials) ARE cached. The final user-scoped token is NOT.
+
+## Root Cause
+
+The issue is in how `BotAuthenticationHandler` calls `IAuthorizationHeaderProvider.CreateAuthorizationHeaderAsync()` with a **null ClaimsPrincipal**. This prevents MSAL's silent token flow from ever executing.
+
+### Call Chain
+
+```
+BotAuthenticationHandler.SendAsync()
+  -> GetAuthorizationHeaderAsync(agenticIdentity)
+    -> options.WithAgentUserIdentity(appId, userId)     // sets ExtraParameters
+    -> _authorizationHeaderProvider.CreateAuthorizationHeaderAsync(
+         scopes, options, claimsPrincipal: null, ct)    // <-- NULL
+```
+
+### Inside microsoft-identity-web
+
+**`DefaultAuthorizationHeaderProvider.CreateAuthorizationHeaderAsync()`**
+File: `src/Microsoft.Identity.Web.TokenAcquisition/DefaultAuthorizationHeaderProvider.cs:68-110`
+
+Routes to `_tokenAcquisition.GetAuthenticationResultForUserAsync()` passing the null ClaimsPrincipal through.
+
+**`TokenAcquisition.TryGetAuthenticationResultForConfidentialClientUsingRopcAsync()`**
+File: `src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs:398-530`
+
+The silent flow check at line ~440:
+```csharp
+if (!forceRefresh && user != null && user.GetMsalAccountId() != null)
+{
+    var account = await application.GetAccountAsync(user.GetMsalAccountId());
+    return await application.AcquireTokenSilent(scopes, account).ExecuteAsync();
+}
+```
+
+**`user` is always null** -> silent flow never executes -> falls through to ROPC:
+
+```csharp
+AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder builder =
+    ((IByUsernameAndPassword)application)
+    .AcquireTokenByUsernamePassword(scopes, username, password);
+```
+
+After the ROPC call succeeds (lines 516-527), the account ID is written back to the ClaimsPrincipal:
+```csharp
+if (user != null && user.GetMsalAccountId() == null)
+{
+    user.AddIdentity(new CaseSensitiveClaimsIdentity(...));
+}
+```
+
+But since `user` is null, this never executes either. Even if it did, the ClaimsPrincipal is request-scoped and discarded after each call.
+
+### Why App-Only Tokens Work
+
+`CreateAuthorizationHeaderForAppAsync()` uses `AcquireTokenForClient()`, which:
+- Does NOT require a ClaimsPrincipal
+- Uses application-level caching keyed by `clientId + scope + tenant`
+- Tokens are cached globally for the process lifetime
+
+### Why Agentic Tokens Don't Cache
+
+- The agentic flow requires user identification (agent OID + agent app ID)
+- MSAL's user token cache requires a persistent account ID from the ClaimsPrincipal
+- Without it, MSAL cannot look up the cached token
+- Each request appears as a "new user" to MSAL
+
+## Impact per Message Turn
+
+For A365TeamsAgent with agentic identity, a single message generates:
+
+1. **Send typing indicator** -> `auth.outbound` (278ms): ROPC hits Entra
+2. **App code calls 2 APIs** (MCP scopes) -> ROPC hits Entra for each new scope
+3. **Send reply message** -> `auth.outbound` (250ms): ROPC hits Entra again
+
+Total: **~500-1000ms of unnecessary Entra round-trips** per message, on top of the LLM latency.
+
+## Possible Fixes
+
+### Option A: Persist ClaimsPrincipal with Account ID in BotAuthenticationHandler
+
+Cache the MSAL account ID after the first successful token acquisition, keyed by `(agenticAppId, agenticUserId)`. On subsequent calls, construct a ClaimsPrincipal with the cached account ID and pass it to `CreateAuthorizationHeaderAsync()`.
+
+```csharp
+// Pseudocode
+private readonly ConcurrentDictionary<(string appId, string userId), ClaimsPrincipal> _accountCache = new();
+
+private async Task<string> GetAuthorizationHeaderAsync(AgenticIdentity? agenticIdentity, CancellationToken ct)
+{
+    // ... existing setup ...
+
+    // Try to get cached ClaimsPrincipal with account ID
+    var key = (agenticIdentity.AgenticAppId, agenticIdentity.AgenticUserId);
+    _accountCache.TryGetValue(key, out ClaimsPrincipal? cachedPrincipal);
+
+    // Pass the cached principal (or null on first call)
+    string token = await _authorizationHeaderProvider.CreateAuthorizationHeaderAsync(
+        [AgenticScope], options, cachedPrincipal, ct);
+
+    // After first call, cache the principal for next time
+    // (Need to capture the account ID from the result somehow)
+    return token;
+}
+```
+
+**Problem**: `CreateAuthorizationHeaderAsync` returns a string (the header value), not the `AuthenticationResult`. We don't get back the account ID to cache. This would require changes to microsoft-identity-web or using a lower-level API.
+
+### Option B: Use ITokenAcquisition Directly with Account Caching
+
+Instead of going through `IAuthorizationHeaderProvider`, use `ITokenAcquisition.GetAuthenticationResultForUserAsync()` directly and manage the ClaimsPrincipal lifecycle ourselves.
+
+```csharp
+private readonly ConcurrentDictionary<string, ClaimsPrincipal> _userPrincipalCache = new();
+
+// After first ROPC call, the ClaimsPrincipal gets the account ID populated
+// Cache it and reuse on subsequent calls
+```
+
+**Problem**: The account ID is populated on the ClaimsPrincipal by `TokenAcquisition` internally, but only if `user != null`. We'd need to pass a non-null (possibly empty) ClaimsPrincipal.
+
+### Option C: Pass Non-Null Empty ClaimsPrincipal (Simplest Fix)
+
+The simplest change: pass a **non-null but empty** `ClaimsPrincipal` and cache it per agent identity. The TokenAcquisition code will:
+1. First call: `user != null` but `user.GetMsalAccountId() == null` -> skip silent, do ROPC, then populate the account ID on the ClaimsPrincipal
+2. Second call (same ClaimsPrincipal instance): `user != null` AND `user.GetMsalAccountId() != null` -> **silent flow succeeds**, cache hit!
+
+```csharp
+private readonly ConcurrentDictionary<string, ClaimsPrincipal> _principalCache = new();
+
+private async Task<string> GetAuthorizationHeaderAsync(AgenticIdentity? agenticIdentity, CancellationToken ct)
+{
+    // ... existing setup ...
+
+    string cacheKey = $"{agenticIdentity.AgenticAppId}:{agenticIdentity.AgenticUserId}";
+    ClaimsPrincipal principal = _principalCache.GetOrAdd(cacheKey, _ => new ClaimsPrincipal());
+
+    string token = await _authorizationHeaderProvider.CreateAuthorizationHeaderAsync(
+        [AgenticScope], options, principal, ct);
+
+    return token;
+}
+```
+
+**This is the most promising approach** because:
+- Minimal code change (just in `BotAuthenticationHandler`)
+- Uses MSAL's built-in silent flow / cache lookup
+- No changes to microsoft-identity-web needed
+- The ClaimsPrincipal persists across requests via the `ConcurrentDictionary`
+- Thread-safe since `BotAuthenticationHandler` is a `DelegatingHandler` (one per typed HttpClient)
+
+**Risks**:
+- `BotAuthenticationHandler` is created per `IHttpClientFactory` handler chain. Need to verify the instance lifecycle — if transient, the cache won't persist. Since it's registered via `AddHttpMessageHandler(sp => new BotAuthenticationHandler(...))`, the handler is created once per typed client and reused.
+- Multi-user scenarios: the cache key must include the user OID to avoid cross-user token leaks.
+- Memory growth: for multi-tenant bots with many users, the dictionary grows. Consider expiration.
+
+### Option D: File Issue with microsoft-identity-web
+
+The ROPC flow in `TokenAcquisition.TryGetAuthenticationResultForConfidentialClientUsingRopcAsync()` should handle the `user == null` case better for agent identities. It has enough information from `ExtraParameters` (agent app ID + user OID) to construct a cache key and attempt silent acquisition without a ClaimsPrincipal.
+
+This is the "correct" long-term fix but requires upstream changes.
+
+## Recommendation
+
+**Start with Option C** — cache ClaimsPrincipal per `(agenticAppId, agenticUserId)` in `BotAuthenticationHandler`. Validate that the silent flow kicks in on the second call within the same turn. This should eliminate 3 of the 4 Entra round-trips per message (the first call will still hit the network, but subsequent calls within the same turn and across turns will use the cache).
+
+**Also file an issue with microsoft-identity-web** (Option D) for the proper long-term fix.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs` | Where the fix goes — pass cached ClaimsPrincipal instead of null |
+| `microsoft-identity-web/src/.../TokenAcquisition.cs:440` | Silent flow guard: `user != null && user.GetMsalAccountId() != null` |
+| `microsoft-identity-web/src/.../TokenAcquisition.cs:465-514` | ROPC fallback that always executes today |
+| `microsoft-identity-web/src/.../TokenAcquisition.cs:516-527` | Account ID written to ClaimsPrincipal (only if non-null) |
+| `microsoft-identity-web/src/.../AgentUserIdentityMsalAddIn.cs` | Transforms ROPC into User FIC grant type |
+| `microsoft-identity-web/src/.../AgentIdentitiesExtension.cs:54-92` | `WithAgentUserIdentity()` sets ExtraParameters |

--- a/core/docs/agentic-token-caching-investigation.md
+++ b/core/docs/agentic-token-caching-investigation.md
@@ -1,13 +1,13 @@
 # Agentic Token Caching Investigation
 
 > **Date**: 2026-06-03
-> **Context**: AppInsights trace `d38cdd6867ffdb64` from A365TeamsAgent shows 4 HTTP calls to `login.microsoftonline.com` per single incoming message, adding ~1s of latency.
+> **Context**: An AppInsights trace shows 4 HTTP calls to `login.microsoftonline.com` per single incoming message, adding ~1s of latency.
 
 ## Problem Statement
 
 When processing a single agentic message, `BotAuthenticationHandler` acquires tokens for `https://botapi.skype.com/.default` via the agentic (User FIC / ROPC) flow. MSAL goes to the Entra network endpoint **on every outbound HTTP request**, even though the token is still valid. The in-memory cache is never consulted for the final token exchange.
 
-In a single message turn with 2 outbound calls (typing + reply), AppInsights shows:
+In a single message turn with 4 total Entra round-trips, 2 are for the outbound Bot Framework API calls (typing + reply). The table below shows those 2 calls as a partial example:
 
 | Call | Target | Duration | Token Source |
 |------|--------|----------|-------------|
@@ -83,7 +83,7 @@ But since `user` is null, this never executes either. Even if it did, the Claims
 
 ## Impact per Message Turn
 
-For A365TeamsAgent with agentic identity, a single message generates:
+For a bot with agentic identity, a single message generates:
 
 1. **Send typing indicator** -> `auth.outbound` (278ms): ROPC hits Entra
 2. **App code calls 2 APIs** (MCP scopes) -> ROPC hits Entra for each new scope

--- a/core/docs/agentic-token-caching-investigation.md
+++ b/core/docs/agentic-token-caching-investigation.md
@@ -161,13 +161,13 @@ private async Task<string> GetAuthorizationHeaderAsync(AgenticIdentity? agenticI
 - Minimal code change (just in `BotAuthenticationHandler`)
 - Uses MSAL's built-in silent flow / cache lookup
 - No changes to microsoft-identity-web needed
-- The ClaimsPrincipal persists across requests via the `ConcurrentDictionary`
-- Thread-safe since `BotAuthenticationHandler` is a `DelegatingHandler` (one per typed HttpClient)
+- The cached ClaimsPrincipal persists across requests for the lifetime of the handler instance
 
-**Risks**:
-- `BotAuthenticationHandler` is created per `IHttpClientFactory` handler chain. Need to verify the instance lifecycle — if transient, the cache won't persist. Since it's registered via `AddHttpMessageHandler(sp => new BotAuthenticationHandler(...))`, the handler is created once per typed client and reused.
-- Multi-user scenarios: the cache key must include the user OID to avoid cross-user token leaks.
-- Memory growth: for multi-tenant bots with many users, the dictionary grows. Consider expiration.
+**Risks (and how the shipped implementation mitigates them)**:
+- `BotAuthenticationHandler` is created per `IHttpClientFactory` handler chain. Handler chains are pooled and rotated by `IHttpClientFactory` based on `HandlerLifetime` (default ~2 minutes), so the in-handler cache is bounded by that rotation rather than the process lifetime. This is acceptable because the dominant cost — intra-turn round-trips — is eliminated.
+- Multi-user scenarios: the cache key must include the user OID to avoid cross-user token leaks. The shipped key is `"{agenticAppId}:{agenticUserGuid:D}"`.
+- Memory growth: a naïve `ConcurrentDictionary` would grow without bound. The shipped implementation uses `MemoryCache` with `SizeLimit = 10_000` and a 1-hour sliding expiry, plus a post-eviction callback that removes the matching per-key `SemaphoreSlim` from `_agenticLocks` so both collections stay bounded together.
+- Concurrent mutation of a shared `ClaimsPrincipal` (MSAL writes the account ID back via `user.AddIdentity(...)`) is not thread-safe. The shipped implementation serialises requests for the same identity through a per-key `SemaphoreSlim`; requests for different identities still run concurrently.
 
 ### Option D: File Issue with microsoft-identity-web
 
@@ -180,6 +180,25 @@ This is the "correct" long-term fix but requires upstream changes.
 **Start with Option C** — cache ClaimsPrincipal per `(agenticAppId, agenticUserId)` in `BotAuthenticationHandler`. Validate that the silent flow kicks in on the second call within the same turn. This should eliminate 3 of the 4 Entra round-trips per message (the first call will still hit the network, but subsequent calls within the same turn and across turns will use the cache).
 
 **Also file an issue with microsoft-identity-web** (Option D) for the proper long-term fix.
+
+## Implementation
+
+The shipped fix in `BotAuthenticationHandler.cs` adopts Option C with the following concrete design:
+
+| Concern | Decision |
+|---------|----------|
+| Principal storage | `MemoryCache` keyed by `"{agenticAppId}:{agenticUserGuid:D}"`, `SizeLimit = 10_000`, `SlidingExpiration = 1h`, `Size = 1` per entry. |
+| Per-identity serialisation | `ConcurrentDictionary<string, SemaphoreSlim>` (`_agenticLocks`). Each `SendAsync` for a given identity acquires the matching semaphore before reading/mutating the cached `ClaimsPrincipal`. |
+| Bounding `_agenticLocks` | A `PostEvictionCallback` on every cache entry calls `_agenticLocks.TryRemove(key, …)` so the two collections shrink together. The semaphore is **not** disposed in the callback — an in-flight request may still hold it; GC reclaims it once all references release. |
+| Handler-level disposal | `Dispose(disposing)` disposes the cache then iterates and disposes any remaining semaphores. |
+| `IHttpClientFactory` lifecycle | Handler chains are pooled by `IHttpClientFactory` and rotated based on `HandlerLifetime` (default ~2 minutes). The cache therefore lives at most for that window, which is sufficient to collapse the per-turn redundant round-trips that motivated this change. |
+
+Verified by `BotAuthenticationHandlerTests`:
+- Same identity reuses the same `ClaimsPrincipal` across calls.
+- Concurrent calls for the same identity are serialised; different identities run concurrently.
+- Cache eviction removes the matching lock entry from `_agenticLocks` and a subsequent call still succeeds.
+- An in-flight call holding a semaphore is not disrupted by concurrent eviction (no `ObjectDisposedException`).
+- `Dispose` cleans up remaining semaphores and the cache.
 
 ## Key Files
 

--- a/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
@@ -46,6 +46,17 @@ internal sealed class BotAuthenticationHandler(
     private readonly MemoryCache _agenticPrincipalCache = new(new MemoryCacheOptions { SizeLimit = 10_000 });
     // Per-key semaphores to prevent concurrent requests from mutating the same ClaimsPrincipal simultaneously.
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _agenticLocks = new();
+    // Removes the lock entry when its principal is evicted from the cache so _agenticLocks stays bounded.
+    // The semaphore itself is NOT disposed here — an in-flight call may still hold it and must be able
+    // to call Release() without ObjectDisposedException; GC reclaims it once all references are gone.
+    private static readonly PostEvictionDelegate _removeAgenticLockOnEviction =
+        static (key, _, _, state) =>
+        {
+            if (state is ConcurrentDictionary<string, SemaphoreSlim> locks && key is string k)
+            {
+                locks.TryRemove(k, out _);
+            }
+        };
     private static readonly Action<ILogger, string, Exception?> _logAgenticToken =
         LoggerMessage.Define<string>(LogLevel.Debug, new(2), "Acquiring agentic token for AgenticAppId {AgenticAppId}");
     private static readonly Action<ILogger, string, Exception?> _logAppOnlyToken =
@@ -150,7 +161,7 @@ internal sealed class BotAuthenticationHandler(
                             {
                                 SlidingExpiration = _agenticPrincipalSlidingExpiry,
                                 Size = 1,
-                            });
+                            }.RegisterPostEvictionCallback(_removeAgenticLockOnEviction, _agenticLocks));
                         }
 
                         string token = await _authorizationHeaderProvider.CreateAuthorizationHeaderAsync([AgenticScope], options, principal, cancellationToken).ConfigureAwait(false);

--- a/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
+using System.Security.Claims;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
@@ -36,6 +38,10 @@ internal sealed class BotAuthenticationHandler(
     private readonly IAuthorizationHeaderProvider _authorizationHeaderProvider = authorizationHeaderProvider ?? throw new ArgumentNullException(nameof(authorizationHeaderProvider));
     private readonly ILogger<BotAuthenticationHandler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private readonly IOptionsMonitor<ManagedIdentityOptions>? _managedIdentityOptions = managedIdentityOptions;
+
+    // Cache ClaimsPrincipal per agentic identity so MSAL can reuse the account ID
+    // populated after the first ROPC call for silent token acquisition on subsequent calls.
+    private readonly ConcurrentDictionary<string, ClaimsPrincipal> _agenticPrincipalCache = new();
     private static readonly Action<ILogger, string, Exception?> _logAgenticToken =
         LoggerMessage.Define<string>(LogLevel.Debug, new(2), "Acquiring agentic token for AgenticAppId {AgenticAppId}");
     private static readonly Action<ILogger, string, Exception?> _logAppOnlyToken =
@@ -121,7 +127,15 @@ internal sealed class BotAuthenticationHandler(
                 {
                     span?.SetTag(Telemetry.Tags.AuthFlow, "agentic");
                     options.WithAgentUserIdentity(agenticIdentity.AgenticAppId, agenticUserGuid);
-                    string token = await _authorizationHeaderProvider.CreateAuthorizationHeaderAsync([AgenticScope], options, null, cancellationToken).ConfigureAwait(false);
+
+                    // Reuse a cached ClaimsPrincipal so MSAL's silent flow can look up
+                    // the account ID populated after the first ROPC token exchange.
+                    // Without this, ClaimsPrincipal is null on every call and MSAL
+                    // always falls through to a network round-trip to Entra.
+                    string cacheKey = $"{agenticIdentity.AgenticAppId}:{agenticUserGuid:D}";
+                    ClaimsPrincipal principal = _agenticPrincipalCache.GetOrAdd(cacheKey, _ => new ClaimsPrincipal());
+
+                    string token = await _authorizationHeaderProvider.CreateAuthorizationHeaderAsync([AgenticScope], options, principal, cancellationToken).ConfigureAwait(false);
                     return token;
                 }
             }

--- a/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
@@ -150,19 +150,6 @@ internal sealed class BotAuthenticationHandler(
                             {
                                 SlidingExpiration = _agenticPrincipalSlidingExpiry,
                                 Size = 1,
-                                PostEvictionCallbacks =
-                                {
-                                    new PostEvictionCallbackRegistration
-                                    {
-                                        EvictionCallback = (key, _, _, _) =>
-                                        {
-                                            if (_agenticLocks.TryRemove((string)key, out SemaphoreSlim? s))
-                                            {
-                                                s.Dispose();
-                                            }
-                                        },
-                                    }
-                                },
                             });
                         }
 
@@ -222,17 +209,15 @@ internal sealed class BotAuthenticationHandler(
     {
         if (disposing)
         {
-            // Snapshot and clear the lock dictionary before disposing the cache so that
-            // post-eviction callbacks (which call TryRemove on _agenticLocks) cannot
-            // race with or double-dispose the semaphores we are about to dispose here.
-            SemaphoreSlim[] semaphores = [.. _agenticLocks.Values];
-            _agenticLocks.Clear();
             _agenticPrincipalCache.Dispose();
-            foreach (SemaphoreSlim s in semaphores)
+            foreach (SemaphoreSlim s in _agenticLocks.Values)
             {
                 s.Dispose();
             }
+
+            _agenticLocks.Clear();
         }
+
         base.Dispose(disposing);
     }
 }

--- a/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
@@ -138,7 +138,7 @@ internal sealed class BotAuthenticationHandler(
                     // always falls through to a network round-trip to Entra.
                     // A per-key semaphore serialises concurrent requests for the same identity
                     // to prevent unsynchronised mutation of the shared ClaimsPrincipal.
-                    string cacheKey = $"{agenticIdentity.AgenticAppId}:{agenticUserGuid:D}";
+                    string cacheKey = GetAgenticCacheKey(agenticIdentity.AgenticAppId, agenticUserGuid);
                     SemaphoreSlim semaphore = _agenticLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
                     await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                     try
@@ -150,6 +150,19 @@ internal sealed class BotAuthenticationHandler(
                             {
                                 SlidingExpiration = _agenticPrincipalSlidingExpiry,
                                 Size = 1,
+                                PostEvictionCallbacks =
+                                {
+                                    new PostEvictionCallbackRegistration
+                                    {
+                                        EvictionCallback = (key, _, _, _) =>
+                                        {
+                                            if (_agenticLocks.TryRemove((string)key, out SemaphoreSlim? s))
+                                            {
+                                                s.Dispose();
+                                            }
+                                        },
+                                    }
+                                },
                             });
                         }
 
@@ -181,6 +194,9 @@ internal sealed class BotAuthenticationHandler(
         }
     }
 
+    private static string GetAgenticCacheKey(string agenticAppId, Guid agenticUserGuid) =>
+        $"{agenticAppId}:{agenticUserGuid:D}";
+
     private void LogTokenClaims(string token)
     {
         if (!_logger.IsEnabled(LogLevel.Trace))
@@ -206,8 +222,13 @@ internal sealed class BotAuthenticationHandler(
     {
         if (disposing)
         {
+            // Snapshot and clear the lock dictionary before disposing the cache so that
+            // post-eviction callbacks (which call TryRemove on _agenticLocks) cannot
+            // race with or double-dispose the semaphores we are about to dispose here.
+            SemaphoreSlim[] semaphores = [.. _agenticLocks.Values];
+            _agenticLocks.Clear();
             _agenticPrincipalCache.Dispose();
-            foreach (SemaphoreSlim s in _agenticLocks.Values)
+            foreach (SemaphoreSlim s in semaphores)
             {
                 s.Dispose();
             }

--- a/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
@@ -156,10 +156,11 @@ internal sealed class BotAuthenticationHandler(
                                     {
                                         EvictionCallback = (key, _, _, _) =>
                                         {
-                                            if (_agenticLocks.TryRemove((string)key, out SemaphoreSlim? s))
+                                            if (key is string k)
                                             {
-                                                s.Dispose();
+                                                _agenticLocks.TryRemove(k, out _);
                                             }
+                                        }
                                         },
                                     }
                                 },

--- a/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
 using System.Security.Claims;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
@@ -34,14 +35,17 @@ internal sealed class BotAuthenticationHandler(
 {
     private const string AgenticScope = "https://botapi.skype.com/.default";
     private const string BotAppScope = "https://api.botframework.com/.default";
+    private static readonly TimeSpan _agenticPrincipalSlidingExpiry = TimeSpan.FromHours(1);
 
     private readonly IAuthorizationHeaderProvider _authorizationHeaderProvider = authorizationHeaderProvider ?? throw new ArgumentNullException(nameof(authorizationHeaderProvider));
     private readonly ILogger<BotAuthenticationHandler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private readonly IOptionsMonitor<ManagedIdentityOptions>? _managedIdentityOptions = managedIdentityOptions;
 
-    // Cache ClaimsPrincipal per agentic identity so MSAL can reuse the account ID
-    // populated after the first ROPC call for silent token acquisition on subsequent calls.
-    private readonly ConcurrentDictionary<string, ClaimsPrincipal> _agenticPrincipalCache = new();
+    // Cache ClaimsPrincipal per agentic identity (bounded + sliding expiry) so MSAL can reuse
+    // the account ID populated after the first ROPC call for silent token acquisition on subsequent calls.
+    private readonly MemoryCache _agenticPrincipalCache = new(new MemoryCacheOptions { SizeLimit = 10_000 });
+    // Per-key semaphores to prevent concurrent requests from mutating the same ClaimsPrincipal simultaneously.
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _agenticLocks = new();
     private static readonly Action<ILogger, string, Exception?> _logAgenticToken =
         LoggerMessage.Define<string>(LogLevel.Debug, new(2), "Acquiring agentic token for AgenticAppId {AgenticAppId}");
     private static readonly Action<ILogger, string, Exception?> _logAppOnlyToken =
@@ -132,11 +136,30 @@ internal sealed class BotAuthenticationHandler(
                     // the account ID populated after the first ROPC token exchange.
                     // Without this, ClaimsPrincipal is null on every call and MSAL
                     // always falls through to a network round-trip to Entra.
+                    // A per-key semaphore serialises concurrent requests for the same identity
+                    // to prevent unsynchronised mutation of the shared ClaimsPrincipal.
                     string cacheKey = $"{agenticIdentity.AgenticAppId}:{agenticUserGuid:D}";
-                    ClaimsPrincipal principal = _agenticPrincipalCache.GetOrAdd(cacheKey, _ => new ClaimsPrincipal());
+                    SemaphoreSlim semaphore = _agenticLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
+                    await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        if (!_agenticPrincipalCache.TryGetValue(cacheKey, out ClaimsPrincipal? principal) || principal is null)
+                        {
+                            principal = new ClaimsPrincipal();
+                            _agenticPrincipalCache.Set(cacheKey, principal, new MemoryCacheEntryOptions
+                            {
+                                SlidingExpiration = _agenticPrincipalSlidingExpiry,
+                                Size = 1,
+                            });
+                        }
 
-                    string token = await _authorizationHeaderProvider.CreateAuthorizationHeaderAsync([AgenticScope], options, principal, cancellationToken).ConfigureAwait(false);
-                    return token;
+                        string token = await _authorizationHeaderProvider.CreateAuthorizationHeaderAsync([AgenticScope], options, principal, cancellationToken).ConfigureAwait(false);
+                        return token;
+                    }
+                    finally
+                    {
+                        semaphore.Release();
+                    }
                 }
             }
             span?.SetTag(Telemetry.Tags.AuthScope, BotAppScope);
@@ -176,5 +199,19 @@ internal sealed class BotAuthenticationHandler(
         {
             _logTokenParseFailure(_logger, ex);
         }
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _agenticPrincipalCache.Dispose();
+            foreach (SemaphoreSlim s in _agenticLocks.Values)
+            {
+                s.Dispose();
+            }
+        }
+        base.Dispose(disposing);
     }
 }

--- a/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs
@@ -156,11 +156,10 @@ internal sealed class BotAuthenticationHandler(
                                     {
                                         EvictionCallback = (key, _, _, _) =>
                                         {
-                                            if (key is string k)
+                                            if (_agenticLocks.TryRemove((string)key, out SemaphoreSlim? s))
                                             {
-                                                _agenticLocks.TryRemove(k, out _);
+                                                s.Dispose();
                                             }
-                                        }
                                         },
                                     }
                                 },

--- a/core/test/Microsoft.Teams.Core.UnitTests/Hosting/BotAuthenticationHandlerTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Hosting/BotAuthenticationHandlerTests.cs
@@ -193,10 +193,12 @@ public class BotAuthenticationHandlerTests
     }
 
     [Fact]
-    public async Task AgenticRequest_SemaphoreSurvivesCacheEviction_NoObjectDisposedException()
+    public async Task AgenticRequest_CacheEviction_RemovesLockEntry_AndSubsequentCallSucceeds()
     {
-        // Use a handler with the real (10,000-entry) cache but trigger eviction
-        // by directly compacting the private MemoryCache after a first call populates it.
+        // After a principal is evicted from the cache, the matching lock entry must be
+        // removed from _agenticLocks so the dictionary stays bounded. A subsequent call
+        // for the same identity must still succeed (creating a fresh semaphore + principal)
+        // without ever throwing ObjectDisposedException.
         (BotAuthenticationHandler handler, Mock<IAuthorizationHeaderProvider> mockProvider) = CreateHandler();
         using HttpMessageInvoker invoker = new(handler, disposeHandler: false);
 
@@ -211,11 +213,16 @@ public class BotAuthenticationHandlerTests
         // Force eviction by compacting the entire cache.
         cache.Compact(1.0);
 
-        // The semaphore must still be in the dictionary (the fix decoupled it from eviction).
-        Assert.NotEmpty(locks);
+        // The post-eviction callback runs on the thread pool; wait briefly for it to remove
+        // the lock entry. Bounded by 2s to fail fast if the callback is not wired up.
+        bool removed = SpinWait.SpinUntil(() => locks.IsEmpty, TimeSpan.FromSeconds(2));
+        Assert.True(removed, "Expected the lock entry to be removed from _agenticLocks after cache eviction.");
 
-        // Second call for the same identity — must NOT throw ObjectDisposedException.
+        // Second call for the same identity — must NOT throw ObjectDisposedException
+        // and must repopulate both the cache and the lock dictionary.
         await invoker.SendAsync(CreateAgenticRequest(TestAppId, TestUserId), CancellationToken.None);
+
+        Assert.NotEmpty(locks);
 
         handler.Dispose();
     }

--- a/core/test/Microsoft.Teams.Core.UnitTests/Hosting/BotAuthenticationHandlerTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Hosting/BotAuthenticationHandlerTests.cs
@@ -1,0 +1,342 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Net;
+using System.Reflection;
+using System.Security.Claims;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Identity.Abstractions;
+using Microsoft.Teams.Core.Hosting;
+using Microsoft.Teams.Core.Schema;
+using Moq;
+
+namespace Microsoft.Teams.Core.UnitTests.Hosting;
+
+public class BotAuthenticationHandlerTests
+{
+    private static readonly string TestAppId = Guid.NewGuid().ToString();
+    private static readonly string TestUserId = Guid.NewGuid().ToString();
+
+    private static (BotAuthenticationHandler handler, Mock<IAuthorizationHeaderProvider> mockProvider) CreateHandler()
+    {
+        Mock<IAuthorizationHeaderProvider> mockProvider = new();
+        mockProvider
+            .Setup(p => p.CreateAuthorizationHeaderAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<AuthorizationHeaderProviderOptions>(),
+                It.IsAny<ClaimsPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Bearer fake-token");
+
+        mockProvider
+            .Setup(p => p.CreateAuthorizationHeaderForAppAsync(
+                It.IsAny<string>(),
+                It.IsAny<AuthorizationHeaderProviderOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Bearer fake-app-token");
+
+        BotAuthenticationHandler handler = new(
+            mockProvider.Object,
+            NullLogger<BotAuthenticationHandler>.Instance);
+
+        handler.InnerHandler = new StubInnerHandler();
+
+        return (handler, mockProvider);
+    }
+
+    private static HttpRequestMessage CreateAgenticRequest(string appId, string userId)
+    {
+        HttpRequestMessage request = new(HttpMethod.Post, "https://smba.trafficmanager.net/test/v3/conversations");
+        request.Options.Set(BotAuthenticationHandler.AgenticIdentityKey, new AgenticIdentity
+        {
+            AgenticAppId = appId,
+            AgenticUserId = userId,
+        });
+        return request;
+    }
+
+    private static MemoryCache GetPrivateCache(BotAuthenticationHandler handler)
+    {
+        FieldInfo field = typeof(BotAuthenticationHandler)
+            .GetField("_agenticPrincipalCache", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (MemoryCache)field.GetValue(handler)!;
+    }
+
+    private static ConcurrentDictionary<string, SemaphoreSlim> GetPrivateLocks(BotAuthenticationHandler handler)
+    {
+        FieldInfo field = typeof(BotAuthenticationHandler)
+            .GetField("_agenticLocks", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (ConcurrentDictionary<string, SemaphoreSlim>)field.GetValue(handler)!;
+    }
+
+    [Fact]
+    public async Task AgenticRequest_ReusesSameClaimsPrincipal_OnSubsequentCalls()
+    {
+        (BotAuthenticationHandler handler, Mock<IAuthorizationHeaderProvider> mockProvider) = CreateHandler();
+        List<ClaimsPrincipal> capturedPrincipals = [];
+
+        mockProvider
+            .Setup(p => p.CreateAuthorizationHeaderAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<AuthorizationHeaderProviderOptions>(),
+                It.IsAny<ClaimsPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<string>, AuthorizationHeaderProviderOptions, ClaimsPrincipal, CancellationToken>(
+                (_, _, principal, _) => capturedPrincipals.Add(principal))
+            .ReturnsAsync("Bearer fake-token");
+
+        using HttpMessageInvoker invoker = new(handler, disposeHandler: false);
+
+        await invoker.SendAsync(CreateAgenticRequest(TestAppId, TestUserId), CancellationToken.None);
+        await invoker.SendAsync(CreateAgenticRequest(TestAppId, TestUserId), CancellationToken.None);
+
+        Assert.Equal(2, capturedPrincipals.Count);
+        Assert.Same(capturedPrincipals[0], capturedPrincipals[1]);
+
+        handler.Dispose();
+    }
+
+    [Fact]
+    public async Task AgenticRequest_ConcurrentCallsForSameIdentity_AreSerialised()
+    {
+        (BotAuthenticationHandler handler, Mock<IAuthorizationHeaderProvider> mockProvider) = CreateHandler();
+
+        int concurrentCount = 0;
+        int maxConcurrent = 0;
+
+        mockProvider
+            .Setup(p => p.CreateAuthorizationHeaderAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<AuthorizationHeaderProviderOptions>(),
+                It.IsAny<ClaimsPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<string>, AuthorizationHeaderProviderOptions, ClaimsPrincipal, CancellationToken>(
+                async (_, _, _, ct) =>
+                {
+                    int current = Interlocked.Increment(ref concurrentCount);
+                    int snapshot;
+                    do
+                    {
+                        snapshot = maxConcurrent;
+                    } while (current > snapshot && Interlocked.CompareExchange(ref maxConcurrent, current, snapshot) != snapshot);
+
+                    await Task.Delay(50, ct);
+                    Interlocked.Decrement(ref concurrentCount);
+                    return "Bearer fake-token";
+                });
+
+        using HttpMessageInvoker invoker = new(handler, disposeHandler: false);
+
+        Task[] tasks = Enumerable.Range(0, 5)
+            .Select(_ => invoker.SendAsync(CreateAgenticRequest(TestAppId, TestUserId), CancellationToken.None))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(1, maxConcurrent);
+
+        handler.Dispose();
+    }
+
+    [Fact]
+    public async Task AgenticRequest_DifferentIdentities_RunConcurrently()
+    {
+        (BotAuthenticationHandler handler, Mock<IAuthorizationHeaderProvider> mockProvider) = CreateHandler();
+
+        int concurrentCount = 0;
+        int maxConcurrent = 0;
+        TaskCompletionSource allStarted = new();
+
+        mockProvider
+            .Setup(p => p.CreateAuthorizationHeaderAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<AuthorizationHeaderProviderOptions>(),
+                It.IsAny<ClaimsPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<string>, AuthorizationHeaderProviderOptions, ClaimsPrincipal, CancellationToken>(
+                async (_, _, _, ct) =>
+                {
+                    int current = Interlocked.Increment(ref concurrentCount);
+                    int snapshot;
+                    do
+                    {
+                        snapshot = maxConcurrent;
+                    } while (current > snapshot && Interlocked.CompareExchange(ref maxConcurrent, current, snapshot) != snapshot);
+
+                    // Wait until all tasks have entered the critical section
+                    if (current >= 3)
+                    {
+                        allStarted.TrySetResult();
+                    }
+
+                    await allStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), ct);
+                    Interlocked.Decrement(ref concurrentCount);
+                    return "Bearer fake-token";
+                });
+
+        using HttpMessageInvoker invoker = new(handler, disposeHandler: false);
+
+        Task[] tasks = Enumerable.Range(0, 3)
+            .Select(i => invoker.SendAsync(
+                CreateAgenticRequest(Guid.NewGuid().ToString(), Guid.NewGuid().ToString()),
+                CancellationToken.None))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        Assert.True(maxConcurrent >= 2, $"Expected concurrent execution for different identities but maxConcurrent was {maxConcurrent}");
+
+        handler.Dispose();
+    }
+
+    [Fact]
+    public async Task AgenticRequest_SemaphoreSurvivesCacheEviction_NoObjectDisposedException()
+    {
+        // Use a handler with the real (10,000-entry) cache but trigger eviction
+        // by directly compacting the private MemoryCache after a first call populates it.
+        (BotAuthenticationHandler handler, Mock<IAuthorizationHeaderProvider> mockProvider) = CreateHandler();
+        using HttpMessageInvoker invoker = new(handler, disposeHandler: false);
+
+        // First call — populates both the cache entry and the semaphore.
+        await invoker.SendAsync(CreateAgenticRequest(TestAppId, TestUserId), CancellationToken.None);
+
+        ConcurrentDictionary<string, SemaphoreSlim> locks = GetPrivateLocks(handler);
+        MemoryCache cache = GetPrivateCache(handler);
+
+        Assert.NotEmpty(locks);
+
+        // Force eviction by compacting the entire cache.
+        cache.Compact(1.0);
+
+        // The semaphore must still be in the dictionary (the fix decoupled it from eviction).
+        Assert.NotEmpty(locks);
+
+        // Second call for the same identity — must NOT throw ObjectDisposedException.
+        await invoker.SendAsync(CreateAgenticRequest(TestAppId, TestUserId), CancellationToken.None);
+
+        handler.Dispose();
+    }
+
+    [Fact]
+    public async Task AgenticRequest_AfterCacheEviction_CreatesNewPrincipal()
+    {
+        (BotAuthenticationHandler handler, Mock<IAuthorizationHeaderProvider> mockProvider) = CreateHandler();
+        List<ClaimsPrincipal> capturedPrincipals = [];
+
+        mockProvider
+            .Setup(p => p.CreateAuthorizationHeaderAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<AuthorizationHeaderProviderOptions>(),
+                It.IsAny<ClaimsPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<string>, AuthorizationHeaderProviderOptions, ClaimsPrincipal, CancellationToken>(
+                (_, _, principal, _) => capturedPrincipals.Add(principal))
+            .ReturnsAsync("Bearer fake-token");
+
+        using HttpMessageInvoker invoker = new(handler, disposeHandler: false);
+
+        // First call — populates cache.
+        await invoker.SendAsync(CreateAgenticRequest(TestAppId, TestUserId), CancellationToken.None);
+
+        // Evict everything.
+        MemoryCache cache = GetPrivateCache(handler);
+        cache.Compact(1.0);
+
+        // Second call — should create a new ClaimsPrincipal since cache was evicted.
+        await invoker.SendAsync(CreateAgenticRequest(TestAppId, TestUserId), CancellationToken.None);
+
+        Assert.Equal(2, capturedPrincipals.Count);
+        Assert.NotSame(capturedPrincipals[0], capturedPrincipals[1]);
+
+        handler.Dispose();
+    }
+
+    [Fact]
+    public async Task AgenticRequest_ConcurrentCallsDuringCacheEviction_DoNotThrow()
+    {
+        (BotAuthenticationHandler handler, Mock<IAuthorizationHeaderProvider> mockProvider) = CreateHandler();
+        SemaphoreSlim gate = new(0, 1);
+
+        mockProvider
+            .Setup(p => p.CreateAuthorizationHeaderAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<AuthorizationHeaderProviderOptions>(),
+                It.IsAny<ClaimsPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<string>, AuthorizationHeaderProviderOptions, ClaimsPrincipal, CancellationToken>(
+                async (_, _, _, ct) =>
+                {
+                    // Signal that we are inside the critical section, then wait.
+                    gate.Release();
+                    await Task.Delay(100, ct);
+                    return "Bearer fake-token";
+                });
+
+        using HttpMessageInvoker invoker = new(handler, disposeHandler: false);
+
+        string appId = Guid.NewGuid().ToString();
+        string userId = Guid.NewGuid().ToString();
+
+        // Start a call that will hold the semaphore.
+        Task firstCall = invoker.SendAsync(CreateAgenticRequest(appId, userId), CancellationToken.None);
+
+        // Wait until it's inside the critical section.
+        await gate.WaitAsync();
+
+        // Evict the cache entry while the semaphore is held.
+        MemoryCache cache = GetPrivateCache(handler);
+        cache.Compact(1.0);
+
+        // The first call should complete without ObjectDisposedException.
+        await firstCall;
+
+        // A follow-up call should also work.
+        // Reset mock to return immediately.
+        mockProvider
+            .Setup(p => p.CreateAuthorizationHeaderAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<AuthorizationHeaderProviderOptions>(),
+                It.IsAny<ClaimsPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Bearer fake-token");
+
+        await invoker.SendAsync(CreateAgenticRequest(appId, userId), CancellationToken.None);
+
+        handler.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_CleansUpSemaphoresAndCache()
+    {
+        (BotAuthenticationHandler handler, _) = CreateHandler();
+        ConcurrentDictionary<string, SemaphoreSlim> locks = GetPrivateLocks(handler);
+
+        // Manually add some semaphores to simulate cached agentic identities.
+        locks.TryAdd("key1", new SemaphoreSlim(1, 1));
+        locks.TryAdd("key2", new SemaphoreSlim(1, 1));
+
+        SemaphoreSlim s1 = locks["key1"];
+        SemaphoreSlim s2 = locks["key2"];
+
+        handler.Dispose();
+
+        Assert.Empty(locks);
+        // Disposed semaphores throw on WaitAsync.
+        Assert.Throws<ObjectDisposedException>(() => s1.Wait(0));
+        Assert.Throws<ObjectDisposedException>(() => s2.Wait(0));
+    }
+
+    /// <summary>
+    /// Stub inner handler that returns 200 OK for all requests.
+    /// </summary>
+    private class StubInnerHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+}


### PR DESCRIPTION
workaround for https://github.com/AzureAD/microsoft-identity-web/issues/3840

Previously, agentic token requests always triggered network calls to Entra due to passing a null ClaimsPrincipal, bypassing MSAL's silent token cache. This change introduces a per-agentic-identity ClaimsPrincipal cache, enabling silent token acquisition and reducing redundant network latency. Also adds a markdown investigation documenting the root cause, impact, and solution rationale.

