### PR TITLE
Add CachingAuthTokens sample with Redis token cache

### DIFF
--- a/core/core.slnx
+++ b/core/core.slnx
@@ -13,6 +13,7 @@
     <Project Path="samples/A2ABot/A2ABot.csproj" />
     <Project Path="samples/AFBot/AFBot.csproj" Id="ca5b4abd-3f26-457b-8197-ff9415506beb" />
     <Project Path="samples/AllInvokesBot/AllInvokesBot.csproj" />
+    <Project Path="samples/CachingAuthTokens/CachingAuthTokens.csproj" Id="01e6530d-ac7d-47ca-9748-785883eb6c39" />
     <Project Path="samples/CompatBot/CompatBot.csproj" Id="39461362-c3d0-41ae-9ed7-f7e1232a8ead" />
     <Project Path="samples/CompatProactive/CompatProactive.csproj" Id="60e946ea-ea2f-4994-8b5b-e6aa98723aa4" />
     <Project Path="samples/CoreBot/CoreBot.csproj" Id="142a67bc-68e7-4020-83cf-51423e317b53" />
@@ -50,7 +51,7 @@
     <Project Path="test/ABSTokenServiceClient/ABSTokenServiceClient.csproj" />
     <Project Path="test/Microsoft.Teams.Apps.BotBuilder.UnitTests/Microsoft.Teams.Apps.BotBuilder.UnitTests.csproj" Id="17f5e8eb-ccb0-40e6-9630-a9d936d6ccde" />
     <Project Path="test/Microsoft.Teams.Apps.UnitTests/Microsoft.Teams.Apps.UnitTests.csproj" Id="16f5e8eb-ccb0-40e6-9630-a9d936d6ccde" />
-    <Project Path="test/Microsoft.Teams.Core.UnitTests/Microsoft.Teams.Core.UnitTests.csproj" Id="8e6790ed-0352-45f6-b3dc-0c4c3bcab038" />    
+    <Project Path="test/Microsoft.Teams.Core.UnitTests/Microsoft.Teams.Core.UnitTests.csproj" Id="8e6790ed-0352-45f6-b3dc-0c4c3bcab038" />
     <Project Path="test/TeamsApisDemo/TeamsApisDemo.csproj" Id="1446b240-c778-4fc6-a389-a655d789444c" />
   </Folder>
   <Project Path="src/Microsoft.Teams.Apps.BotBuilder/Microsoft.Teams.Apps.BotBuilder.csproj" />

--- a/core/samples/CachingAuthTokens/CachingAuthTokens.csproj
+++ b/core/samples/CachingAuthTokens/CachingAuthTokens.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Teams.Apps\Microsoft.Teams.Apps.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/core/samples/CachingAuthTokens/Program.cs
+++ b/core/samples/CachingAuthTokens/Program.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics;
+using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Handlers;
+
+var builder = WebApplication.CreateSlimBuilder(args);
+builder.Services
+    .AddTeamsBotApplication()
+    .AddStackExchangeRedisCache(options =>
+    {
+        options.Configuration = builder.Configuration.GetConnectionString("Redis"); // requires a Redis instance, for local testing you can use Docker: `docker run -p 6379:6379 redis`
+    });
+
+var app = builder.Build();
+
+var bot = app.UseTeamsBotApplication();
+
+bot.OnMessage(async (ctx, ct) =>
+{
+    var clock = Stopwatch.StartNew();
+    var text = ctx.Activity.Text;
+    var replyText = $"Echo: {text}";
+    await ctx.SendActivityAsync(replyText, ct);
+
+    var diagnosticInfo = $"sdk version: {TeamsBotApplication.Version} os: {Environment.OSVersion}";
+    diagnosticInfo += $" auth latency: {clock.Elapsed.TotalMilliseconds}ms";
+    await ctx.SendActivityAsync(diagnosticInfo, ct);
+});
+
+app.Run();

--- a/core/samples/CachingAuthTokens/appsettings.json
+++ b/core/samples/CachingAuthTokens/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.Teams": "Information"
+    }
+  },
+  "ConnectionStrings": {
+    "Redis": "localhost:6379"
+  },
+  "AllowedHosts": "*"
+}

--- a/core/src/Microsoft.Teams.Core/Hosting/AddBotApplicationExtensions.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/AddBotApplicationExtensions.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Web;
-using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
+using Microsoft.Identity.Web.TokenCacheProviders.Distributed;
 
 namespace Microsoft.Teams.Core.Hosting;
 
@@ -157,7 +157,7 @@ public static class AddBotApplicationExtensions
     {
         services.AddHttpClient()
                 .AddTokenAcquisition(true)
-                .AddInMemoryTokenCaches()
+                .AddDistributedTokenCaches()
                 .AddAgentIdentities();
 
         ArgumentNullException.ThrowIfNull(botConfig);


### PR DESCRIPTION
Introduce CachingAuthTokens sample project using .NET 10.0 and StackExchange.Redis for distributed token caching. Update AddBotApplicationExtensions to use distributed token caches instead of in-memory. Add appsettings.json for configuration and implement a basic echo bot in Program.cs that reports SDK version, OS, and reply latency. Update solution file to include the new sample.