### PR TITLE
fix(compat): reuse TurnContext in OnTurnError error path

### DIFF
--- a/core/samples/CompatBot/Program.cs
+++ b/core/samples/CompatBot/Program.cs
@@ -31,6 +31,10 @@ WebApplication app = builder.Build();
 TeamsBotFrameworkHttpAdapter compatAdapter = (TeamsBotFrameworkHttpAdapter)app.Services.GetRequiredService<IBotFrameworkHttpAdapter>();
 compatAdapter.Use(new MyCompatMiddleware());
 compatAdapter.Use(new MyCompatMiddleware());
+compatAdapter.OnTurnError = async (turnContext, exception) =>
+{
+    await turnContext.SendActivityAsync(MessageFactory.Text("Oops, something went wrong! Please try again later."));
+};
 
 app.MapPost("/api/messages", async (IBotFrameworkHttpAdapter adapter, IBot bot, HttpRequest request, HttpResponse response, CancellationToken ct) =>
     await adapter.ProcessAsync(request, response, bot, ct)).RequireAuthorization();

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsBotFrameworkHttpAdapter.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsBotFrameworkHttpAdapter.cs
@@ -61,11 +61,10 @@ public class TeamsBotFrameworkHttpAdapter : TeamsBotAdapter, IBotFrameworkHttpAd
         ArgumentNullException.ThrowIfNull(httpResponse);
         ArgumentNullException.ThrowIfNull(bot);
 
-        CoreActivity? coreActivity = null;
+        TurnContext? turnContext = null;
         _activityCallback.Value = async (activity, ct) =>
         {
-            coreActivity = activity;
-            TurnContext turnContext = new(this, activity.ToBotFrameworkActivity());
+            turnContext = new(this, activity.ToBotFrameworkActivity());
             turnContext.TurnState.Add<Microsoft.Bot.Connector.Authentication.UserTokenClient>(new CompatUserTokenClient(_teamsBotApplication.UserTokenClient));
             CompatConnectorClient connectionClient = new(new CompatConversations(_teamsBotApplication.ConversationClient)
             {
@@ -85,11 +84,11 @@ public class TeamsBotFrameworkHttpAdapter : TeamsBotAdapter, IBotFrameworkHttpAd
         {
             if (OnTurnError != null)
             {
-                if (ex is BotHandlerException aex)
+#pragma warning disable CA1508 // turnContext is assigned by the async callback captured in the closure
+                if (ex is BotHandlerException aex && turnContext != null)
+#pragma warning restore CA1508
                 {
                     _logger?.ActivityProcessingErrorDelegating(ex, aex.Activity?.Id);
-                    coreActivity = aex.Activity;
-                    using TurnContext turnContext = new(this, coreActivity!.ToBotFrameworkActivity());
                     await OnTurnError(turnContext, ex).ConfigureAwait(false);
                 }
                 else
@@ -105,6 +104,7 @@ public class TeamsBotFrameworkHttpAdapter : TeamsBotAdapter, IBotFrameworkHttpAd
         finally
         {
             _activityCallback.Value = null;
+            turnContext?.Dispose();
         }
     }
 

--- a/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatAdapterTests.cs
+++ b/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatAdapterTests.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Schema;
 using Moq;
 
 namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
@@ -60,6 +62,64 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             Assert.NotNull(capturedConnectorClient);
             Assert.Equal("CompatConnectorClient", capturedConnectorClient.GetType().Name);
             Assert.IsAssignableFrom<Microsoft.Bot.Connector.IConnectorClient>(capturedConnectorClient);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_OnTurnError_ReceivesTurnContextWithTurnState()
+        {
+            // Arrange
+            TeamsBotFrameworkHttpAdapter adapter = CreateCompatAdapter();
+
+            ITurnContext? capturedTurnContext = null;
+            Microsoft.Bot.Connector.Authentication.UserTokenClient? capturedUserTokenClient = null;
+            Microsoft.Bot.Connector.IConnectorClient? capturedConnectorClient = null;
+            string? capturedCustomTurnState = null;
+
+            adapter.OnTurnError = (turnContext, exception) =>
+            {
+                capturedTurnContext = turnContext;
+                capturedUserTokenClient = turnContext.TurnState.Get<Microsoft.Bot.Connector.Authentication.UserTokenClient>();
+                capturedConnectorClient = turnContext.TurnState.Get<Microsoft.Bot.Connector.IConnectorClient>();
+                capturedCustomTurnState = turnContext.TurnState.Get<string>("customTurnStateKey");
+                return Task.CompletedTask;
+            };
+
+            Mock<IBot> mockBot = new();
+            mockBot
+                .Setup(b => b.OnTurnAsync(It.IsAny<ITurnContext>(), It.IsAny<CancellationToken>()))
+                .Returns<ITurnContext, CancellationToken>((tc, _) =>
+                {
+                    tc.TurnState.Add("customTurnStateKey", "customTurnStateValue");
+                    throw new InvalidOperationException("Test exception");
+                });
+
+            CoreActivity activity = new()
+            {
+                Type = ActivityType.Message,
+                Id = "act123",
+                ServiceUrl = new Uri("https://smba.trafficmanager.net/teams/"),
+                Conversation = new Conversation("conv123"),
+                From = new Teams.Core.Schema.ConversationAccount { Id = "user123" }
+            };
+
+            DefaultHttpContext httpContext = new();
+            byte[] bodyBytes = Encoding.UTF8.GetBytes(activity.ToJson());
+            httpContext.Request.Body = new MemoryStream(bodyBytes);
+            httpContext.Request.ContentType = "application/json";
+
+            // Act
+            await adapter.ProcessAsync(httpContext.Request, httpContext.Response, mockBot.Object, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(capturedTurnContext);
+
+            Assert.NotNull(capturedUserTokenClient);
+            Assert.Equal("CompatUserTokenClient", capturedUserTokenClient.GetType().Name);
+
+            Assert.NotNull(capturedConnectorClient);
+            Assert.Equal("CompatConnectorClient", capturedConnectorClient.GetType().Name);
+
+            Assert.Equal("customTurnStateValue", capturedCustomTurnState);
         }
 
         private static TeamsBotFrameworkHttpAdapter CreateCompatAdapter()


### PR DESCRIPTION
## Summary
- Reuse the same `TurnContext` in the `OnTurnError` handler instead of creating a new bare one, so error handlers have access to turn state (`IConnectorClient`, `UserTokenClient`, and any bot-added state)
- Add `OnTurnError` handler to CompatBot sample

## Testing
- Unit test: `OnTurnError` receives `TurnContext` with `UserTokenClient` and `IConnectorClient` populated
- Unit test: custom turn state added by bot logic is accessible in `OnTurnError`
- E2E: CompatBot echoes messages normally via pa-bot in Teams
- E2E: sending "throw" triggers `OnTurnError` which sends error message back to user
- E2E: custom turn state set before throw is readable in `OnTurnError` handler
- All 42 existing + new unit tests pass