### PR TITLE
chore: exclude deprecated packages from NuGet release

### DIFF
--- a/Libraries/Microsoft.Teams.AI.Models.OpenAI/Microsoft.Teams.AI.Models.OpenAI.csproj
+++ b/Libraries/Microsoft.Teams.AI.Models.OpenAI/Microsoft.Teams.AI.Models.OpenAI.csproj
@@ -4,6 +4,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Microsoft.Teams.AI.Models.OpenAI</PackageId>
+    <IsPackable>false</IsPackable>
     <PackageDescription>[DEPRECATED] Microsoft.Teams.AI.Models.OpenAI is deprecated and will be removed by end of summer 2026.</PackageDescription>
     <PackageProjectUrl>https://microsoft.github.io/teams-sdk</PackageProjectUrl>
     <PackageTags>microsoft;teams;msteams;copilot;ai;openai;deprecated</PackageTags>

--- a/Libraries/Microsoft.Teams.AI/Microsoft.Teams.AI.csproj
+++ b/Libraries/Microsoft.Teams.AI/Microsoft.Teams.AI.csproj
@@ -4,6 +4,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Microsoft.Teams.AI</PackageId>
+    <IsPackable>false</IsPackable>
     <PackageDescription>[DEPRECATED] Microsoft.Teams.AI is deprecated and will be removed by end of summer 2026.</PackageDescription>
     <PackageProjectUrl>https://microsoft.github.io/teams-sdk</PackageProjectUrl>
     <PackageTags>microsoft;teams;msteams;copilot;ai;deprecated</PackageTags>

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore.DevTools/Microsoft.Teams.Plugins.AspNetCore.DevTools.csproj
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore.DevTools/Microsoft.Teams.Plugins.AspNetCore.DevTools.csproj
@@ -4,6 +4,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Microsoft.Teams.Plugins.AspNetCore.DevTools</PackageId>
+    <IsPackable>false</IsPackable>
     <PackageDescription>[DEPRECATED] Teams AspNetCore DevTools Plugin. Use Microsoft 365 Agents Playground instead.</PackageDescription>
     <PackageProjectUrl>https://microsoft.github.io/teams-sdk</PackageProjectUrl>
     <PackageTags>microsoft;teams;msteams;copilot;ai;plugins;aspnetcore;devtools</PackageTags>


### PR DESCRIPTION
## Summary
- Set `<IsPackable>false</IsPackable>` on three deprecated packages so they are no longer included in NuGet releases:
  - `Microsoft.Teams.AI`
  - `Microsoft.Teams.AI.Models.OpenAI`
  - `Microsoft.Teams.Plugins.AspNetCore.DevTools`
- Projects still build normally (project references from other packages are unaffected), but `dotnet pack` skips them across all pipelines (Azure DevOps and GitHub Actions)
- No pipeline YAML changes required

## Test plan
- [x] Verify `dotnet build` succeeds (project references still resolve)
- [x] Verify `dotnet pack` produces no `.nupkg` for the three deprecated packages
- [x] Confirm other Legacy packages still pack correctly