### PR TITLE
Add distributed state for OAuth deduplication and update sample state usage

### DIFF
--- a/core/docs/Observability-Design.md
+++ b/core/docs/Observability-Design.md
@@ -17,7 +17,17 @@ Consuming bot                            Teams SDK (this design)
     .AddSource(                           └─ "conversation_client" (ConversationClient send/update/delete)
         TeamsBotApplicationTelemetry
         .ActivitySourceName))            ActivitySource("Microsoft.Teams.Apps")
-                                          └─ "handler"             (Router.DispatchAsync)
+        ├─ "handler"                  (Router.DispatchAsync)
+        ├─ "state.load"               (TurnStateLoader)
+        ├─ "state.save"               (TurnStateLoader)
+        ├─ "state.delete"             (TurnStateLoader)
+        ├─ "oauth.signin"             (OAuthFlow.SignInAsync)
+        ├─ "oauth.signout"            (OAuthFlow.SignOutAsync)
+        ├─ "oauth.get_token"          (OAuthFlow.GetTokenAsync)
+        ├─ "oauth.token_exchange"     (OAuthFlow.HandleTokenExchangeAsync)
+        ├─ "oauth.verify_state"       (OAuthFlow.HandleVerifyStateAsync)
+        ├─ "oauth.signin_failure"     (OAuthFlow.HandleSignInFailureAsync)
+        └─ "oauth.connection_status"  (OAuthFlow.GetConnectionStatusAsync)
 .WithMetrics(m => m
     .AddMeter(CoreTelemetryNames         Meter("Microsoft.Teams.Core")
         .MeterName)                       ├─ teams.activities.received   (Counter)
@@ -28,10 +38,13 @@ Consuming bot                            Teams SDK (this design)
                                           └─ teams.outbound.errors       (Counter)
 
                                          Meter("Microsoft.Teams.Apps")
-                                          ├─ teams.handler.dispatched    (Counter)
-                                          ├─ teams.handler.duration      (Histogram, ms)
-                                          ├─ teams.handler.failures      (Counter)
-                                          └─ teams.handler.unmatched     (Counter)
+                                         ├─ teams.handler.dispatched         (Counter)
+                                         ├─ teams.handler.duration           (Histogram, ms)
+                                         ├─ teams.handler.failures           (Counter)
+                                         ├─ teams.handler.unmatched          (Counter)
+                                         ├─ teams.oauth.operations           (Counter)
+                                         ├─ teams.oauth.operation.duration   (Histogram, ms)
+                                         └─ teams.oauth.errors               (Counter)
 ```
 
 ## Layering constraints
@@ -46,7 +59,7 @@ Telemetry follows the same rule: **each assembly publishes its own ActivitySourc
 | Layer | Public name class | Source / Meter name | Spans | Metrics |
 |---|---|---|---|---|
 | `Microsoft.Teams.Core` | `Microsoft.Teams.Core.Diagnostics.CoreTelemetryNames` | `"Microsoft.Teams.Core"` | `turn`, `middleware`, `auth.outbound`, `conversation_client` | `teams.activities.received`, `teams.turn.duration`, `teams.handler.errors`, `teams.middleware.duration`, `teams.outbound.calls`, `teams.outbound.errors` |
-| `Microsoft.Teams.Apps` | `Microsoft.Teams.Apps.Diagnostics.TeamsBotApplicationTelemetry` | `"Microsoft.Teams.Apps"` | `handler` | `teams.handler.dispatched`, `teams.handler.duration`, `teams.handler.failures`, `teams.handler.unmatched` |
+| `Microsoft.Teams.Apps` | `Microsoft.Teams.Apps.Diagnostics.TeamsBotApplicationTelemetry` | `"Microsoft.Teams.Apps"` | `handler`, `state.load`, `state.save`, `state.delete`, `oauth.signin`, `oauth.signout`, `oauth.get_token`, `oauth.token_exchange`, `oauth.verify_state`, `oauth.signin_failure`, `oauth.connection_status` | `teams.handler.dispatched`, `teams.handler.duration`, `teams.handler.failures`, `teams.handler.unmatched`, `teams.state.*`, `teams.oauth.operations`, `teams.oauth.operation.duration`, `teams.oauth.errors` |
 
 Cross-assembly use is one-way: Apps's `Router` may call Core utilities (for example, the public `RecordException` extension on `Activity` defined in `Microsoft.Teams.Core.Diagnostics.ActivityExtensions`), but Core never reaches up into Apps. If a future Core-level helper would need an Apps concept, that helper belongs in Apps, not in Core.
 
@@ -85,6 +98,13 @@ The auto-instrumented HTTP-server span (from the OTel distro's ASP.NET Core inst
 | `handler` | Apps | `Microsoft.Teams.Apps/Routing/Router.cs` `DispatchAsync` matched-route invocation | `handler.type` (activity type or invoke name), `handler.dispatch` (`type` / `invoke` / `catchall`) |
 | `auth.outbound` | Core | `Microsoft.Teams.Core/Hosting/BotAuthenticationHandler.cs` `GetAuthorizationHeaderAsync` | `auth.flow` (`agentic` / `app_only` / `managed_identity`) |
 | `conversation_client` | Core | `Microsoft.Teams.Core/ConversationClient.cs` `SendActivityAsync` / `UpdateActivityAsync` / `DeleteActivityAsync` | `service.url`, `conversation.id`, `activity.type`, `activity.id` (set after response when known), `operation` |
+| `oauth.signin` | Apps | `Microsoft.Teams.Apps/OAuth/OAuthFlow.cs` `SignInAsync` | `oauth.connection`, `oauth.operation` (`signin`), `oauth.result` (`cached` / `card_sent` / `failure`), `oauth.error.type` (only on unexpected exceptions). Span event `oauth.card.sent` is added when an OAuthCard is sent. |
+| `oauth.signout` | Apps | `Microsoft.Teams.Apps/OAuth/OAuthFlow.cs` `SignOutAsync` | `oauth.connection`, `oauth.operation` (`signout`), `oauth.result` (`success` / `failure`), `oauth.error.type` (on exceptions) |
+| `oauth.get_token` | Apps | `Microsoft.Teams.Apps/OAuth/OAuthFlow.cs` `GetTokenAsync` | `oauth.connection`, `oauth.operation` (`get_token`), `oauth.result` (`hit` / `miss` / `failure`), `oauth.error.type` (on exceptions) |
+| `oauth.token_exchange` | Apps | `Microsoft.Teams.Apps/OAuth/OAuthFlow.cs` `HandleTokenExchangeAsync` (signin/tokenExchange invoke) | `oauth.connection`, `oauth.operation` (`token_exchange`), `oauth.result` (`success` / `duplicate` / `failure`), `invoke.response.status`, `oauth.callback.invoked`, `oauth.error.type` (only on unexpected HTTP status — not 404/400/412 — or `invalid_op`) |
+| `oauth.verify_state` | Apps | `Microsoft.Teams.Apps/OAuth/OAuthFlow.cs` `HandleVerifyStateAsync` (signin/verifyState invoke) | `oauth.connection`, `oauth.operation` (`verify_state`), `oauth.result` (`success` / `no_token` / `failure`), `invoke.response.status`, `oauth.callback.invoked`, `oauth.error.type` (only on unexpected HTTP status — not 404/400/412) |
+| `oauth.signin_failure` | Apps | `Microsoft.Teams.Apps/OAuth/OAuthFlow.cs` `HandleSignInFailureAsync` (signin/failure invoke) | `oauth.connection`, `oauth.operation` (`signin_failure`), `oauth.result` (`notified`), `oauth.failure.code` (the client-supplied failure code, e.g. `tokenmissing`, `resourcematchfailed`), `invoke.response.status`, `oauth.callback.invoked` |
+| `oauth.connection_status` | Apps | `Microsoft.Teams.Apps/OAuth/OAuthFlow.cs` `GetConnectionStatusAsync` | `oauth.connection=all`, `oauth.operation` (`connection_status`), `oauth.result` (`success` / `failure`), `oauth.error.type` (on exceptions) |
 
 On exception every span sets `Status = Error` with the exception message and adds an `exception` span event with `exception.type`, `exception.message`, and `exception.stacktrace` tags. This is done through the `RecordException` extension method in `Microsoft.Teams.Core.Diagnostics.ActivityExtensions`, which is `public` so the Apps layer (`Router`) can use it too. The extension uses manual event tagging on both `net8.0` and `net10.0` to stay consistent across target frameworks; it intentionally does not delegate to the BCL `Activity.AddException` (added in .NET 9), because that API only adds the event without setting `ActivityStatusCode.Error`.
 
@@ -115,6 +135,20 @@ Core-meter instruments cover the turn pipeline, middleware, and outbound HTTP cl
 | `teams.handler.duration` | Histogram | ms | `handler.type`, `handler.dispatch` | `finally` block around each matched-route invocation (recorded even on exception) |
 | `teams.handler.failures` | Counter | — | `handler.type`, `handler.dispatch` | catch block when a route handler throws |
 | `teams.handler.unmatched` | Counter | — | `activity.type` (DispatchAsync) or `activity.type` + `invoke.name` (DispatchWithReturnAsync) | branch where no route selector matched |
+
+### OAuth meter (`Microsoft.Teams.Apps`)
+
+OAuth flow operations share three instruments, parameterized by the `oauth.operation` and `oauth.result` tags. The operations counter and duration histogram are recorded in the `finally` block of every flow method (so both successful and failed attempts are observed). The errors counter is only incremented for **unexpected** errors: HTTP status codes outside the protocol-fallback set (anything other than 404, 400, 412) and unexpected exception types (e.g. `InvalidOperationException` from the Token Service client). Expected protocol fallbacks — the Token Service returning 404/400/412 to indicate "no token, ask user to sign in" — are recorded with `oauth.result=failure` on the operations counter but **do not** increment `teams.oauth.errors`, so the error rate metric stays meaningful for alerting.
+
+| Metric | Kind | Unit | Tags | Where |
+|---|---|---|---|---|
+| `teams.oauth.operations` | Counter | — | `oauth.connection`, `oauth.operation` ∈ {`signin`, `signout`, `get_token`, `token_exchange`, `verify_state`, `signin_failure`, `connection_status`}, `oauth.result` ∈ {`cached`, `card_sent`, `hit`, `miss`, `success`, `failure`, `duplicate`, `no_token`, `notified`} | `finally` block of every OAuth flow method |
+| `teams.oauth.operation.duration` | Histogram | ms | same as `teams.oauth.operations` | `finally` block of every OAuth flow method |
+| `teams.oauth.errors` | Counter | — | `oauth.connection`, `oauth.operation`, `oauth.error.type` ∈ {`http_error`, `invalid_op`, `empty_token`} | only when an unexpected exception or unexpected HTTP status is observed (see above) |
+
+`oauth.connection` is the connection name (e.g. `graph`, `github`) and is constrained to the small set of OAuth connections the bot registers via `AddOAuthFlow(name)`. The special value `all` is used by `connection_status`, which queries every registered connection in a single call. User IDs, conversation IDs, tokens, exchange IDs, and the `signin/failure` client-supplied message are intentionally **not** emitted as tags or span attributes to keep cardinality bounded and avoid leaking PII.
+
+A single `signin/verifyState` invoke in a multi-connection deployment may emit N records on `teams.oauth.operations` (one per registered OAuth flow that the verifyState dispatch loop probes), with N–1 carrying `oauth.result=no_token` and one carrying `oauth.result=success` or `oauth.result=failure`. Aggregating success rate by `oauth.connection` is therefore more meaningful than aggregating by the raw invoke count.
 
 OTLP exposes these names with dots; Prometheus/Mimir maps them to `teams_*_total` (counters) and `teams_*_milliseconds_*` (histograms).
 
@@ -156,6 +190,9 @@ HTTP server span                       (auto, OTel ASP.NET Core)
 └─ turn                                (Microsoft.Teams.Core)
    ├─ middleware [n times]             (Microsoft.Teams.Core)
    ├─ handler                          (Microsoft.Teams.Apps)
+   │  ├─ state.load / state.save       (Microsoft.Teams.Apps, when state is used)
+   │  └─ oauth.* [zero or more]        (Microsoft.Teams.Apps, when OAuth flows are called)
+   │     └─ conversation_client        (Microsoft.Teams.Core, when an OAuthCard is sent)
    └─ conversation_client              (Microsoft.Teams.Core)
       ├─ auth.outbound                 (Microsoft.Teams.Core)
       │  └─ HTTP client span           (auto, OTel HttpClient — token endpoint)

--- a/core/samples/ObservabilityBot/ObservabilityBot.csproj
+++ b/core/samples/ObservabilityBot/ObservabilityBot.csproj
@@ -17,6 +17,7 @@
 		<PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
 		<PackageReference Include="ModelContextProtocol" Version="1.3.0" />
 		<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/core/samples/ObservabilityBot/ObservabilityBotApp.cs
+++ b/core/samples/ObservabilityBot/ObservabilityBotApp.cs
@@ -11,6 +11,7 @@ using Microsoft.Teams.Apps.Api.Clients;
 using Microsoft.Teams.Apps.Handlers;
 using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Apps.Schema.Entities;
+using Microsoft.Teams.Apps.State;
 
 namespace ObservabilityBot;
 
@@ -27,8 +28,9 @@ public class ObservabilityBotApp : TeamsBotApplication
         ILogger<ObservabilityBotApp> logger,
         IChatClient chatClient,
         ChatOptions chatOptions,
-        TeamsBotApplicationOptions? teamsOptions = null)
-        : base(teamsApiClient, httpContextAccessor, logger, teamsOptions)
+        TeamsBotApplicationOptions? teamsOptions = null,
+        TurnStateLoader? turnStateLoader = null)
+        : base(teamsApiClient, httpContextAccessor, logger, teamsOptions, turnStateLoader)
     {
         _chatClient = chatClient;
         _chatOptions = chatOptions;
@@ -45,8 +47,8 @@ public class ObservabilityBotApp : TeamsBotApplication
 
         await context.Typing(ct);
 
-        var conversationId = context.Activity.Conversation.Id;
-        var history = context.State.ConversationState.Get<List<ChatMessage>>() ?? new List<ChatMessage>();
+        string conversationId = context.Activity.Conversation.Id;
+        List<ChatMessage> history = context.State.UserState?.Get<List<ChatMessage>>() ?? [];
 
         lock (history)
         {
@@ -54,7 +56,7 @@ public class ObservabilityBotApp : TeamsBotApplication
         }
 
         // Build Agent365 scope contracts from the turn context.
-        var recipient = context.Activity.Recipient;
+        TeamsConversationAccount? recipient = context.Activity.Recipient;
         var agentDetails = new AgentDetails(
             agentId: recipient?.AgenticAppId ?? recipient?.Id,
             agentName: recipient?.Name,
@@ -76,110 +78,110 @@ public class ObservabilityBotApp : TeamsBotApplication
 
         try
         {
-        // === InferenceScope: wraps the LLM + tool-call loop ===
-        var inferenceDetails = new InferenceCallDetails(
-            InferenceOperationType.Chat,
-            model: _deploymentName,
-            providerName: "AzureOpenAI");
+            // === InferenceScope: wraps the LLM + tool-call loop ===
+            var inferenceDetails = new InferenceCallDetails(
+                InferenceOperationType.Chat,
+                model: _deploymentName,
+                providerName: "AzureOpenAI");
 
-        List<ChatMessage> snapshot;
-        lock (history) { snapshot = [.. history]; }
+            List<ChatMessage> snapshot;
+            lock (history) { snapshot = [.. history]; }
 
-        ChatResponse chatResponse;
-        using (var inferenceScope = InferenceScope.Start(request, inferenceDetails, agentDetails))
-        {
-            chatResponse = await _chatClient.GetResponseAsync(snapshot, _chatOptions, ct);
-
-            if (chatResponse.Usage is { } usage)
+            ChatResponse chatResponse;
+            using (var inferenceScope = InferenceScope.Start(request, inferenceDetails, agentDetails))
             {
-                if (usage.InputTokenCount is { } inputTokens)
-                    inferenceScope.RecordInputTokens((int)inputTokens);
-                if (usage.OutputTokenCount is { } outputTokens)
-                    inferenceScope.RecordOutputTokens((int)outputTokens);
-            }
+                chatResponse = await _chatClient.GetResponseAsync(snapshot, _chatOptions, ct);
 
-            var finishReason = chatResponse.FinishReason?.Value ?? "stop";
-            inferenceScope.RecordFinishReasons([finishReason]);
-        }
-
-        lock (history)
-        {
-            history.AddRange(chatResponse.Messages);
-        }
-        
-            // === ExecuteToolScope: record each tool invocation ===
-        var toolCalls = chatResponse.Messages
-            .SelectMany(m => m.Contents.OfType<FunctionCallContent>())
-            .GroupBy(fc => fc.CallId ?? fc.Name ?? "")
-            .ToDictionary(g => g.Key, g => g.First());
-
-        foreach (var funcResult in chatResponse.Messages
-            .SelectMany(m => m.Contents.OfType<FunctionResultContent>()))
-        {
-            toolCalls.TryGetValue(funcResult.CallId ?? "", out var matchingCall);
-
-            var toolDetails = new ToolCallDetails(
-                toolName: matchingCall?.Name ?? "unknown",
-                arguments: matchingCall?.Arguments is { } args ? JsonSerializer.Serialize(args) : null,
-                toolCallId: funcResult.CallId);
-
-            using var toolScope = ExecuteToolScope.Start(request, toolDetails, agentDetails);
-            if (funcResult.Result is not null)
-            {
-                toolScope.RecordResponse(funcResult.Result.ToString()!);
-            }
-        }
-
-        // Extract citations from tool results.
-        var citations = chatResponse.Messages
-            .SelectMany(m => m.Contents.OfType<FunctionResultContent>())
-            .Where(frc => frc.Result is not null)
-            .SelectMany(frc =>
-            {
-                try
+                if (chatResponse.Usage is { } usage)
                 {
-                    var json = JsonSerializer.Deserialize<JsonElement>(frc.Result!.ToString()!);
-                    if (json.TryGetProperty("structuredContent", out var sc) &&
-                        sc.TryGetProperty("results", out var results))
-                    {
-                        return results.EnumerateArray()
-                            .Where(r => r.TryGetProperty("contentUrl", out _))
-                            .Select(r => (
-                                Title: r.GetProperty("title").GetString() ?? "",
-                                Url: r.GetProperty("contentUrl").GetString() ?? "",
-                                Content: r.TryGetProperty("content", out var c) ? c.GetString() ?? "" : ""
-                            ));
-                    }
+                    if (usage.InputTokenCount is { } inputTokens)
+                        inferenceScope.RecordInputTokens((int)inputTokens);
+                    if (usage.OutputTokenCount is { } outputTokens)
+                        inferenceScope.RecordOutputTokens((int)outputTokens);
                 }
-                catch (JsonException) { }
-                return [];
-            })
-            .DistinctBy(c => c.Url)
-            .Take(5).ToList();
 
-        var responseText = chatResponse.Text;
+                string finishReason = chatResponse.FinishReason?.Value ?? "stop";
+                inferenceScope.RecordFinishReasons([finishReason]);
+            }
 
-        for (int i = 0; i < citations.Count; i++)
-        {
-            responseText += $"[{i + 1}] ";
-        }
+            lock (history)
+            {
+                history.AddRange(chatResponse.Messages);
+            }
 
-        // Record output on the top-level invoke_agent span before it closes.
-        invokeScope.RecordOutputMessages([responseText]);
+            // === ExecuteToolScope: record each tool invocation ===
+            var toolCalls = chatResponse.Messages
+                .SelectMany(m => m.Contents.OfType<FunctionCallContent>())
+                .GroupBy(fc => fc.CallId ?? fc.Name ?? "")
+                .ToDictionary(g => g.Key, g => g.First());
 
-        var builder = TeamsActivity.CreateBuilder()
-            .WithText(responseText, TextFormats.Markdown)
-            .AddMention(context.Activity?.From!)
-            .AddAIGenerated();
+            foreach (FunctionResultContent? funcResult in chatResponse.Messages
+                .SelectMany(m => m.Contents.OfType<FunctionResultContent>()))
+            {
+                toolCalls.TryGetValue(funcResult.CallId ?? "", out FunctionCallContent? matchingCall);
 
-        for (int i = 0; i < citations.Count; i++)
-        {
-            var (Title, Url, Content) = citations[i];
-            var abstract_ = Content.Length > 160 ? Content[..157] + "..." : Content;
-            builder.AddCitation(i + 1, new CitationAppearance() { Name = Title, Url = new Uri(Url), Abstract = abstract_, Icon = CitationIcon.Text });
-        }
+                var toolDetails = new ToolCallDetails(
+                    toolName: matchingCall?.Name ?? "unknown",
+                    arguments: matchingCall?.Arguments is { } args ? JsonSerializer.Serialize(args) : null,
+                    toolCallId: funcResult.CallId);
 
-        await context.Send(builder.Build(), ct);
+                using var toolScope = ExecuteToolScope.Start(request, toolDetails, agentDetails);
+                if (funcResult.Result is not null)
+                {
+                    toolScope.RecordResponse(funcResult.Result.ToString()!);
+                }
+            }
+
+            // Extract citations from tool results.
+            var citations = chatResponse.Messages
+                .SelectMany(m => m.Contents.OfType<FunctionResultContent>())
+                .Where(frc => frc.Result is not null)
+                .SelectMany(frc =>
+                {
+                    try
+                    {
+                        JsonElement json = JsonSerializer.Deserialize<JsonElement>(frc.Result!.ToString()!);
+                        if (json.TryGetProperty("structuredContent", out JsonElement sc) &&
+                            sc.TryGetProperty("results", out JsonElement results))
+                        {
+                            return results.EnumerateArray()
+                                .Where(r => r.TryGetProperty("contentUrl", out _))
+                                .Select(r => (
+                                    Title: r.GetProperty("title").GetString() ?? "",
+                                    Url: r.GetProperty("contentUrl").GetString() ?? "",
+                                    Content: r.TryGetProperty("content", out JsonElement c) ? c.GetString() ?? "" : ""
+                                ));
+                        }
+                    }
+                    catch (JsonException) { }
+                    return [];
+                })
+                .DistinctBy(c => c.Url)
+                .Take(5).ToList();
+
+            string responseText = chatResponse.Text;
+
+            for (int i = 0; i < citations.Count; i++)
+            {
+                responseText += $"[{i + 1}] ";
+            }
+
+            // Record output on the top-level invoke_agent span before it closes.
+            invokeScope.RecordOutputMessages([responseText]);
+
+            TeamsActivityBuilder builder = TeamsActivity.CreateBuilder()
+                .WithText(responseText, TextFormats.Markdown)
+                .AddMention(context.Activity?.From!)
+                .AddAIGenerated();
+
+            for (int i = 0; i < citations.Count; i++)
+            {
+                (string? Title, string? Url, string? Content) = citations[i];
+                string abstract_ = Content.Length > 160 ? Content[..157] + "..." : Content;
+                builder.AddCitation(i + 1, new CitationAppearance() { Name = Title, Url = new Uri(Url), Abstract = abstract_, Icon = CitationIcon.Text });
+            }
+
+            await context.Send(builder.Build(), ct);
         }
         catch (Exception ex)
         {
@@ -188,7 +190,7 @@ public class ObservabilityBotApp : TeamsBotApplication
         }
         finally
         {
-            context.State.ConversationState.Set(history);
+            context.State.UserState?.Set(history);
         }
     }
 }

--- a/core/samples/ObservabilityBot/Program.cs
+++ b/core/samples/ObservabilityBot/Program.cs
@@ -5,6 +5,7 @@ using Azure.AI.OpenAI;
 using Microsoft.Extensions.AI;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.Internal;
 using Microsoft.OpenTelemetry;
 using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Diagnostics;
@@ -21,6 +22,10 @@ string[] meterNames      = [CoreTelemetryNames.MeterName, TeamsBotApplicationTel
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 IServiceProvider? rootProvider = null;
 builder.Services.AddTeamsBotApplication<ObservabilityBotApp>(o => o.UseState());
+builder.Services.AddStackExchangeRedisCache(options =>
+{
+    options.Configuration = "localhost:6379";
+});
 
 builder.Services.AddOpenTelemetry()
     .ConfigureResource(r => r

--- a/core/samples/ObservabilityBot/Program.cs
+++ b/core/samples/ObservabilityBot/Program.cs
@@ -5,7 +5,6 @@ using Azure.AI.OpenAI;
 using Microsoft.Extensions.AI;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Web;
-using Microsoft.Identity.Web.Internal;
 using Microsoft.OpenTelemetry;
 using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Diagnostics;
@@ -17,7 +16,7 @@ using OpenTelemetry.Resources;
 
 
 string[] activitySources = [CoreTelemetryNames.ActivitySourceName, TeamsBotApplicationTelemetry.ActivitySourceName, "Experimental.Microsoft.Extensions.AI", "ModelContextProtocol"];
-string[] meterNames      = [CoreTelemetryNames.MeterName, TeamsBotApplicationTelemetry.MeterName, "Experimental.Microsoft.Agents.AI", "ModelContextProtocol"];
+string[] meterNames = [CoreTelemetryNames.MeterName, TeamsBotApplicationTelemetry.MeterName, "Experimental.Microsoft.Agents.AI", "ModelContextProtocol"];
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 IServiceProvider? rootProvider = null;
@@ -35,22 +34,23 @@ builder.Services.AddOpenTelemetry()
             ["deployment.environment"] = builder.Environment.EnvironmentName,
             ["service.namespace"] = "Microsoft.Teams"
         }))
-    .UseMicrosoftOpenTelemetry(o => {
+    .UseMicrosoftOpenTelemetry(o =>
+    {
         o.Exporters = ExportTarget.Otlp | ExportTarget.Agent365 | ExportTarget.AzureMonitor;
         o.Instrumentation.EnableHttpClientInstrumentation = true;
         o.Instrumentation.EnableAspNetCoreInstrumentation = true;
 
         o.Agent365.ContextualTokenResolver = async trctx =>
         {
-            var provider = rootProvider!.GetRequiredService<IAuthorizationHeaderProvider>();
-            var options = new AuthorizationHeaderProviderOptions { AcquireTokenOptions = new() { AuthenticationOptionsName = "AzureAd", Tenant = trctx.TenantId } };
+            IAuthorizationHeaderProvider provider = rootProvider!.GetRequiredService<IAuthorizationHeaderProvider>();
+            AuthorizationHeaderProviderOptions options = new() { AcquireTokenOptions = new() { AuthenticationOptionsName = "AzureAd", Tenant = trctx.TenantId } };
             ArgumentNullException.ThrowIfNull(trctx.Identity.AgenticUserId);
             options.WithAgentUserIdentity(trctx.Identity.AgentId, new Guid(trctx.Identity.AgenticUserId));
             var token = await provider.CreateAuthorizationHeaderAsync(
                 ["api://9b975845-388f-4429-889e-eab1ef63949c/.default"], options);
             return token.Substring("Bearer".Length).Trim();
         };
-     })
+    })
     .WithTracing(t => t.AddSource(activitySources))
     .WithMetrics(m => m.AddMeter(meterNames));
 
@@ -83,14 +83,14 @@ builder.Services.AddSingleton<IChatClient>(sp =>
 
 builder.Services.AddSingleton<ChatOptions>(sp =>
 {
-    var msdocsClient = sp.GetRequiredKeyedService<Task<McpClient>>("msdocs").GetAwaiter().GetResult();
-    var msdocsTools = msdocsClient.ListToolsAsync().GetAwaiter().GetResult();
+    McpClient msdocsClient = sp.GetRequiredKeyedService<Task<McpClient>>("msdocs").GetAwaiter().GetResult();
+    IList<McpClientTool> msdocsTools = msdocsClient.ListToolsAsync().GetAwaiter().GetResult();
 
     return new ChatOptions
     {
         AllowMultipleToolCalls = true,
         Instructions = "Use the following tools to answer the user's question. If you don't know the answer, use the 'Search Microsoft Docs' tool to find relevant information. Use calendar tools for scheduling-related queries.",
-        Tools = [..msdocsTools]
+        Tools = [.. msdocsTools]
     };
 });
 

--- a/core/samples/SsoBot/Program.cs
+++ b/core/samples/SsoBot/Program.cs
@@ -19,15 +19,14 @@ using Microsoft.Teams.Apps.Schema;
 
 WebApplicationBuilder webAppBuilder = WebApplication.CreateSlimBuilder(args);
 
-AppBuilder appBuilder = App.Builder().AddOAuth("sso");
-
-webAppBuilder.AddTeams(appBuilder);
+//AppBuilder appBuilder = App.Builder().AddOAuth("sso");
+//webAppBuilder.AddTeams(appBuilder);
 
 // Configure the single OAuth flow at the DI level
-//webAppBuilder.Services.AddTeamsBotApplication(options =>
-//{
-//    options.AddOAuthFlow("sso");
-//});
+webAppBuilder.Services.AddTeamsBotApplication(options =>
+{
+    options.AddOAuthFlow("sso");
+});
 
 WebApplication webApp = webAppBuilder.Build();
 

--- a/core/samples/SsoBot/Program.cs
+++ b/core/samples/SsoBot/Program.cs
@@ -12,15 +12,37 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Microsoft.OpenTelemetry;
 using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Diagnostics;
 using Microsoft.Teams.Apps.Handlers;
 using Microsoft.Teams.Apps.OAuth;
 using Microsoft.Teams.Apps.Schema;
+using Microsoft.Teams.Core.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
 
 WebApplicationBuilder webAppBuilder = WebApplication.CreateSlimBuilder(args);
 
-//AppBuilder appBuilder = App.Builder().AddOAuth("sso");
-//webAppBuilder.AddTeams(appBuilder);
+string[] activitySources = [CoreTelemetryNames.ActivitySourceName, TeamsBotApplicationTelemetry.ActivitySourceName];
+string[] meterNames = [CoreTelemetryNames.MeterName, TeamsBotApplicationTelemetry.MeterName];
+
+webAppBuilder.Services.AddOpenTelemetry()
+    .ConfigureResource(r => r
+        .AddService(serviceName: "SsoBot", serviceVersion: "0.0.1")
+        .AddAttributes(new Dictionary<string, object>
+        {
+            ["deployment.environment"] = webAppBuilder.Environment.EnvironmentName,
+            ["service.namespace"] = "Microsoft.Teams"
+        }))
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.Otlp;
+        o.Instrumentation.EnableHttpClientInstrumentation = true;
+        o.Instrumentation.EnableAspNetCoreInstrumentation = true;
+    })
+    .WithTracing(t => t.AddSource(activitySources))
+    .WithMetrics(m => m.AddMeter(meterNames));
 
 // Configure the single OAuth flow at the DI level
 webAppBuilder.Services.AddTeamsBotApplication(options =>

--- a/core/samples/SsoBot/SsoBot.csproj
+++ b/core/samples/SsoBot/SsoBot.csproj
@@ -9,5 +9,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Microsoft.Teams.Apps\Microsoft.Teams.Apps.csproj" />
 	</ItemGroup>
-
+	<ItemGroup>
+		<PackageReference Include="Microsoft.OpenTelemetry" Version="1.0.3" />
+	</ItemGroup>
 </Project>

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -63,7 +63,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     public TurnStateContainer State
     {
         get => _state ?? throw new InvalidOperationException(
-            "State is not available. Call UseState() during service registration.");
+            "State is not available. Call UseState() during service registration, and if using a custom TeamsBotApplication make sure you pass a TurnStateLoader instance.");
         internal set => _state = value;
     }
 

--- a/core/src/Microsoft.Teams.Apps/Diagnostics/AppsTelemetry.cs
+++ b/core/src/Microsoft.Teams.Apps/Diagnostics/AppsTelemetry.cs
@@ -49,12 +49,32 @@ internal static class AppsTelemetry
     public static readonly Histogram<long> StateBytesWritten =
         Meter.CreateHistogram<long>(Metrics.StateBytesWritten, unit: "By", description: "Bytes written to cache per state save.");
 
+    // ── OAuth instruments ────────────────────────────────────────────────
+
+    public static readonly Counter<long> OAuthOperationCount =
+        Meter.CreateCounter<long>(Metrics.OAuthOperations, description: "Total OAuth flow operations attempted. For verify_state and signin_failure invokes, each per-flow attempt is counted independently in multi-connection deployments.");
+
+    public static readonly Histogram<double> OAuthOperationDuration =
+        Meter.CreateHistogram<double>(Metrics.OAuthOperationDuration, unit: "ms", description: "Duration of OAuth flow operations.");
+
+    public static readonly Counter<long> OAuthErrors =
+        Meter.CreateCounter<long>(Metrics.OAuthErrors, description: "Total OAuth flow operations that failed with an unexpected exception. Expected protocol fallbacks (HTTP 404/400/412 from the Token Service) are not counted here; they are recorded as oauth.result=failure on teams.oauth.operations instead.");
+
     public static class Spans
     {
         public const string Handler = "handler";
         public const string StateLoad = "state.load";
         public const string StateSave = "state.save";
         public const string StateDelete = "state.delete";
+
+        // OAuth spans
+        public const string OAuthSignIn = "oauth.signin";
+        public const string OAuthSignOut = "oauth.signout";
+        public const string OAuthGetToken = "oauth.get_token";
+        public const string OAuthTokenExchange = "oauth.token_exchange";
+        public const string OAuthVerifyState = "oauth.verify_state";
+        public const string OAuthSignInFailure = "oauth.signin_failure";
+        public const string OAuthConnectionStatus = "oauth.connection_status";
     }
 
     public static class Tags
@@ -72,6 +92,15 @@ internal static class AppsTelemetry
         public const string StateBytesRead = "state.bytes.read";
         public const string StateBytesWritten = "state.bytes.written";
         public const string Operation = "operation";
+
+        // OAuth tags
+        public const string OAuthConnection = "oauth.connection";
+        public const string OAuthOperation = "oauth.operation";
+        public const string OAuthResult = "oauth.result";
+        public const string OAuthErrorType = "oauth.error.type";
+        public const string OAuthFailureCode = "oauth.failure.code";
+        public const string OAuthCallbackInvoked = "oauth.callback.invoked";
+        public const string InvokeResponseStatus = "invoke.response.status";
     }
 
     public static class Metrics
@@ -87,5 +116,75 @@ internal static class AppsTelemetry
         public const string StateCacheErrors = "teams.state.cache.errors";
         public const string StateBytesRead = "teams.state.bytes.read";
         public const string StateBytesWritten = "teams.state.bytes.written";
+
+        // OAuth metrics
+        public const string OAuthOperations = "teams.oauth.operations";
+        public const string OAuthOperationDuration = "teams.oauth.operation.duration";
+        public const string OAuthErrors = "teams.oauth.errors";
     }
+
+    /// <summary>
+    /// Values used for the <see cref="Tags.OAuthOperation"/> tag.
+    /// Low cardinality: one of seven well-known operation names.
+    /// </summary>
+    public static class OAuthOperations
+    {
+        public const string SignIn = "signin";
+        public const string SignOut = "signout";
+        public const string GetToken = "get_token";
+        public const string TokenExchange = "token_exchange";
+        public const string VerifyState = "verify_state";
+        public const string SignInFailure = "signin_failure";
+        public const string ConnectionStatus = "connection_status";
+    }
+
+    /// <summary>
+    /// Values used for the <see cref="Tags.OAuthResult"/> tag.
+    /// </summary>
+    public static class OAuthResults
+    {
+        /// <summary>SignIn returned a cached token without sending an OAuthCard.</summary>
+        public const string Cached = "cached";
+        /// <summary>SignIn sent an OAuthCard because no cached token was found.</summary>
+        public const string CardSent = "card_sent";
+        /// <summary>GetToken found a cached token in the Token Store.</summary>
+        public const string Hit = "hit";
+        /// <summary>GetToken found no cached token in the Token Store.</summary>
+        public const string Miss = "miss";
+        /// <summary>Operation completed successfully.</summary>
+        public const string Success = "success";
+        /// <summary>Expected protocol failure (e.g., Token Service returned 404/400/412, or null state).</summary>
+        public const string Failure = "failure";
+        /// <summary>Duplicate signin/tokenExchange invoke; deduplicated to a 200 no-op.</summary>
+        public const string Duplicate = "duplicate";
+        /// <summary>verify_state attempted on a flow whose connection didn't match the code.</summary>
+        public const string NoToken = "no_token";
+        /// <summary>signin_failure invoke acknowledged and forwarded to the OnSignInFailure callback.</summary>
+        public const string Notified = "notified";
+    }
+
+    /// <summary>
+    /// Values used for the <see cref="Tags.OAuthErrorType"/> tag.
+    /// Set only on the <see cref="OAuthErrors"/> counter and on spans when an unexpected exception escapes.
+    /// </summary>
+    public static class OAuthErrorTypes
+    {
+        public const string HttpError = "http_error";
+        public const string InvalidOperation = "invalid_op";
+        public const string EmptyToken = "empty_token";
+    }
+
+    /// <summary>
+    /// Names of low-cardinality span events emitted by OAuth flows.
+    /// </summary>
+    public static class OAuthEvents
+    {
+        public const string CardSent = "oauth.card.sent";
+    }
+
+    /// <summary>
+    /// Special <see cref="Tags.OAuthConnection"/> value used by operations that span all connections
+    /// (e.g., <c>connection_status</c> returns the status of every registered OAuth connection).
+    /// </summary>
+    public const string OAuthAllConnections = "all";
 }

--- a/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
+++ b/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
@@ -2,11 +2,14 @@
 // Licensed under the MIT License.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Microsoft.Teams.Apps.Diagnostics;
 using Microsoft.Teams.Apps.Handlers;
 using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Diagnostics;
 
 namespace Microsoft.Teams.Apps.OAuth;
 
@@ -97,8 +100,30 @@ public class OAuthFlow
         string userId = GetUserId(context);
         string channelId = GetChannelId(context);
 
-        GetTokenResult? result = await _app.UserTokenClient.GetTokenAsync(userId, _connectionName, channelId, cancellationToken: cancellationToken).ConfigureAwait(false);
-        return result?.Token;
+        using Activity? span = AppsTelemetry.Source.StartActivity(AppsTelemetry.Spans.OAuthGetToken, ActivityKind.Internal);
+        span?.SetTag(AppsTelemetry.Tags.OAuthConnection, _connectionName);
+        span?.SetTag(AppsTelemetry.Tags.OAuthOperation, AppsTelemetry.OAuthOperations.GetToken);
+
+        long startTs = Stopwatch.GetTimestamp();
+        string result = AppsTelemetry.OAuthResults.Miss;
+        try
+        {
+            GetTokenResult? tokenResult = await _app.UserTokenClient.GetTokenAsync(userId, _connectionName, channelId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            result = tokenResult?.Token is not null ? AppsTelemetry.OAuthResults.Hit : AppsTelemetry.OAuthResults.Miss;
+            span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+            return tokenResult?.Token;
+        }
+        catch (Exception ex)
+        {
+            result = AppsTelemetry.OAuthResults.Failure;
+            string errorType = ex is HttpRequestException ? AppsTelemetry.OAuthErrorTypes.HttpError : AppsTelemetry.OAuthErrorTypes.InvalidOperation;
+            RecordOAuthError(span, AppsTelemetry.OAuthOperations.GetToken, errorType, ex);
+            throw;
+        }
+        finally
+        {
+            RecordOperation(AppsTelemetry.OAuthOperations.GetToken, result, startTs);
+        }
     }
 
     /// <summary>
@@ -126,71 +151,96 @@ public class OAuthFlow
         string userId = GetUserId(context);
         string channelId = GetChannelId(context);
 
-        // 1. Try silent token acquisition
-        GetTokenResult? existingToken = await _app.UserTokenClient.GetTokenAsync(userId, _connectionName, channelId, cancellationToken: cancellationToken).ConfigureAwait(false);
-        if (existingToken?.Token is not null)
-        {
-            _logger.LogDebug("Token found in store for connection '{ConnectionName}', user '{UserId}'.", _connectionName, userId);
-            return existingToken.Token;
-        }
+        using Activity? span = AppsTelemetry.Source.StartActivity(AppsTelemetry.Spans.OAuthSignIn, ActivityKind.Internal);
+        span?.SetTag(AppsTelemetry.Tags.OAuthConnection, _connectionName);
+        span?.SetTag(AppsTelemetry.Tags.OAuthOperation, AppsTelemetry.OAuthOperations.SignIn);
 
-        // 2. No token - get sign-in resource and send OAuthCard
-        _logger.LogDebug("No cached token for connection '{ConnectionName}'. Initiating sign-in flow.", _connectionName);
-
-        // Build state with MsAppId so the Token Service returns TokenExchangeResource for SSO
-        var tokenExchangeState = new
+        long startTs = Stopwatch.GetTimestamp();
+        string result = AppsTelemetry.OAuthResults.Failure;
+        try
         {
-            ConnectionName = _connectionName,
-            Conversation = new
+            // 1. Try silent token acquisition
+            GetTokenResult? existingToken = await _app.UserTokenClient.GetTokenAsync(userId, _connectionName, channelId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (existingToken?.Token is not null)
             {
-                ActivityId = context.Activity.Id,
-                Bot = new { Id = context.Activity.Recipient?.Id },
-                ChannelId = channelId,
-                Conversation = new { Id = context.Activity.Conversation?.Id },
-                ServiceUrl = context.Activity.ServiceUrl?.ToString(),
-                User = new { Id = userId }
-            },
-            MsAppId = _app.AppId
-        };
-        string state = Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(tokenExchangeState));
+                _logger.LogDebug("Token found in store for connection '{ConnectionName}', user '{UserId}'.", _connectionName, userId);
+                result = AppsTelemetry.OAuthResults.Cached;
+                span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+                return existingToken.Token;
+            }
 
-        GetSignInResourceResult signInResource = await _app.UserTokenClient
-            .GetSignInResourceAsync(state, cancellationToken: cancellationToken)
-            .ConfigureAwait(false);
+            // 2. No token - get sign-in resource and send OAuthCard
+            _logger.LogDebug("No cached token for connection '{ConnectionName}'. Initiating sign-in flow.", _connectionName);
 
-        OAuthCard oauthCard = new()
+            // Build state with MsAppId so the Token Service returns TokenExchangeResource for SSO
+            var tokenExchangeState = new
+            {
+                ConnectionName = _connectionName,
+                Conversation = new
+                {
+                    ActivityId = context.Activity.Id,
+                    Bot = new { Id = context.Activity.Recipient?.Id },
+                    ChannelId = channelId,
+                    Conversation = new { Id = context.Activity.Conversation?.Id },
+                    ServiceUrl = context.Activity.ServiceUrl?.ToString(),
+                    User = new { Id = userId }
+                },
+                MsAppId = _app.AppId
+            };
+            string state = Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(tokenExchangeState));
+
+            GetSignInResourceResult signInResource = await _app.UserTokenClient
+                .GetSignInResourceAsync(state, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            OAuthCard oauthCard = new()
+            {
+                Text = options.OAuthCardText,
+                ConnectionName = _connectionName,
+                Buttons =
+                [
+                    new SuggestedAction(ActionType.SignIn, options.SignInButtonText, signInResource.SignInLink)
+                ],
+                TokenExchangeResource = signInResource.TokenExchangeResource,
+                TokenPostResource = signInResource.TokenPostResource
+            };
+
+            // Serialize to JsonElement so the source-generated JSON context can handle it
+            JsonElement oauthCardJson = JsonSerializer.SerializeToElement(oauthCard);
+
+            TeamsAttachment attachment = TeamsAttachment.CreateBuilder()
+                .WithContentType(AttachmentContentType.OAuthCard)
+                .WithContent(oauthCardJson)
+                .Build();
+
+            TeamsActivity oauthActivity = TeamsActivity.CreateBuilder()
+                .WithConversationReference(context.Activity)
+                .WithRecipient(context.Activity.From, false)
+                .WithAttachment(attachment)
+                .Build();
+
+            await context.SendActivityAsync(oauthActivity, cancellationToken).ConfigureAwait(false);
+
+            // Track that this user has a pending sign-in for this flow.
+            // Use user state when available (distributed); fall back to in-memory otherwise.
+            SetPendingSignIn(context, userId);
+
+            span?.AddEvent(new ActivityEvent(AppsTelemetry.OAuthEvents.CardSent));
+            result = AppsTelemetry.OAuthResults.CardSent;
+            span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+            return null;
+        }
+        catch (Exception ex)
         {
-            Text = options.OAuthCardText,
-            ConnectionName = _connectionName,
-            Buttons =
-            [
-                new SuggestedAction(ActionType.SignIn, options.SignInButtonText, signInResource.SignInLink)
-            ],
-            TokenExchangeResource = signInResource.TokenExchangeResource,
-            TokenPostResource = signInResource.TokenPostResource
-        };
-
-        // Serialize to JsonElement so the source-generated JSON context can handle it
-        JsonElement oauthCardJson = JsonSerializer.SerializeToElement(oauthCard);
-
-        TeamsAttachment attachment = TeamsAttachment.CreateBuilder()
-            .WithContentType(AttachmentContentType.OAuthCard)
-            .WithContent(oauthCardJson)
-            .Build();
-
-        TeamsActivity oauthActivity = TeamsActivity.CreateBuilder()
-            .WithConversationReference(context.Activity)
-            .WithRecipient(context.Activity.From, false)
-            .WithAttachment(attachment)
-            .Build();
-
-        await context.SendActivityAsync(oauthActivity, cancellationToken).ConfigureAwait(false);
-
-        // Track that this user has a pending sign-in for this flow.
-        // Use user state when available (distributed); fall back to in-memory otherwise.
-        SetPendingSignIn(context, userId);
-
-        return null;
+            result = AppsTelemetry.OAuthResults.Failure;
+            string errorType = ex is HttpRequestException ? AppsTelemetry.OAuthErrorTypes.HttpError : AppsTelemetry.OAuthErrorTypes.InvalidOperation;
+            RecordOAuthError(span, AppsTelemetry.OAuthOperations.SignIn, errorType, ex);
+            throw;
+        }
+        finally
+        {
+            RecordOperation(AppsTelemetry.OAuthOperations.SignIn, result, startTs);
+        }
     }
 
     /// <summary>
@@ -205,8 +255,30 @@ public class OAuthFlow
         string userId = GetUserId(context);
         string channelId = GetChannelId(context);
 
-        _logger.LogDebug("Signing out user '{UserId}' from connection '{ConnectionName}'.", userId, _connectionName);
-        await _app.UserTokenClient.SignOutUserAsync(userId, _connectionName, channelId, cancellationToken).ConfigureAwait(false);
+        using Activity? span = AppsTelemetry.Source.StartActivity(AppsTelemetry.Spans.OAuthSignOut, ActivityKind.Internal);
+        span?.SetTag(AppsTelemetry.Tags.OAuthConnection, _connectionName);
+        span?.SetTag(AppsTelemetry.Tags.OAuthOperation, AppsTelemetry.OAuthOperations.SignOut);
+
+        long startTs = Stopwatch.GetTimestamp();
+        string result = AppsTelemetry.OAuthResults.Failure;
+        try
+        {
+            _logger.LogDebug("Signing out user '{UserId}' from connection '{ConnectionName}'.", userId, _connectionName);
+            await _app.UserTokenClient.SignOutUserAsync(userId, _connectionName, channelId, cancellationToken).ConfigureAwait(false);
+            result = AppsTelemetry.OAuthResults.Success;
+            span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+        }
+        catch (Exception ex)
+        {
+            result = AppsTelemetry.OAuthResults.Failure;
+            string errorType = ex is HttpRequestException ? AppsTelemetry.OAuthErrorTypes.HttpError : AppsTelemetry.OAuthErrorTypes.InvalidOperation;
+            RecordOAuthError(span, AppsTelemetry.OAuthOperations.SignOut, errorType, ex);
+            throw;
+        }
+        finally
+        {
+            RecordOperation(AppsTelemetry.OAuthOperations.SignOut, result, startTs);
+        }
     }
 
     /// <summary>
@@ -237,7 +309,30 @@ public class OAuthFlow
         string userId = GetUserId(context);
         string channelId = GetChannelId(context);
 
-        return await _app.UserTokenClient.GetTokenStatusAsync(userId, channelId, cancellationToken: cancellationToken).ConfigureAwait(false);
+        using Activity? span = AppsTelemetry.Source.StartActivity(AppsTelemetry.Spans.OAuthConnectionStatus, ActivityKind.Internal);
+        span?.SetTag(AppsTelemetry.Tags.OAuthConnection, AppsTelemetry.OAuthAllConnections);
+        span?.SetTag(AppsTelemetry.Tags.OAuthOperation, AppsTelemetry.OAuthOperations.ConnectionStatus);
+
+        long startTs = Stopwatch.GetTimestamp();
+        string result = AppsTelemetry.OAuthResults.Failure;
+        try
+        {
+            IList<GetTokenStatusResult> statuses = await _app.UserTokenClient.GetTokenStatusAsync(userId, channelId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            result = AppsTelemetry.OAuthResults.Success;
+            span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+            return statuses;
+        }
+        catch (Exception ex)
+        {
+            result = AppsTelemetry.OAuthResults.Failure;
+            string errorType = ex is HttpRequestException ? AppsTelemetry.OAuthErrorTypes.HttpError : AppsTelemetry.OAuthErrorTypes.InvalidOperation;
+            RecordOAuthError(span, AppsTelemetry.OAuthOperations.ConnectionStatus, errorType, ex, AppsTelemetry.OAuthAllConnections);
+            throw;
+        }
+        finally
+        {
+            RecordOperation(AppsTelemetry.OAuthOperations.ConnectionStatus, result, startTs, AppsTelemetry.OAuthAllConnections);
+        }
     }
 
     /// <summary>
@@ -246,54 +341,98 @@ public class OAuthFlow
     internal async Task<InvokeResponse> HandleTokenExchangeAsync(Context<InvokeActivity> context, SignInTokenExchangeValue exchangeValue, CancellationToken cancellationToken)
     {
         string exchangeId = exchangeValue.Id ?? string.Empty;
-
-        // Deduplication: Teams sends duplicate exchanges from multiple endpoints.
-        // Use conversation state when available (distributed, works across instances);
-        // fall back to in-memory ConcurrentDictionary otherwise.
-        if (IsDuplicateExchange(context, exchangeId))
-        {
-            _logger.LogDebug("Duplicate signin/tokenExchange with Id '{ExchangeId}' - returning 200 no-op.", exchangeId);
-            return new InvokeResponse(200);
-        }
-
-        string userId = GetUserId(context);
-        string channelId = GetChannelId(context);
         string connectionName = exchangeValue.ConnectionName ?? _connectionName;
+
+        using Activity? span = AppsTelemetry.Source.StartActivity(AppsTelemetry.Spans.OAuthTokenExchange, ActivityKind.Internal);
+        span?.SetTag(AppsTelemetry.Tags.OAuthConnection, connectionName);
+        span?.SetTag(AppsTelemetry.Tags.OAuthOperation, AppsTelemetry.OAuthOperations.TokenExchange);
+
+        long startTs = Stopwatch.GetTimestamp();
+        string result = AppsTelemetry.OAuthResults.Failure;
+        InvokeResponse response;
 
         try
         {
-            GetTokenResult tokenResult = await _app.UserTokenClient
-                .ExchangeTokenAsync(userId, connectionName, channelId, exchangeValue.Token, cancellationToken)
-                .ConfigureAwait(false);
+            // Deduplication: Teams sends duplicate exchanges from multiple endpoints.
+            // Use conversation state when available (distributed, works across instances);
+            // fall back to in-memory ConcurrentDictionary otherwise.
+            if (IsDuplicateExchange(context, exchangeId))
+            {
+                _logger.LogDebug("Duplicate signin/tokenExchange with Id '{ExchangeId}' - returning 200 no-op.", exchangeId);
+                result = AppsTelemetry.OAuthResults.Duplicate;
+                span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+                response = new InvokeResponse(200);
+                span?.SetTag(AppsTelemetry.Tags.InvokeResponseStatus, response.Status);
+                return response;
+            }
 
-            if (tokenResult?.Token is not null)
+            string userId = GetUserId(context);
+            string channelId = GetChannelId(context);
+
+            try
+            {
+                GetTokenResult tokenResult = await _app.UserTokenClient
+                    .ExchangeTokenAsync(userId, connectionName, channelId, exchangeValue.Token, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (tokenResult?.Token is not null)
+                {
+                    ClearPendingSignIn(context, userId);
+                    _logger.LogDebug("Token exchange succeeded for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
+                    bool callbackInvoked = false;
+                    if (_onSignInComplete is not null)
+                    {
+                        Context<TeamsActivity> baseContext = new(context.TeamsBotApplication, context.Activity);
+                        await _onSignInComplete(baseContext, tokenResult, cancellationToken).ConfigureAwait(false);
+                        callbackInvoked = true;
+                    }
+                    span?.SetTag(AppsTelemetry.Tags.OAuthCallbackInvoked, callbackInvoked);
+                    result = AppsTelemetry.OAuthResults.Success;
+                    span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+                    response = new InvokeResponse(200);
+                    span?.SetTag(AppsTelemetry.Tags.InvokeResponseStatus, response.Status);
+                    return response;
+                }
+            }
+            catch (HttpRequestException ex)
             {
                 ClearPendingSignIn(context, userId);
-                _logger.LogDebug("Token exchange succeeded for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
-                if (_onSignInComplete is not null)
+                _logger.LogWarning(ex, "Token exchange failed for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
+                response = await HandleTokenExchangeFailureAsync(context, exchangeValue, ex.StatusCode, ex.Message, cancellationToken).ConfigureAwait(false);
+                result = AppsTelemetry.OAuthResults.Failure;
+                span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+                span?.SetTag(AppsTelemetry.Tags.InvokeResponseStatus, response.Status);
+                if (IsUnexpectedHttpStatus(ex.StatusCode))
                 {
-                    Context<TeamsActivity> baseContext = new(context.TeamsBotApplication, context.Activity);
-                    await _onSignInComplete(baseContext, tokenResult, cancellationToken).ConfigureAwait(false);
+                    RecordOAuthError(span, AppsTelemetry.OAuthOperations.TokenExchange, AppsTelemetry.OAuthErrorTypes.HttpError, ex, connectionName);
                 }
-                return new InvokeResponse(200);
+                return response;
             }
-        }
-        catch (HttpRequestException ex)
-        {
-            ClearPendingSignIn(context, userId);
-            _logger.LogWarning(ex, "Token exchange failed for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
-            return await HandleTokenExchangeFailureAsync(context, exchangeValue, ex.StatusCode, ex.Message, cancellationToken).ConfigureAwait(false);
-        }
-        catch (InvalidOperationException ex)
-        {
-            ClearPendingSignIn(context, userId);
-            _logger.LogWarning(ex, "Token exchange failed for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
-            return await HandleTokenExchangeFailureAsync(context, exchangeValue, null, ex.Message, cancellationToken).ConfigureAwait(false);
-        }
+            catch (InvalidOperationException ex)
+            {
+                ClearPendingSignIn(context, userId);
+                _logger.LogWarning(ex, "Token exchange failed for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
+                response = await HandleTokenExchangeFailureAsync(context, exchangeValue, null, ex.Message, cancellationToken).ConfigureAwait(false);
+                result = AppsTelemetry.OAuthResults.Failure;
+                span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+                span?.SetTag(AppsTelemetry.Tags.InvokeResponseStatus, response.Status);
+                RecordOAuthError(span, AppsTelemetry.OAuthOperations.TokenExchange, AppsTelemetry.OAuthErrorTypes.InvalidOperation, ex, connectionName);
+                return response;
+            }
 
-        // Token was null without exception — treat as expected failure
-        ClearPendingSignIn(context, userId);
-        return await HandleTokenExchangeFailureAsync(context, exchangeValue, null, "Token exchange returned null token.", cancellationToken).ConfigureAwait(false);
+            // Token was null without exception — treat as expected failure
+            ClearPendingSignIn(context, userId);
+            response = await HandleTokenExchangeFailureAsync(context, exchangeValue, null, "Token exchange returned null token.", cancellationToken).ConfigureAwait(false);
+            result = AppsTelemetry.OAuthResults.Failure;
+            span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+            span?.SetTag(AppsTelemetry.Tags.OAuthErrorType, AppsTelemetry.OAuthErrorTypes.EmptyToken);
+            span?.SetTag(AppsTelemetry.Tags.InvokeResponseStatus, response.Status);
+            return response;
+        }
+        finally
+        {
+            RecordOperation(AppsTelemetry.OAuthOperations.TokenExchange, result, startTs, connectionName);
+        }
     }
 
     private async Task<InvokeResponse> HandleTokenExchangeFailureAsync(
@@ -334,66 +473,104 @@ public class OAuthFlow
     /// </summary>
     internal async Task<InvokeResponse> HandleVerifyStateAsync(Context<InvokeActivity> context, SignInVerifyStateValue verifyValue, CancellationToken cancellationToken)
     {
-        if (verifyValue.State is null)
-        {
-            _logger.LogWarning(
-                "Verify state: state parameter is null for conversation '{ConversationId}', user '{UserId}'.",
-                context.Activity.Conversation?.Id,
-                context.Activity.From?.Id);
-            return new InvokeResponse(404);
-        }
+        using Activity? span = AppsTelemetry.Source.StartActivity(AppsTelemetry.Spans.OAuthVerifyState, ActivityKind.Internal);
+        span?.SetTag(AppsTelemetry.Tags.OAuthConnection, _connectionName);
+        span?.SetTag(AppsTelemetry.Tags.OAuthOperation, AppsTelemetry.OAuthOperations.VerifyState);
 
-        string userId = GetUserId(context);
-        string channelId = GetChannelId(context);
-        string connectionName = _connectionName;
+        long startTs = Stopwatch.GetTimestamp();
+        string result = AppsTelemetry.OAuthResults.Failure;
+        InvokeResponse response;
 
         try
         {
-            GetTokenResult? tokenResult = await _app.UserTokenClient
-                .GetTokenAsync(userId, connectionName, channelId, code: verifyValue.State, cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+            if (verifyValue.State is null)
+            {
+                _logger.LogWarning(
+                    "Verify state: state parameter is null for conversation '{ConversationId}', user '{UserId}'.",
+                    context.Activity.Conversation?.Id,
+                    context.Activity.From?.Id);
+                result = AppsTelemetry.OAuthResults.Failure;
+                span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+                response = new InvokeResponse(404);
+                span?.SetTag(AppsTelemetry.Tags.InvokeResponseStatus, response.Status);
+                return response;
+            }
 
-            if (tokenResult?.Token is not null)
+            string userId = GetUserId(context);
+            string channelId = GetChannelId(context);
+            string connectionName = _connectionName;
+
+            try
+            {
+                GetTokenResult? tokenResult = await _app.UserTokenClient
+                    .GetTokenAsync(userId, connectionName, channelId, code: verifyValue.State, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (tokenResult?.Token is not null)
+                {
+                    ClearPendingSignIn(context, userId);
+                    _logger.LogDebug("Verify state succeeded for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
+                    bool callbackInvoked = false;
+                    if (_onSignInComplete is not null)
+                    {
+                        Context<TeamsActivity> baseContext = new(context.TeamsBotApplication, context.Activity);
+                        await _onSignInComplete(baseContext, tokenResult, cancellationToken).ConfigureAwait(false);
+                        callbackInvoked = true;
+                    }
+                    span?.SetTag(AppsTelemetry.Tags.OAuthCallbackInvoked, callbackInvoked);
+                    result = AppsTelemetry.OAuthResults.Success;
+                    span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+                    response = new InvokeResponse(200);
+                    span?.SetTag(AppsTelemetry.Tags.InvokeResponseStatus, response.Status);
+                    return response;
+                }
+            }
+            catch (HttpRequestException ex)
             {
                 ClearPendingSignIn(context, userId);
-                _logger.LogDebug("Verify state succeeded for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
-                if (_onSignInComplete is not null)
+                _logger.LogWarning(ex, "Verify state failed for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
+
+                bool callbackInvoked = false;
+                if (_onSignInFailure is not null)
                 {
                     Context<TeamsActivity> baseContext = new(context.TeamsBotApplication, context.Activity);
-                    await _onSignInComplete(baseContext, tokenResult, cancellationToken).ConfigureAwait(false);
+                    await _onSignInFailure(baseContext, null, cancellationToken).ConfigureAwait(false);
+                    callbackInvoked = true;
                 }
-                return new InvokeResponse(200);
+                span?.SetTag(AppsTelemetry.Tags.OAuthCallbackInvoked, callbackInvoked);
+
+                result = AppsTelemetry.OAuthResults.Failure;
+                span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+
+                // For unexpected status codes, return the original code
+                if (IsUnexpectedHttpStatus(ex.StatusCode))
+                {
+                    response = new InvokeResponse((int)ex.StatusCode!.Value);
+                    span?.SetTag(AppsTelemetry.Tags.InvokeResponseStatus, response.Status);
+                    RecordOAuthError(span, AppsTelemetry.OAuthOperations.VerifyState, AppsTelemetry.OAuthErrorTypes.HttpError, ex);
+                    return response;
+                }
+
+                // 412 tells Teams to fall back to the sign-in card
+                response = new InvokeResponse(412);
+                span?.SetTag(AppsTelemetry.Tags.InvokeResponseStatus, response.Status);
+                return response;
             }
+
+            // No token returned — the code likely belongs to a different connection.
+            // Do NOT fire OnSignInFailure or clear pending state; the verifyState loop
+            // in OAuthFlowExtensions will try the next registered flow.
+            _logger.LogDebug("Verify state: no token for connection '{ConnectionName}', user '{UserId}'. Code may belong to another connection.", connectionName, userId);
+            result = AppsTelemetry.OAuthResults.NoToken;
+            span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+            response = new InvokeResponse(412);
+            span?.SetTag(AppsTelemetry.Tags.InvokeResponseStatus, response.Status);
+            return response;
         }
-        catch (HttpRequestException ex)
+        finally
         {
-            ClearPendingSignIn(context, userId);
-            _logger.LogWarning(ex, "Verify state failed for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
-
-            if (_onSignInFailure is not null)
-            {
-                Context<TeamsActivity> baseContext = new(context.TeamsBotApplication, context.Activity);
-                await _onSignInFailure(baseContext, null, cancellationToken).ConfigureAwait(false);
-            }
-
-            // For unexpected status codes, return the original code
-            if (ex.StatusCode.HasValue
-                && ex.StatusCode.Value != System.Net.HttpStatusCode.NotFound
-                && ex.StatusCode.Value != System.Net.HttpStatusCode.BadRequest
-                && ex.StatusCode.Value != System.Net.HttpStatusCode.PreconditionFailed)
-            {
-                return new InvokeResponse((int)ex.StatusCode.Value);
-            }
-
-            // 412 tells Teams to fall back to the sign-in card
-            return new InvokeResponse(412);
+            RecordOperation(AppsTelemetry.OAuthOperations.VerifyState, result, startTs);
         }
-
-        // No token returned — the code likely belongs to a different connection.
-        // Do NOT fire OnSignInFailure or clear pending state; the verifyState loop
-        // in OAuthFlowExtensions will try the next registered flow.
-        _logger.LogDebug("Verify state: no token for connection '{ConnectionName}', user '{UserId}'. Code may belong to another connection.", connectionName, userId);
-        return new InvokeResponse(412);
     }
 
     /// <summary>
@@ -423,29 +600,52 @@ public class OAuthFlow
     /// </summary>
     internal async Task<InvokeResponse> HandleSignInFailureAsync(Context<InvokeActivity> context, SignInFailureValue failureValue, CancellationToken cancellationToken)
     {
-        string? userId = context.Activity.From?.Id;
-        if (userId is not null)
+        using Activity? span = AppsTelemetry.Source.StartActivity(AppsTelemetry.Spans.OAuthSignInFailure, ActivityKind.Internal);
+        span?.SetTag(AppsTelemetry.Tags.OAuthConnection, _connectionName);
+        span?.SetTag(AppsTelemetry.Tags.OAuthOperation, AppsTelemetry.OAuthOperations.SignInFailure);
+        if (!string.IsNullOrEmpty(failureValue.Code))
         {
-            ClearPendingSignIn(context, userId);
+            span?.SetTag(AppsTelemetry.Tags.OAuthFailureCode, failureValue.Code);
         }
 
-        _logger.LogWarning(
-            "Sign-in failed for user '{UserId}' in conversation '{ConversationId}': {FailureCode} — {FailureMessage}.{Guidance}",
-            userId,
-            context.Activity.Conversation?.Id,
-            failureValue.Code,
-            failureValue.Message,
-            string.Equals(failureValue.Code, "resourcematchfailed", StringComparison.OrdinalIgnoreCase)
-                ? " Verify that your Entra app registration has 'Expose an API' configured with the correct Application ID URI matching your OAuth connection's Token Exchange URL."
-                : string.Empty);
-
-        if (_onSignInFailure is not null)
+        long startTs = Stopwatch.GetTimestamp();
+        string result = AppsTelemetry.OAuthResults.Notified;
+        try
         {
-            Context<TeamsActivity> baseContext = new(context.TeamsBotApplication, context.Activity);
-            await _onSignInFailure(baseContext, failureValue, cancellationToken).ConfigureAwait(false);
-        }
+            string? userId = context.Activity.From?.Id;
+            if (userId is not null)
+            {
+                ClearPendingSignIn(context, userId);
+            }
 
-        return new InvokeResponse(200);
+            _logger.LogWarning(
+                "Sign-in failed for user '{UserId}' in conversation '{ConversationId}': {FailureCode} — {FailureMessage}.{Guidance}",
+                userId,
+                context.Activity.Conversation?.Id,
+                failureValue.Code,
+                failureValue.Message,
+                string.Equals(failureValue.Code, "resourcematchfailed", StringComparison.OrdinalIgnoreCase)
+                    ? " Verify that your Entra app registration has 'Expose an API' configured with the correct Application ID URI matching your OAuth connection's Token Exchange URL."
+                    : string.Empty);
+
+            bool callbackInvoked = false;
+            if (_onSignInFailure is not null)
+            {
+                Context<TeamsActivity> baseContext = new(context.TeamsBotApplication, context.Activity);
+                await _onSignInFailure(baseContext, failureValue, cancellationToken).ConfigureAwait(false);
+                callbackInvoked = true;
+            }
+            span?.SetTag(AppsTelemetry.Tags.OAuthCallbackInvoked, callbackInvoked);
+            span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
+
+            InvokeResponse response = new(200);
+            span?.SetTag(AppsTelemetry.Tags.InvokeResponseStatus, response.Status);
+            return response;
+        }
+        finally
+        {
+            RecordOperation(AppsTelemetry.OAuthOperations.SignInFailure, result, startTs);
+        }
     }
 
     /// <summary>
@@ -534,5 +734,40 @@ public class OAuthFlow
 
     private static string GetChannelId<TActivity>(Context<TActivity> context) where TActivity : TeamsActivity
         => context.Activity.ChannelId ?? throw new InvalidOperationException("Activity.ChannelId is required for OAuth operations.");
+
+    // ── Telemetry helpers ────────────────────────────────────────────────
+
+    private void RecordOperation(string operation, string result, long startTimestamp, string? connectionName = null)
+    {
+        double elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
+        TagList tags = new()
+        {
+            { AppsTelemetry.Tags.OAuthConnection, connectionName ?? _connectionName },
+            { AppsTelemetry.Tags.OAuthOperation, operation },
+            { AppsTelemetry.Tags.OAuthResult, result },
+        };
+        AppsTelemetry.OAuthOperationCount.Add(1, tags);
+        AppsTelemetry.OAuthOperationDuration.Record(elapsedMs, tags);
+    }
+
+    private void RecordOAuthError(Activity? span, string operation, string errorType, Exception ex, string? connectionName = null)
+    {
+        span?.SetTag(AppsTelemetry.Tags.OAuthErrorType, errorType);
+        span?.RecordException(ex);
+        AppsTelemetry.OAuthErrors.Add(1, BuildErrorTags(operation, errorType, connectionName));
+    }
+
+    private TagList BuildErrorTags(string operation, string errorType, string? connectionName = null) => new()
+    {
+        { AppsTelemetry.Tags.OAuthConnection, connectionName ?? _connectionName },
+        { AppsTelemetry.Tags.OAuthOperation, operation },
+        { AppsTelemetry.Tags.OAuthErrorType, errorType },
+    };
+
+    private static bool IsUnexpectedHttpStatus(System.Net.HttpStatusCode? statusCode)
+        => statusCode.HasValue
+            && statusCode.Value != System.Net.HttpStatusCode.NotFound
+            && statusCode.Value != System.Net.HttpStatusCode.BadRequest
+            && statusCode.Value != System.Net.HttpStatusCode.PreconditionFailed;
 
 }

--- a/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
+++ b/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
@@ -41,12 +41,12 @@ public class OAuthFlow
     private SignInCompleteHandler? _onSignInComplete;
     private SignInFailureHandler? _onSignInFailure;
 
-    // Deduplication cache for signin/tokenExchange invoke activities.
-    // Teams may send duplicates from multiple endpoints (mobile, desktop, web).
+    // In-memory fallback for deduplication when turn state is not configured.
+    // When UseState() is configured, conversation state is used instead (works across instances).
     private readonly ConcurrentDictionary<string, DateTimeOffset> _processedExchanges = new();
 
-    // Tracks users with a pending sign-in (OAuthCard sent, waiting for tokenExchange/verifyState/failure).
-    // Used to scope signin/failure notifications to flows that actually initiated a sign-in.
+    // In-memory fallback for pending sign-in tracking when turn state is not configured.
+    // When UseState() is configured, user state is used instead (works across instances).
     private readonly ConcurrentDictionary<string, DateTimeOffset> _pendingSignIns = new();
 
     internal OAuthFlow(TeamsBotApplication app, string connectionName, OAuthOptions options, ILogger logger)
@@ -186,8 +186,9 @@ public class OAuthFlow
 
         await context.SendActivityAsync(oauthActivity, cancellationToken).ConfigureAwait(false);
 
-        // Track that this user has a pending sign-in for this flow
-        _pendingSignIns[userId] = DateTimeOffset.UtcNow;
+        // Track that this user has a pending sign-in for this flow.
+        // Use user state when available (distributed); fall back to in-memory otherwise.
+        SetPendingSignIn(context, userId);
 
         return null;
     }
@@ -246,14 +247,14 @@ public class OAuthFlow
     {
         string exchangeId = exchangeValue.Id ?? string.Empty;
 
-        // Deduplication: Teams sends duplicate exchanges from multiple endpoints
-        if (!_processedExchanges.TryAdd(exchangeId, DateTimeOffset.UtcNow))
+        // Deduplication: Teams sends duplicate exchanges from multiple endpoints.
+        // Use conversation state when available (distributed, works across instances);
+        // fall back to in-memory ConcurrentDictionary otherwise.
+        if (IsDuplicateExchange(context, exchangeId))
         {
             _logger.LogDebug("Duplicate signin/tokenExchange with Id '{ExchangeId}' - returning 200 no-op.", exchangeId);
             return new InvokeResponse(200);
         }
-
-        CleanupExpiredEntries();
 
         string userId = GetUserId(context);
         string channelId = GetChannelId(context);
@@ -267,7 +268,7 @@ public class OAuthFlow
 
             if (tokenResult?.Token is not null)
             {
-                _pendingSignIns.TryRemove(userId, out _);
+                ClearPendingSignIn(context, userId);
                 _logger.LogDebug("Token exchange succeeded for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
                 if (_onSignInComplete is not null)
                 {
@@ -279,19 +280,19 @@ public class OAuthFlow
         }
         catch (HttpRequestException ex)
         {
-            _pendingSignIns.TryRemove(userId, out _);
+            ClearPendingSignIn(context, userId);
             _logger.LogWarning(ex, "Token exchange failed for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
             return await HandleTokenExchangeFailureAsync(context, exchangeValue, ex.StatusCode, ex.Message, cancellationToken).ConfigureAwait(false);
         }
         catch (InvalidOperationException ex)
         {
-            _pendingSignIns.TryRemove(userId, out _);
+            ClearPendingSignIn(context, userId);
             _logger.LogWarning(ex, "Token exchange failed for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
             return await HandleTokenExchangeFailureAsync(context, exchangeValue, null, ex.Message, cancellationToken).ConfigureAwait(false);
         }
 
         // Token was null without exception — treat as expected failure
-        _pendingSignIns.TryRemove(userId, out _);
+        ClearPendingSignIn(context, userId);
         return await HandleTokenExchangeFailureAsync(context, exchangeValue, null, "Token exchange returned null token.", cancellationToken).ConfigureAwait(false);
     }
 
@@ -354,7 +355,7 @@ public class OAuthFlow
 
             if (tokenResult?.Token is not null)
             {
-                _pendingSignIns.TryRemove(userId, out _);
+                ClearPendingSignIn(context, userId);
                 _logger.LogDebug("Verify state succeeded for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
                 if (_onSignInComplete is not null)
                 {
@@ -366,7 +367,7 @@ public class OAuthFlow
         }
         catch (HttpRequestException ex)
         {
-            _pendingSignIns.TryRemove(userId, out _);
+            ClearPendingSignIn(context, userId);
             _logger.LogWarning(ex, "Verify state failed for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
 
             if (_onSignInFailure is not null)
@@ -396,16 +397,24 @@ public class OAuthFlow
     }
 
     /// <summary>
-    /// Whether this flow has a pending sign-in for the given user.
+    /// Whether this flow has a pending sign-in for the user in the given context.
     /// Used to scope <c>signin/failure</c> notifications to flows that initiated a sign-in.
     /// </summary>
     /// <remarks>
-    /// Best-effort: in multi-instance deployments the OAuthCard may have been sent by a different instance,
-    /// so this check may return false even when a sign-in is active. Callers should fall back
-    /// to notifying all flows when no flow reports a pending sign-in.
+    /// When turn state is configured, checks user state (works across instances).
+    /// Falls back to in-memory tracking when state is not configured.
+    /// Callers should fall back to notifying all flows when no flow reports a pending sign-in
+    /// (e.g., multi-instance deployment without distributed state).
     /// </remarks>
-    internal bool HasPendingSignIn(string userId)
+    internal bool HasPendingSignIn(Context<InvokeActivity> context)
     {
+        string pendingKey = $"oauth:pending:{_connectionName}";
+        if (context.HasState && context.State.UserState is not null)
+        {
+            return context.State.UserState.ContainsKey(pendingKey);
+        }
+
+        string userId = context.Activity.From?.Id ?? string.Empty;
         return _pendingSignIns.ContainsKey(userId);
     }
 
@@ -417,7 +426,7 @@ public class OAuthFlow
         string? userId = context.Activity.From?.Id;
         if (userId is not null)
         {
-            _pendingSignIns.TryRemove(userId, out _);
+            ClearPendingSignIn(context, userId);
         }
 
         _logger.LogWarning(
@@ -437,6 +446,68 @@ public class OAuthFlow
         }
 
         return new InvokeResponse(200);
+    }
+
+    /// <summary>
+    /// Check whether the given exchange ID has already been processed, and mark it as processed if not.
+    /// Always uses in-memory ConcurrentDictionary for atomic same-instance dedup (concurrent requests
+    /// load separate state snapshots, so state alone cannot catch same-instance races).
+    /// Additionally persists to conversation state when available for cross-instance dedup.
+    /// </summary>
+    private bool IsDuplicateExchange(Context<InvokeActivity> context, string exchangeId)
+    {
+        // Atomic same-instance check — catches concurrent duplicate requests on this node
+        if (!_processedExchanges.TryAdd(exchangeId, DateTimeOffset.UtcNow))
+        {
+            return true;
+        }
+
+        // Cross-instance check via state — catches duplicates routed to different nodes
+        string dedupKey = $"oauth:exchange:{exchangeId}";
+        if (context.HasState)
+        {
+            if (context.State.ConversationState.ContainsKey(dedupKey))
+            {
+                return true;
+            }
+
+            context.State.ConversationState.Set(dedupKey, DateTimeOffset.UtcNow);
+        }
+
+        CleanupExpiredEntries();
+        return false;
+    }
+
+    /// <summary>
+    /// Record that this user has a pending sign-in for this flow.
+    /// Uses user state when available (distributed); falls back to in-memory.
+    /// </summary>
+    private void SetPendingSignIn<TActivity>(Context<TActivity> context, string userId) where TActivity : TeamsActivity
+    {
+        string pendingKey = $"oauth:pending:{_connectionName}";
+        if (context.HasState && context.State.UserState is not null)
+        {
+            context.State.UserState.Set(pendingKey, DateTimeOffset.UtcNow);
+        }
+        else
+        {
+            _pendingSignIns[userId] = DateTimeOffset.UtcNow;
+        }
+    }
+
+    /// <summary>
+    /// Clear the pending sign-in tracking for this user/flow.
+    /// Clears from both state and in-memory to handle transitions.
+    /// </summary>
+    private void ClearPendingSignIn<TActivity>(Context<TActivity> context, string userId) where TActivity : TeamsActivity
+    {
+        string pendingKey = $"oauth:pending:{_connectionName}";
+        if (context.HasState && context.State.UserState is not null)
+        {
+            context.State.UserState.Remove(pendingKey);
+        }
+
+        _pendingSignIns.TryRemove(userId, out _);
     }
 
     private void CleanupExpiredEntries()

--- a/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlowExtensions.cs
+++ b/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlowExtensions.cs
@@ -105,10 +105,10 @@ public static class OAuthFlowExtensions
                 // signin/failure doesn't carry a connection name.
                 // Scope to flows that have an active sign-in for this user;
                 // fall back to all flows if none report a pending sign-in
-                // (e.g., multi-instance deployment where the OAuthCard was sent by another node).
+                // (e.g., multi-instance deployment without distributed state).
                 IEnumerable<OAuthFlow> allFlows = registry.GetAllFlows();
                 List<OAuthFlow> activeFlows = userId is not null
-                    ? allFlows.Where(f => f.HasPendingSignIn(userId)).ToList()
+                    ? allFlows.Where(f => f.HasPendingSignIn(ctx)).ToList()
                     : [];
                 IEnumerable<OAuthFlow> targetFlows = activeFlows.Count > 0 ? activeFlows : allFlows;
 

--- a/core/src/Microsoft.Teams.Apps/State/TurnStateLoader.cs
+++ b/core/src/Microsoft.Teams.Apps/State/TurnStateLoader.cs
@@ -74,7 +74,7 @@ public sealed class TurnStateLoader
         }
         catch (Exception ex)
         {
-            span.RecordException(ex);
+            span?.RecordException(ex);
             AppsTelemetry.StateCacheErrors.Add(1, new KeyValuePair<string, object?>(AppsTelemetry.Tags.Operation, "load"));
             _logger.StateLoadFailed(ex, conversationId);
             throw;

--- a/core/src/Microsoft.Teams.Apps/TeamsBotApplication.HostingExtensions.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsBotApplication.HostingExtensions.cs
@@ -175,10 +175,9 @@ public static class TeamsBotApplicationHostingExtensions
         }
 
         // Provide an in-memory cache as fallback so UseState() works out of the box.
-        // Since this uses TryAdd, any IDistributedCache registered by the developer
-        // (before or after this call) will take precedence via last-wins DI resolution
-        // only if they use Add (not TryAdd). Redis (AddStackExchangeRedisCache) uses Add,
-        // so it always wins regardless of order.
+        // AddDistributedMemoryCache() uses TryAdd, so it will not replace an existing IDistributedCache registration.
+        // If the developer registers another IDistributedCache later using Add*,
+        // the last registration will be resolved (e.g., AddStackExchangeRedisCache).
         services.AddDistributedMemoryCache();
 
         services.AddSingleton<TurnStateLoader>();

--- a/core/src/Microsoft.Teams.Apps/TeamsBotApplicationOptions.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsBotApplicationOptions.cs
@@ -29,6 +29,7 @@ public sealed class TeamsBotApplicationOptions : BotApplicationOptions
         configure?.Invoke(options);
 
         OAuthFlows.Add(new OAuthFlowDescriptor(connectionName, options));
+        this.UseState(); // OAuthFlows require state, so enable it automatically when AddOAuthFlow is called.
         return this;
     }
 

--- a/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTelemetryTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTelemetryTests.cs
@@ -1,0 +1,602 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Teams.Apps.Api.Clients;
+using Microsoft.Teams.Apps.Diagnostics;
+using Microsoft.Teams.Apps.Handlers;
+using Microsoft.Teams.Apps.OAuth;
+using Microsoft.Teams.Apps.Schema;
+using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Schema;
+using Moq;
+
+namespace Microsoft.Teams.Apps.UnitTests;
+
+/// <summary>
+/// Verifies that <see cref="OAuthFlow"/> emits the OTel spans and metrics described in
+/// <c>core/docs/sso/OAuthFlow-Design.md</c> and <c>core/docs/Observability-Design.md</c>.
+/// </summary>
+public class OAuthFlowTelemetryTests
+{
+    private const string GraphConnection = "graph";
+    private const string TestUserId = "user-1";
+    private const string TestChannelId = "msteams";
+
+    // ==================== GetTokenAsync ====================
+
+    [Fact]
+    public async Task GetTokenAsync_CachedToken_EmitsHitResult()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        harness.MockUserTokenClient
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetTokenResult { Token = "tok", ConnectionName = GraphConnection });
+
+        Context<MessageActivity> ctx = CreateMessageContext(harness);
+        string? token = await harness.Flow.GetTokenAsync(ctx);
+
+        Assert.Equal("tok", token);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthGetToken);
+        Assert.Equal(AppsTelemetry.OAuthOperations.GetToken, span.GetTagItem(AppsTelemetry.Tags.OAuthOperation));
+        Assert.Equal(AppsTelemetry.OAuthResults.Hit, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+        Assert.Equal(GraphConnection, span.GetTagItem(AppsTelemetry.Tags.OAuthConnection));
+
+        Assert.Equal(1, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthOperations));
+        Assert.Equal(1, metrics.HistogramSampleCount(AppsTelemetry.Metrics.OAuthOperationDuration));
+        Assert.Equal(0, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_NoToken_EmitsMissResult()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        harness.MockUserTokenClient
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GetTokenResult?)null);
+
+        Context<MessageActivity> ctx = CreateMessageContext(harness);
+        string? token = await harness.Flow.GetTokenAsync(ctx);
+
+        Assert.Null(token);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthGetToken);
+        Assert.Equal(AppsTelemetry.OAuthResults.Miss, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+        Assert.Equal(0, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+    }
+
+    // ==================== SignInAsync ====================
+
+    [Fact]
+    public async Task SignInAsync_CachedToken_EmitsCachedResultWithoutCardEvent()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        harness.MockUserTokenClient
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetTokenResult { Token = "cached", ConnectionName = GraphConnection });
+
+        Context<MessageActivity> ctx = CreateMessageContext(harness);
+        string? token = await harness.Flow.SignInAsync(ctx);
+
+        Assert.Equal("cached", token);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthSignIn);
+        Assert.Equal(AppsTelemetry.OAuthResults.Cached, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+        Assert.DoesNotContain(span.Events, e => e.Name == AppsTelemetry.OAuthEvents.CardSent);
+
+        Assert.Equal(1, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthOperations));
+        Assert.Equal(0, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+    }
+
+    [Fact]
+    public async Task SignInAsync_NoCachedToken_EmitsCardSentResultAndCardSentEvent()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        SetupSilentTokenReturnsNull(harness.MockUserTokenClient);
+        SetupGetSignInResource(harness.MockUserTokenClient);
+        SetupSendActivity(harness);
+
+        Context<MessageActivity> ctx = CreateMessageContext(harness);
+        string? token = await harness.Flow.SignInAsync(ctx);
+
+        Assert.Null(token);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthSignIn);
+        Assert.Equal(AppsTelemetry.OAuthResults.CardSent, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+        Assert.Contains(span.Events, e => e.Name == AppsTelemetry.OAuthEvents.CardSent);
+        Assert.Equal(0, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+    }
+
+    // ==================== SignOutAsync ====================
+
+    [Fact]
+    public async Task SignOutAsync_EmitsSuccessResult()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        harness.MockUserTokenClient
+            .Setup(c => c.SignOutUserAsync(TestUserId, GraphConnection, TestChannelId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        Context<MessageActivity> ctx = CreateMessageContext(harness);
+        await harness.Flow.SignOutAsync(ctx);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthSignOut);
+        Assert.Equal(AppsTelemetry.OAuthResults.Success, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+        Assert.Equal(1, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthOperations));
+        Assert.Equal(0, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+    }
+
+    // ==================== GetConnectionStatusAsync ====================
+
+    [Fact]
+    public async Task GetConnectionStatusAsync_TagsConnectionAsAll()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        harness.MockUserTokenClient
+            .Setup(c => c.GetTokenStatusAsync(TestUserId, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new GetTokenStatusResult { ConnectionName = GraphConnection, HasToken = true } });
+
+        Context<MessageActivity> ctx = CreateMessageContext(harness);
+        IList<GetTokenStatusResult> statuses = await harness.Flow.GetConnectionStatusAsync(ctx);
+
+        Assert.Single(statuses);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthConnectionStatus);
+        Assert.Equal(AppsTelemetry.OAuthAllConnections, span.GetTagItem(AppsTelemetry.Tags.OAuthConnection));
+        Assert.Equal(AppsTelemetry.OAuthOperations.ConnectionStatus, span.GetTagItem(AppsTelemetry.Tags.OAuthOperation));
+        Assert.Equal(AppsTelemetry.OAuthResults.Success, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+
+        IReadOnlyList<KeyValuePair<string, object?>> tags = metrics.GetCounterTags(AppsTelemetry.Metrics.OAuthOperations);
+        Assert.Contains(new KeyValuePair<string, object?>(AppsTelemetry.Tags.OAuthConnection, AppsTelemetry.OAuthAllConnections), tags);
+    }
+
+    // ==================== HandleTokenExchangeAsync ====================
+
+    [Fact]
+    public async Task TokenExchange_Success_EmitsSuccessResult()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        harness.MockUserTokenClient
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetTokenResult { Token = "access", ConnectionName = GraphConnection });
+
+        SignInTokenExchangeValue exchangeValue = new() { Id = "ex-success", ConnectionName = GraphConnection, Token = "sso-token" };
+        Context<InvokeActivity> ctx = CreateInvokeContext(harness);
+
+        InvokeResponse response = await harness.Flow.HandleTokenExchangeAsync(ctx, exchangeValue, CancellationToken.None);
+
+        Assert.Equal(200, response.Status);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthTokenExchange);
+        Assert.Equal(AppsTelemetry.OAuthResults.Success, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+        Assert.Equal(200, span.GetTagItem(AppsTelemetry.Tags.InvokeResponseStatus));
+        Assert.Equal(0, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+    }
+
+    [Fact]
+    public async Task TokenExchange_Duplicate_EmitsDuplicateResultAndNoError()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        harness.MockUserTokenClient
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetTokenResult { Token = "access", ConnectionName = GraphConnection });
+
+        SignInTokenExchangeValue exchangeValue = new() { Id = "ex-dup", ConnectionName = GraphConnection, Token = "sso-token" };
+        Context<InvokeActivity> ctx = CreateInvokeContext(harness);
+
+        // First call: success; second call (same exchange id): duplicate
+        await harness.Flow.HandleTokenExchangeAsync(ctx, exchangeValue, CancellationToken.None);
+        InvokeResponse second = await harness.Flow.HandleTokenExchangeAsync(ctx, exchangeValue, CancellationToken.None);
+
+        Assert.Equal(200, second.Status);
+
+        List<Activity> exchangeSpans = spans.Stopped
+            .Where(a => a.OperationName == AppsTelemetry.Spans.OAuthTokenExchange)
+            .ToList();
+        Assert.Equal(2, exchangeSpans.Count);
+        Assert.Contains(exchangeSpans, s => string.Equals(s.GetTagItem(AppsTelemetry.Tags.OAuthResult) as string, AppsTelemetry.OAuthResults.Duplicate, StringComparison.Ordinal));
+
+        Assert.Equal(0, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+    }
+
+    [Fact]
+    public async Task TokenExchange_ExpectedFallback_Returns412AndDoesNotIncrementErrors()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        harness.MockUserTokenClient
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Bad request", null, System.Net.HttpStatusCode.BadRequest));
+
+        SignInTokenExchangeValue exchangeValue = new() { Id = "ex-bad", ConnectionName = GraphConnection, Token = "sso-token" };
+        Context<InvokeActivity> ctx = CreateInvokeContext(harness);
+
+        InvokeResponse response = await harness.Flow.HandleTokenExchangeAsync(ctx, exchangeValue, CancellationToken.None);
+
+        Assert.Equal(412, response.Status);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthTokenExchange);
+        Assert.Equal(AppsTelemetry.OAuthResults.Failure, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+        Assert.Null(span.GetTagItem(AppsTelemetry.Tags.OAuthErrorType));
+        Assert.Equal(0, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+    }
+
+    [Fact]
+    public async Task TokenExchange_UnexpectedStatus_IncrementsErrorsWithHttpErrorType()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        harness.MockUserTokenClient
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Forbidden", null, System.Net.HttpStatusCode.Forbidden));
+
+        SignInTokenExchangeValue exchangeValue = new() { Id = "ex-forbidden", ConnectionName = GraphConnection, Token = "sso-token" };
+        Context<InvokeActivity> ctx = CreateInvokeContext(harness);
+
+        InvokeResponse response = await harness.Flow.HandleTokenExchangeAsync(ctx, exchangeValue, CancellationToken.None);
+
+        Assert.Equal(403, response.Status);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthTokenExchange);
+        Assert.Equal(AppsTelemetry.OAuthResults.Failure, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+        Assert.Equal(AppsTelemetry.OAuthErrorTypes.HttpError, span.GetTagItem(AppsTelemetry.Tags.OAuthErrorType));
+
+        Assert.Equal(1, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+        IReadOnlyList<KeyValuePair<string, object?>> errorTags = metrics.GetCounterTags(AppsTelemetry.Metrics.OAuthErrors);
+        Assert.Contains(new KeyValuePair<string, object?>(AppsTelemetry.Tags.OAuthErrorType, AppsTelemetry.OAuthErrorTypes.HttpError), errorTags);
+        Assert.Contains(new KeyValuePair<string, object?>(AppsTelemetry.Tags.OAuthOperation, AppsTelemetry.OAuthOperations.TokenExchange), errorTags);
+    }
+
+    // ==================== HandleVerifyStateAsync ====================
+
+    [Fact]
+    public async Task VerifyState_NullState_EmitsFailureResultWithoutError()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        Context<InvokeActivity> ctx = CreateInvokeContext(harness);
+        SignInVerifyStateValue verifyValue = new() { State = null };
+
+        InvokeResponse response = await harness.Flow.HandleVerifyStateAsync(ctx, verifyValue, CancellationToken.None);
+
+        Assert.Equal(404, response.Status);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthVerifyState);
+        Assert.Equal(AppsTelemetry.OAuthResults.Failure, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+        Assert.Equal(0, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+    }
+
+    [Fact]
+    public async Task VerifyState_NoToken_EmitsNoTokenResultAndDoesNotIncrementErrors()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        harness.MockUserTokenClient
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GetTokenResult?)null);
+
+        Context<InvokeActivity> ctx = CreateInvokeContext(harness);
+        SignInVerifyStateValue verifyValue = new() { State = "code" };
+
+        InvokeResponse response = await harness.Flow.HandleVerifyStateAsync(ctx, verifyValue, CancellationToken.None);
+
+        Assert.Equal(412, response.Status);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthVerifyState);
+        Assert.Equal(AppsTelemetry.OAuthResults.NoToken, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+        Assert.Equal(0, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+    }
+
+    [Fact]
+    public async Task VerifyState_ExpectedFallback_DoesNotIncrementErrors()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        harness.MockUserTokenClient
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Bad request", null, System.Net.HttpStatusCode.BadRequest));
+
+        Context<InvokeActivity> ctx = CreateInvokeContext(harness);
+        SignInVerifyStateValue verifyValue = new() { State = "code" };
+
+        InvokeResponse response = await harness.Flow.HandleVerifyStateAsync(ctx, verifyValue, CancellationToken.None);
+
+        Assert.Equal(412, response.Status);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthVerifyState);
+        Assert.Equal(AppsTelemetry.OAuthResults.Failure, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+        Assert.Null(span.GetTagItem(AppsTelemetry.Tags.OAuthErrorType));
+        Assert.Equal(0, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+    }
+
+    [Fact]
+    public async Task VerifyState_UnexpectedStatus_IncrementsErrorsWithHttpErrorType()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        harness.MockUserTokenClient
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Forbidden", null, System.Net.HttpStatusCode.Forbidden));
+
+        Context<InvokeActivity> ctx = CreateInvokeContext(harness);
+        SignInVerifyStateValue verifyValue = new() { State = "code" };
+
+        InvokeResponse response = await harness.Flow.HandleVerifyStateAsync(ctx, verifyValue, CancellationToken.None);
+
+        Assert.Equal(403, response.Status);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthVerifyState);
+        Assert.Equal(AppsTelemetry.OAuthResults.Failure, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+        Assert.Equal(AppsTelemetry.OAuthErrorTypes.HttpError, span.GetTagItem(AppsTelemetry.Tags.OAuthErrorType));
+        Assert.Equal(1, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+    }
+
+    // ==================== HandleSignInFailureAsync ====================
+
+    [Fact]
+    public async Task SignInFailure_EmitsNotifiedResultWithFailureCodeTag()
+    {
+        using SpanCapture spans = new();
+        using MetricCapture metrics = new();
+        TestHarness harness = CreateHarness();
+
+        Context<InvokeActivity> ctx = CreateInvokeContext(harness);
+        SignInFailureValue failureValue = new() { Code = "resourcematchfailed", Message = "URI mismatch" };
+
+        InvokeResponse response = await harness.Flow.HandleSignInFailureAsync(ctx, failureValue, CancellationToken.None);
+
+        Assert.Equal(200, response.Status);
+
+        Activity span = AssertOAuthSpan(spans, AppsTelemetry.Spans.OAuthSignInFailure);
+        Assert.Equal(AppsTelemetry.OAuthResults.Notified, span.GetTagItem(AppsTelemetry.Tags.OAuthResult));
+        Assert.Equal("resourcematchfailed", span.GetTagItem(AppsTelemetry.Tags.OAuthFailureCode));
+        Assert.Equal(0, metrics.GetCounterTotal(AppsTelemetry.Metrics.OAuthErrors));
+    }
+
+    // ==================== test scaffolding ====================
+
+    private static Activity AssertOAuthSpan(SpanCapture capture, string operationName)
+    {
+        Activity? span = capture.Stopped
+            .Where(a => a.OperationName == operationName)
+            .Where(a => (a.GetTagItem(AppsTelemetry.Tags.OAuthConnection) as string) == GraphConnection
+                        || (a.GetTagItem(AppsTelemetry.Tags.OAuthConnection) as string) == AppsTelemetry.OAuthAllConnections)
+            .LastOrDefault();
+        Assert.NotNull(span);
+        return span!;
+    }
+
+    private static TestHarness CreateHarness()
+    {
+        Mock<UserTokenClient> mockUserTokenClient = CreateMockUserTokenClient();
+        Mock<ConversationClient> mockConversationClient = new(new HttpClient(), NullLogger<ConversationClient>.Instance);
+
+        ApiClient apiClient = new(
+            new HttpClient(),
+            mockConversationClient.Object,
+            mockUserTokenClient.Object);
+
+        TeamsBotApplication app = new(
+            apiClient,
+            new HttpContextAccessor(),
+            NullLogger<TeamsBotApplication>.Instance,
+            new TeamsBotApplicationOptions { AppId = "test-app-id" });
+
+        OAuthFlow flow = app.AddOAuthFlow(GraphConnection);
+
+        return new TestHarness
+        {
+            App = app,
+            MockUserTokenClient = mockUserTokenClient,
+            MockConversationClient = mockConversationClient,
+            Flow = flow,
+        };
+    }
+
+    private static Mock<UserTokenClient> CreateMockUserTokenClient()
+    {
+        Mock<IConfiguration> mockConfig = new();
+        return new Mock<UserTokenClient>(
+            new HttpClient(),
+            mockConfig.Object,
+            NullLogger<UserTokenClient>.Instance);
+    }
+
+    private static Context<MessageActivity> CreateMessageContext(TestHarness harness)
+    {
+        MessageActivity activity = new("hello")
+        {
+            ChannelId = TestChannelId,
+            From = new TeamsConversationAccount { Id = TestUserId },
+            Recipient = new TeamsConversationAccount { Id = "bot-id" },
+            Conversation = new TeamsConversation { Id = "conv-1" },
+            ServiceUrl = new Uri("https://smba.trafficmanager.net/test/"),
+        };
+
+        return new Context<MessageActivity>(harness.App, activity);
+    }
+
+    private static Context<InvokeActivity> CreateInvokeContext(TestHarness harness)
+    {
+        InvokeActivity activity = new()
+        {
+            ChannelId = TestChannelId,
+            From = new TeamsConversationAccount { Id = TestUserId },
+            Recipient = new TeamsConversationAccount { Id = "bot-id" },
+            Conversation = new TeamsConversation { Id = "conv-1" },
+            ServiceUrl = new Uri("https://smba.trafficmanager.net/test/"),
+        };
+
+        return new Context<InvokeActivity>(harness.App, activity);
+    }
+
+    private static void SetupSilentTokenReturnsNull(Mock<UserTokenClient> mock)
+    {
+        mock.Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GetTokenResult?)null);
+    }
+
+    private static void SetupGetSignInResource(Mock<UserTokenClient> mock)
+    {
+        mock.Setup(c => c.GetSignInResourceAsync(It.IsAny<string>(), null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetSignInResourceResult
+            {
+                SignInLink = "https://login.microsoftonline.com/test",
+                TokenExchangeResource = new TokenExchangeResource { Id = "tex-1", Uri = new Uri("api://test") },
+                TokenPostResource = new TokenPostResource { SasUrl = new Uri("https://token.botframework.com/test") }
+            });
+    }
+
+    private static void SetupSendActivity(TestHarness harness)
+    {
+        harness.MockConversationClient
+            .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SendActivityResponse { Id = "activity-1" });
+    }
+
+    private sealed class TestHarness
+    {
+        public required TeamsBotApplication App { get; init; }
+        public required Mock<UserTokenClient> MockUserTokenClient { get; init; }
+        public required Mock<ConversationClient> MockConversationClient { get; init; }
+        public required OAuthFlow Flow { get; init; }
+    }
+
+    /// <summary>
+    /// Subscribes to spans emitted on the <see cref="TeamsBotApplicationTelemetry.ActivitySourceName"/>
+    /// source for the lifetime of the instance. Mirrors the helper used in <c>RouterTelemetryTests</c>.
+    /// </summary>
+    private sealed class SpanCapture : IDisposable
+    {
+        private readonly ActivityListener _listener;
+        public List<Activity> Stopped { get; } = [];
+
+        public SpanCapture()
+        {
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = src => src.Name == TeamsBotApplicationTelemetry.ActivitySourceName,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = a =>
+                {
+                    lock (Stopped) { Stopped.Add(a); }
+                },
+            };
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    /// <summary>
+    /// Subscribes a <see cref="MeterListener"/> to the Apps meter and aggregates emitted measurements
+    /// (counter totals, histogram sample counts, and the most recent tag set per instrument).
+    /// </summary>
+    private sealed class MetricCapture : IDisposable
+    {
+        private readonly MeterListener _listener;
+        private readonly Dictionary<string, long> _counterTotals = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, int> _histogramSamples = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, KeyValuePair<string, object?>[]> _lastTags = new(StringComparer.Ordinal);
+
+        public MetricCapture()
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, listener) =>
+                {
+                    if (instrument.Meter.Name == TeamsBotApplicationTelemetry.MeterName)
+                    {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+            _listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+            {
+                lock (_counterTotals)
+                {
+                    _counterTotals.TryGetValue(instrument.Name, out long total);
+                    _counterTotals[instrument.Name] = total + value;
+                    _lastTags[instrument.Name] = tags.ToArray();
+                }
+            });
+            _listener.SetMeasurementEventCallback<double>((instrument, _, tags, _) =>
+            {
+                lock (_histogramSamples)
+                {
+                    _histogramSamples.TryGetValue(instrument.Name, out int count);
+                    _histogramSamples[instrument.Name] = count + 1;
+                    _lastTags[instrument.Name] = tags.ToArray();
+                }
+            });
+            _listener.Start();
+        }
+
+        public long GetCounterTotal(string name)
+        {
+            lock (_counterTotals)
+            {
+                return _counterTotals.TryGetValue(name, out long total) ? total : 0;
+            }
+        }
+
+        public int HistogramSampleCount(string name)
+        {
+            lock (_histogramSamples)
+            {
+                return _histogramSamples.TryGetValue(name, out int count) ? count : 0;
+            }
+        }
+
+        public IReadOnlyList<KeyValuePair<string, object?>> GetCounterTags(string name)
+        {
+            lock (_counterTotals)
+            {
+                return _lastTags.TryGetValue(name, out KeyValuePair<string, object?>[]? tags) ? tags : [];
+            }
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+}

--- a/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTests.cs
@@ -47,8 +47,8 @@ public class OAuthFlowTests
         SignInFailureValue failureValue = new() { Code = "tokenmissing", Message = "Token acquisition failed." };
 
         // The route handler filters by HasPendingSignIn, so verify the flags
-        Assert.True(harness.GraphFlow.HasPendingSignIn(TestUserId));
-        Assert.False(harness.GitHubFlow.HasPendingSignIn(TestUserId));
+        Assert.True(harness.GraphFlow.HasPendingSignIn(CreateInvokeContext(harness, TestUserId)));
+        Assert.False(harness.GitHubFlow.HasPendingSignIn(CreateInvokeContext(harness, TestUserId)));
 
         await harness.GraphFlow.HandleSignInFailureAsync(failureCtx, failureValue, CancellationToken.None);
 
@@ -69,14 +69,14 @@ public class OAuthFlowTests
         Context<MessageActivity> ctx = CreateMessageContext(harness, TestUserId);
         await harness.GraphFlow!.SignInAsync(ctx);
 
-        Assert.True(harness.GraphFlow.HasPendingSignIn(TestUserId));
+        Assert.True(harness.GraphFlow.HasPendingSignIn(CreateInvokeContext(harness, TestUserId)));
 
         // Act
         Context<InvokeActivity> failureCtx = CreateInvokeContext(harness, TestUserId);
         await harness.GraphFlow.HandleSignInFailureAsync(failureCtx, new SignInFailureValue { Code = "invokeerror" }, CancellationToken.None);
 
         // Assert
-        Assert.False(harness.GraphFlow.HasPendingSignIn(TestUserId));
+        Assert.False(harness.GraphFlow.HasPendingSignIn(CreateInvokeContext(harness, TestUserId)));
     }
 
     [Fact]
@@ -91,7 +91,7 @@ public class OAuthFlowTests
         Context<MessageActivity> ctx = CreateMessageContext(harness, TestUserId);
         await harness.GraphFlow!.SignInAsync(ctx);
 
-        Assert.True(harness.GraphFlow.HasPendingSignIn(TestUserId));
+        Assert.True(harness.GraphFlow.HasPendingSignIn(CreateInvokeContext(harness, TestUserId)));
 
         // Arrange exchange
         harness.MockUserTokenClient
@@ -106,7 +106,7 @@ public class OAuthFlowTests
 
         // Assert
         Assert.Equal(200, response.Status);
-        Assert.False(harness.GraphFlow.HasPendingSignIn(TestUserId));
+        Assert.False(harness.GraphFlow.HasPendingSignIn(CreateInvokeContext(harness, TestUserId)));
     }
 
     [Fact]
@@ -121,7 +121,7 @@ public class OAuthFlowTests
         Context<MessageActivity> ctx = CreateMessageContext(harness, TestUserId);
         await harness.GraphFlow!.SignInAsync(ctx);
 
-        Assert.True(harness.GraphFlow.HasPendingSignIn(TestUserId));
+        Assert.True(harness.GraphFlow.HasPendingSignIn(CreateInvokeContext(harness, TestUserId)));
 
         // Arrange exchange failure
         harness.MockUserTokenClient
@@ -136,7 +136,7 @@ public class OAuthFlowTests
 
         // Assert - 401 passed through (unexpected code)
         Assert.Equal(401, response.Status);
-        Assert.False(harness.GraphFlow.HasPendingSignIn(TestUserId));
+        Assert.False(harness.GraphFlow.HasPendingSignIn(CreateInvokeContext(harness, TestUserId)));
     }
 
     [Fact]
@@ -151,7 +151,7 @@ public class OAuthFlowTests
         Context<MessageActivity> ctx = CreateMessageContext(harness, TestUserId);
         await harness.GraphFlow!.SignInAsync(ctx);
 
-        Assert.True(harness.GraphFlow.HasPendingSignIn(TestUserId));
+        Assert.True(harness.GraphFlow.HasPendingSignIn(CreateInvokeContext(harness, TestUserId)));
 
         // Arrange verify state
         harness.MockUserTokenClient
@@ -166,7 +166,7 @@ public class OAuthFlowTests
 
         // Assert
         Assert.Equal(200, response.Status);
-        Assert.False(harness.GraphFlow.HasPendingSignIn(TestUserId));
+        Assert.False(harness.GraphFlow.HasPendingSignIn(CreateInvokeContext(harness, TestUserId)));
     }
 
     // ==================== No pending sign-in for unrelated user ====================
@@ -183,8 +183,8 @@ public class OAuthFlowTests
         Context<MessageActivity> ctx = CreateMessageContext(harness, TestUserId);
         await harness.GraphFlow!.SignInAsync(ctx);
 
-        Assert.True(harness.GraphFlow.HasPendingSignIn(TestUserId));
-        Assert.False(harness.GraphFlow.HasPendingSignIn("other-user"));
+        Assert.True(harness.GraphFlow.HasPendingSignIn(CreateInvokeContext(harness, TestUserId)));
+        Assert.False(harness.GraphFlow.HasPendingSignIn(CreateInvokeContext(harness, "other-user")));
     }
 
     // ==================== Token exchange error code mapping ====================
@@ -384,7 +384,7 @@ public class OAuthFlowTests
         string? token = await harness.GraphFlow!.SignInAsync(ctx);
 
         Assert.Equal("cached-token", token);
-        Assert.False(harness.GraphFlow.HasPendingSignIn(TestUserId));
+        Assert.False(harness.GraphFlow.HasPendingSignIn(CreateInvokeContext(harness, TestUserId)));
     }
 
     [Fact]
@@ -400,7 +400,7 @@ public class OAuthFlowTests
         string? token = await harness.GraphFlow!.SignInAsync(ctx);
 
         Assert.Null(token);
-        Assert.True(harness.GraphFlow.HasPendingSignIn(TestUserId));
+        Assert.True(harness.GraphFlow.HasPendingSignIn(CreateInvokeContext(harness, TestUserId)));
     }
 
     // ==================== Helpers ====================


### PR DESCRIPTION
Stacked on top of #550 (base: `feature/turn-state`). Review/merge #550 first; this PR will retarget to `main` automatically once that lands.

## Changes

### Distributed state for OAuth deduplication/tracking (53f4c817)
- Enable distributed state (via Redis) for OAuth flow deduplication and pending sign-in tracking.
- `OAuthFlow` now uses conversation/user state when available, with in-memory fallback.
- Refactor `HasPendingSignIn` to accept context; add helper methods for state management.
- Update related tests and documentation.
- `AddOAuthFlow` now ensures state is enabled and wires `StackExchangeRedisCache`.

### Sample state usage update (9bd54750)
- `ObservabilityBot` chat history switched from `ConversationState` to `UserState`.
- `ObservabilityBotApp` accepts optional `TurnStateLoader` via constructor and passes it to the base.
- Clarify error messages and DI comments; improve exception handling in `TurnStateLoader`.
- Update cache registration documentation for DI behavior.

## Files
- `core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs`
- `core/src/Microsoft.Teams.Apps/OAuth/OAuthFlowExtensions.cs`
- `core/src/Microsoft.Teams.Apps/TeamsBotApplicationOptions.cs`
- `core/src/Microsoft.Teams.Apps/State/TurnStateLoader.cs`
- `core/src/Microsoft.Teams.Apps/TeamsBotApplication.HostingExtensions.cs`
- `core/src/Microsoft.Teams.Apps/Context.cs`
- `core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTests.cs`
- `core/samples/ObservabilityBot/*`, `core/samples/SsoBot/Program.cs`
