### PR TITLE
fix: rename misleading latency label in CachingAuthTokens sample

### DIFF
--- a/core/samples/CachingAuthTokens/Program.cs
+++ b/core/samples/CachingAuthTokens/Program.cs
@@ -22,7 +22,7 @@ bot.OnMessage(async (ctx, ct) =>
     await ctx.SendActivityAsync(replyText, ct);
 
     var diagnosticInfo = $"sdk version: {TeamsBotApplication.Version} os: {Environment.OSVersion}";
-    diagnosticInfo += $" auth latency: {clock.Elapsed.TotalMilliseconds}ms";
+    diagnosticInfo += $" reply latency: {clock.Elapsed.TotalMilliseconds}ms";
     await ctx.SendActivityAsync(diagnosticInfo, ct);
 });
 


### PR DESCRIPTION
Follow-up to #561.

The stopwatch in the CachingAuthTokens sample measures `SendActivityAsync` round-trip time, not token acquisition latency. This renames the label from "auth latency" to "reply latency" to accurately reflect what is being measured.