### PR TITLE
Validate serviceurl claim matches activity ServiceUrl in AspNetCorePlugin

### DIFF
--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.cs
@@ -191,6 +191,22 @@ public partial class AspNetCorePlugin : ISenderPlugin, IAspNetCorePlugin
                 return Results.BadRequest("Missing activity");
             }
 
+            // Require the token's serviceurl claim to match the activity's serviceUrl
+            // (normalized, case-insensitive) when the activity specifies one. Mismatches
+            // are logged server-side.
+            if (!string.IsNullOrEmpty(activity.ServiceUrl))
+            {
+                var claimServiceUrl = token.Token.Payload.TryGetValue("serviceurl", out var serviceUrlClaim)
+                    ? serviceUrlClaim as string
+                    : null;
+
+                if (!NormalizeServiceUrl(claimServiceUrl).Equals(NormalizeServiceUrl(activity.ServiceUrl), StringComparison.OrdinalIgnoreCase))
+                {
+                    Logger.Warn($"Rejecting activity {activity.Id}: serviceUrl '{activity.ServiceUrl}' does not match the token serviceurl claim '{claimServiceUrl}'.");
+                    return Results.Unauthorized();
+                }
+            }
+
             var data = new Dictionary<string, object?>
             {
                 ["Request.TraceId"] = httpContext.TraceIdentifier
@@ -241,6 +257,12 @@ public partial class AspNetCorePlugin : ISenderPlugin, IAspNetCorePlugin
             return Results.Problem(detail: ex.Message, statusCode: 500);
         }
     }
+
+    // Normalize a serviceUrl for comparison: null/empty becomes empty, and a single
+    // trailing slash is trimmed so "https://host/teams" and "https://host/teams/" match.
+    private static string NormalizeServiceUrl(string? serviceUrl) =>
+        string.IsNullOrEmpty(serviceUrl) ? string.Empty :
+            serviceUrl.EndsWith('/') ? serviceUrl[..^1] : serviceUrl;
 
     public JsonWebToken ExtractToken(HttpRequest httpRequest)
     {

--- a/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginTests.cs
+++ b/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginTests.cs
@@ -47,15 +47,32 @@ public class AspNetCorePluginTests
         return ctx;
     }
 
-    private static MessageActivity CreateMessageActivity()
+    private static MessageActivity CreateMessageActivity(string? serviceUrl = null)
     {
         return new MessageActivity("hi")
         {
             From = new() { Id = "user" },
             Recipient = new() { Id = "bot" },
-            Conversation = new Conversation() { Id = "conv", Type = ConversationType.Personal }
+            Conversation = new Conversation() { Id = "conv", Type = ConversationType.Personal },
+            ServiceUrl = serviceUrl
         };
     }
+
+    // Builds an unsigned-but-parseable JWT carrying the given serviceurl claim (omitted when null).
+    // JsonWebToken/JwtSecurityTokenHandler.ReadJwtToken parses without verifying the signature.
+    private static string CreateJwt(string? serviceUrl)
+    {
+        var payload = new Dictionary<string, object> { ["exp"] = 4702515200L };
+        if (serviceUrl is not null)
+        {
+            payload["serviceurl"] = serviceUrl;
+        }
+        return $"{Base64Url(new { alg = "HS256", typ = "JWT" })}.{Base64Url(payload)}.signature";
+    }
+
+    private static string Base64Url(object value) =>
+        Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(value)))
+            .TrimEnd('=').Replace('+', '-').Replace('/', '_');
 
     [Fact]
     public async Task Test_Do_Http_CallsExtractTokenAndActivity_AndCallsCoreDo()
@@ -195,5 +212,85 @@ public class AspNetCorePluginTests
         // Assert
         Assert.Same(response, res);
         logger.Verify(l => l.Debug(It.IsAny<object[]>()), Times.AtLeastOnce);
+    }
+
+    [Theory]
+    [InlineData("https://smba.trafficmanager.net/teams/", "https://smba.trafficmanager.net/teams/")] // exact match
+    [InlineData("HTTPS://SMBA.TRAFFICMANAGER.NET/teams/", "https://smba.trafficmanager.net/teams/")] // case-insensitive
+    [InlineData("https://smba.trafficmanager.net/teams", "https://smba.trafficmanager.net/teams/")] // trailing-slash normalized
+    public async Task Test_Do_Http_ServiceUrlClaimMatches_Processes(string claimServiceUrl, string activityServiceUrl)
+    {
+        // Arrange
+        var activity = CreateMessageActivity(activityServiceUrl);
+        var coreResponse = new Response(HttpStatusCode.Accepted, new { ok = true });
+        var eventsCalled = new List<string>();
+        EventFunction events = (plugin, name, payload, ct) =>
+        {
+            eventsCalled.Add(name);
+            if (name == "activity") return Task.FromResult<object?>(coreResponse);
+            return Task.FromResult<object?>(null);
+        };
+        var plugin = CreatePlugin(new Mock<ILogger>(), events);
+        var ctx = CreateHttpContext(activity, CreateJwt(claimServiceUrl));
+
+        // Act
+        var result = await plugin.Do(ctx);
+
+        // Assert
+        Assert.Contains("activity", eventsCalled);
+        var jsonResult = Assert.IsType<Microsoft.AspNetCore.Http.HttpResults.JsonHttpResult<object?>>(result);
+        Assert.Equal((int)coreResponse.Status, jsonResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task Test_Do_Http_ServiceUrlClaimMismatch_ReturnsUnauthorized()
+    {
+        // Arrange
+        var activity = CreateMessageActivity("https://smba.trafficmanager.net/teams/");
+        var eventsCalled = new List<string>();
+        EventFunction events = (plugin, name, payload, ct) =>
+        {
+            eventsCalled.Add(name);
+            if (name == "activity") return Task.FromResult<object?>(new Response(HttpStatusCode.OK, new { ok = true }));
+            return Task.FromResult<object?>(null);
+        };
+        var logger = new Mock<ILogger>();
+        var plugin = CreatePlugin(logger, events);
+        var ctx = CreateHttpContext(activity, CreateJwt("https://evil.example.com/"));
+
+        // Act
+        var result = await plugin.Do(ctx);
+
+        // Assert: rejected with 401, activity never dispatched, neither URL echoed, logged server-side.
+        var unauthorized = Assert.IsType<Microsoft.AspNetCore.Http.HttpResults.UnauthorizedHttpResult>(result);
+        Assert.Equal(401, unauthorized.StatusCode);
+        Assert.DoesNotContain("activity", eventsCalled);
+        logger.Verify(l => l.Warn(It.IsAny<object[]>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Test_Do_Http_NoServiceUrlClaim_ReturnsUnauthorized()
+    {
+        // Arrange: activity carries a serviceUrl but the token has no serviceurl claim.
+        var activity = CreateMessageActivity("https://smba.trafficmanager.net/teams/");
+        var eventsCalled = new List<string>();
+        EventFunction events = (plugin, name, payload, ct) =>
+        {
+            eventsCalled.Add(name);
+            if (name == "activity") return Task.FromResult<object?>(new Response(HttpStatusCode.OK, new { ok = true }));
+            return Task.FromResult<object?>(null);
+        };
+        var logger = new Mock<ILogger>();
+        var plugin = CreatePlugin(logger, events);
+        var ctx = CreateHttpContext(activity, CreateJwt(null));
+
+        // Act
+        var result = await plugin.Do(ctx);
+
+        // Assert: a token without a serviceurl claim is rejected when the activity has one.
+        var unauthorized = Assert.IsType<Microsoft.AspNetCore.Http.HttpResults.UnauthorizedHttpResult>(result);
+        Assert.Equal(401, unauthorized.StatusCode);
+        Assert.DoesNotContain("activity", eventsCalled);
+        logger.Verify(l => l.Warn(It.IsAny<object[]>()), Times.Once);
     }
 }


### PR DESCRIPTION
## What

Adds serviceurl claim validation to `AspNetCorePlugin.Do(HttpContext)`. When an inbound activity carries a `serviceUrl`, the authenticated token's `serviceurl` claim must be present and match it (normalized for a single trailing slash, case-insensitive). On mismatch or a missing claim the request is rejected with `401`; activities without a `serviceUrl` are unaffected. Mismatch detail is logged server-side only — the response body returns neither value.

## Cross-SDK parity

The TypeScript and Python SDKs already perform this claim-vs-activity check, failing closed when the `serviceurl` claim is absent. This mirrors that behavior in the .NET 2.0 (`Libraries/`) plugin.

## Tests

Five unit tests in `AspNetCorePluginTests.cs`:
- exact match -> processes
- case-insensitive match -> processes
- trailing-slash-normalized match -> processes
- mismatched claim -> `401`
- missing claim (activity has a serviceUrl) -> `401`

Manually verified end-to-end in Teams: a real message round-trips and the bot replies (claim matches), with no regression to the activity path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)