### PR TITLE
test: add Trait categories to integration tests

### DIFF
--- a/core/test/IntegrationTests/ApiClientTests.cs
+++ b/core/test/IntegrationTests/ApiClientTests.cs
@@ -48,6 +48,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     #region Activities
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Activities")]
     public async Task Activities_CreateAsync()
     {
         CoreActivity activity = CreateMessageActivity($"[ApiClient.Activities.Create] at `{DateTime.UtcNow:s}`");
@@ -60,6 +61,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Activities")]
     public async Task Activities_UpdateAsync()
     {
         CoreActivity original = CreateMessageActivity($"[ApiClient.Activities.Update] Original at `{DateTime.UtcNow:s}`");
@@ -77,6 +79,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Activities")]
     public async Task Activities_ReplyAsync()
     {
         CoreActivity original = CreateMessageActivity($"[ApiClient.Activities.Reply] Parent at `{DateTime.UtcNow:s}`");
@@ -94,6 +97,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Activities")]
     public async Task Activities_DeleteAsync()
     {
         CoreActivity activity = CreateMessageActivity($"[ApiClient.Activities.Delete] at `{DateTime.UtcNow:s}`");
@@ -112,6 +116,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     #region Targeted Activities
 
     [SkippableFact]
+    [Trait("Category", "Activities")]
     public async Task Activities_CreateTargetedAsync()
     {
         Skip.If(_f.AgenticIdentity is not null, "Targeted activities return 500 with agentic identity — service limitation");
@@ -128,6 +133,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [SkippableFact]
+    [Trait("Category", "Activities")]
     public async Task Activities_UpdateTargetedAsync()
     {
         Skip.If(_f.AgenticIdentity is not null, "Targeted activities return 500 with agentic identity — service limitation");
@@ -148,6 +154,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [SkippableFact]
+    [Trait("Category", "Activities")]
     public async Task Activities_DeleteTargetedAsync()
     {
         Skip.If(_f.AgenticIdentity is not null, "Targeted activities return 500 with agentic identity — service limitation");
@@ -169,6 +176,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     #region Members
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Members")]
     public async Task Members_GetAsync()
     {
         IList<TeamsConversationAccount?> members = await _api.Conversations.Members.GetAsync(_f.ConversationId, _f.AgenticIdentity);
@@ -183,6 +191,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [SkippableFact(Timeout = 5000)]
+    [Trait("Category", "Members")]
     public async Task Members_GetPagedAsync()
     {
         Skip.If(_f.AgenticIdentity is not null, "Paged members returns 500 with agentic identity — service limitation");
@@ -200,6 +209,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
 
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Members")]
     public async Task Members_GetByIdAsync()
     {
         string memberId = _f.MemberMri1!;
@@ -213,6 +223,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Members")]
     public async Task Members_GetByIdAsync_AsTeamsConversationAccount()
     {
         string memberId = _f.MemberMri1!;
@@ -230,6 +241,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     #region Reactions
 
     [SkippableFact]
+    [Trait("Category", "Reactions")]
     public async Task Reactions_AddAndDelete()
     {
         Skip.If(_f.AgenticIdentity is not null, "Reactions API returns 404 with agentic identity — service limitation");
@@ -254,6 +266,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     #region Teams
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Teams")]
     public async Task Teams_GetByIdAsync()
     {
         Team? team = await _api.Teams.GetByIdAsync(_f.TeamId, _f.AgenticIdentity);
@@ -263,6 +276,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Teams")]
     public async Task Teams_GetConversationsAsync()
     {
         List<TeamsChannel>? channels = await _api.Teams.GetConversationsAsync(_f.TeamId, _f.AgenticIdentity);
@@ -281,6 +295,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     #region Meetings
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Meetings")]
     public async Task Meetings_GetByIdAsync()
     {
         Meeting? meeting = await _api.Meetings.GetByIdAsync(_f.MeetingId, _f.AgenticIdentity);
@@ -294,6 +309,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [SkippableFact(Timeout = 15000)]
+    [Trait("Category", "Meetings")]
     public async Task Meetings_GetParticipantAsync()
     {
         // The meetings participant API requires AAD object ID, not MRI/pairwise bot framework ID.
@@ -332,6 +348,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     #region Bots — SignIn
 
     [SkippableFact(Timeout = 5000)]
+    [Trait("Category", "Bots")]
     public async Task Bots_SignIn_GetUrlAsync()
     {
         Skip.If(_f.AgenticIdentity is not null, "UserTokenClient does not support agentic identity");
@@ -358,6 +375,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [SkippableFact(Timeout = 5000)]
+    [Trait("Category", "Bots")]
     public async Task Bots_SignIn_GetResourceAsync()
     {
         Skip.If(_f.AgenticIdentity is not null, "UserTokenClient does not support agentic identity");
@@ -388,6 +406,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     #region Users — Token
 
     [SkippableFact(Timeout = 5000)]
+    [Trait("Category", "Users")]
     public async Task Users_Token_GetStatusAsync()
     {
         Skip.If(_f.AgenticIdentity is not null, "UserTokenClient does not support agentic identity");
@@ -408,6 +427,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [SkippableFact(Timeout = 5000)]
+    [Trait("Category", "Users")]
     public async Task Users_Token_GetAsync()
     {
         Skip.If(_f.AgenticIdentity is not null, "UserTokenClient does not support agentic identity");
@@ -420,6 +440,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [SkippableFact(Timeout = 5000)]
+    [Trait("Category", "Users")]
     public async Task Users_Token_SignOutAsync()
     {
         Skip.If(_f.AgenticIdentity is not null, "UserTokenClient does not support agentic identity");
@@ -436,6 +457,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     #region ForServiceUrl
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Client")]
     public async Task ForServiceUrl_CreatesScopedClient()
     {
         ApiClient scoped = _f.ApiClient.ForServiceUrl(_f.ServiceUrl);

--- a/core/test/IntegrationTests/CompatTeamsInfoTests.cs
+++ b/core/test/IntegrationTests/CompatTeamsInfoTests.cs
@@ -107,6 +107,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     #region Member Methods (non-team scope)
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Members")]
     public async Task GetMemberAsync_ReturnsTeamsChannelAccount()
     {
         string memberId = _f.MemberMri1!;
@@ -120,6 +121,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Members")]
     public async Task GetMembersAsync_ReturnsTeamsChannelAccounts()
     {
         using TurnContext ctx = CreateTurnContext();
@@ -136,6 +138,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [SkippableFact(Timeout = 5000)]
+    [Trait("Category", "Members")]
     public async Task GetPagedMembersAsync_ReturnsPaged()
     {
         Skip.If(_f.AgenticIdentity is not null, "Paged members returns 500 with agentic identity — service limitation");
@@ -161,6 +164,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     #region Team-scoped Member Methods
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Members")]
     public async Task GetTeamMemberAsync_ReturnsTeamsChannelAccount()
     {
         string memberId = _f.MemberMri1!;
@@ -174,6 +178,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Members")]
     public async Task GetMemberAsync_WithTeamScope_DelegatesToGetTeamMember()
     {
         string memberId = _f.MemberMri1!;
@@ -187,6 +192,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Members")]
     public async Task GetTeamMembersAsync_ReturnsMembers()
     {
         using TurnContext ctx = CreateTurnContext(teamId: _f.TeamId);
@@ -203,6 +209,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [SkippableFact(Timeout = 5000)]
+    [Trait("Category", "Members")]
     public async Task GetPagedTeamMembersAsync_ReturnsPaged()
     {
         Skip.If(_f.AgenticIdentity is not null, "Paged members returns 500 with agentic identity — service limitation");
@@ -228,6 +235,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     #region Team & Channel Methods
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Teams")]
     public async Task GetTeamDetailsAsync_ReturnsDetails()
     {
 
@@ -241,6 +249,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Teams")]
     public async Task GetTeamDetailsAsync_InfersTeamIdFromActivity()
     {
 
@@ -254,6 +263,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Teams")]
     public async Task GetTeamChannelsAsync_ReturnsChannels()
     {
 
@@ -271,6 +281,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Teams")]
     public async Task GetTeamChannelsAsync_InfersTeamIdFromActivity()
     {
 
@@ -288,6 +299,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     #region Meeting Methods
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Meetings")]
     public async Task GetMeetingParticipantAsync_ReturnsParticipant()
     {
 
@@ -329,6 +341,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     #region Error Cases
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "ErrorHandling")]
     public async Task GetTeamDetailsAsync_ThrowsWithoutTeamScope()
     {
         // No teamId in activity and no explicit teamId parameter
@@ -338,6 +351,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "ErrorHandling")]
     public async Task GetTeamChannelsAsync_ThrowsWithoutTeamScope()
     {
         using TurnContext ctx = CreateTurnContext();
@@ -346,6 +360,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "ErrorHandling")]
     public async Task GetMemberAsync_ThrowsWithNullUserId()
     {
         using TurnContext ctx = CreateTurnContext();

--- a/core/test/IntegrationTests/ConversationClientTests.cs
+++ b/core/test/IntegrationTests/ConversationClientTests.cs
@@ -23,6 +23,7 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Activities")]
     public async Task SendActivity()
     {
         CoreActivity activity = CoreActivity.CreateBuilder()
@@ -41,6 +42,7 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Activities")]
     public async Task UpdateActivity()
     {
         CoreActivity activity = CoreActivity.CreateBuilder()
@@ -70,6 +72,7 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Activities")]
     public async Task DeleteActivity()
     {
         CoreActivity activity = CoreActivity.CreateBuilder()
@@ -92,6 +95,7 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Activities")]
     public async Task GetConversationMembers()
     {
         IList<ConversationAccount> members = await _f.ConversationClient.GetConversationMembersAsync(
@@ -107,6 +111,7 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Activities")]
     public async Task GetConversationMember()
     {
         string memberId = _f.MemberMri1!;
@@ -120,6 +125,7 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [SkippableFact(Timeout = 5000)]
+    [Trait("Category", "Activities")]
     public async Task GetPagedMembers()
     {
         Skip.If(_f.AgenticIdentity is not null, "Paged members returns 500 with agentic identity — service limitation");
@@ -138,6 +144,7 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
     }
 
     [SkippableFact]
+    [Trait("Category", "Activities")]
     public async Task AddAndDeleteReaction()
     {
         Skip.If(_f.AgenticIdentity is not null, "Reactions API returns 404 with agentic identity — service limitation");

--- a/core/test/IntegrationTests/CreateConversationDiagnosticTests.cs
+++ b/core/test/IntegrationTests/CreateConversationDiagnosticTests.cs
@@ -121,6 +121,7 @@ public class CreateConversationDiagnosticTests : IClassFixture<IntegrationTestFi
     // =========================================================================
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Diagnostic")]
     public async Task PersonalChat_MinimalParams()
     {
         (string memberMri, _, _) = await GetMemberMrisAsync();
@@ -134,6 +135,7 @@ public class CreateConversationDiagnosticTests : IClassFixture<IntegrationTestFi
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Diagnostic")]
     public async Task PersonalChat_WithBot()
     {
         (string memberMri, _, _) = await GetMemberMrisAsync();
@@ -148,6 +150,7 @@ public class CreateConversationDiagnosticTests : IClassFixture<IntegrationTestFi
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Diagnostic")]
     public async Task PersonalChat_WithInitialActivity()
     {
         (string memberMri, _, _) = await GetMemberMrisAsync();
@@ -169,6 +172,7 @@ public class CreateConversationDiagnosticTests : IClassFixture<IntegrationTestFi
     // =========================================================================
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Diagnostic")]
     public async Task GroupChat_TwoMembers_NoBotNoChannelData()
     {
         (string first, string? second, _) = await GetMemberMrisAsync();
@@ -183,6 +187,7 @@ public class CreateConversationDiagnosticTests : IClassFixture<IntegrationTestFi
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Diagnostic")]
     public async Task GroupChat_TwoMembers_WithBot()
     {
         (string first, string? second, _) = await GetMemberMrisAsync();
@@ -198,6 +203,7 @@ public class CreateConversationDiagnosticTests : IClassFixture<IntegrationTestFi
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Diagnostic")]
     public async Task GroupChat_TwoMembers_WithBotAndChannelData()
     {
         (string first, string? second, _) = await GetMemberMrisAsync();
@@ -214,6 +220,7 @@ public class CreateConversationDiagnosticTests : IClassFixture<IntegrationTestFi
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Diagnostic")]
     public async Task GroupChat_TwoMembers_WithTopicAndActivity()
     {
         (string first, string? second, _) = await GetMemberMrisAsync();
@@ -235,6 +242,7 @@ public class CreateConversationDiagnosticTests : IClassFixture<IntegrationTestFi
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Diagnostic")]
     public async Task GroupChat_OneMember_IsGroupTrue()
     {
         (string memberMri, _, _) = await GetMemberMrisAsync();
@@ -248,6 +256,7 @@ public class CreateConversationDiagnosticTests : IClassFixture<IntegrationTestFi
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Diagnostic")]
     public async Task GroupChat_OneMember_WithBot()
     {
         (string memberMri, _, _) = await GetMemberMrisAsync();
@@ -263,6 +272,7 @@ public class CreateConversationDiagnosticTests : IClassFixture<IntegrationTestFi
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Diagnostic")]
     public async Task GroupChat_ThreeMembers()
     {
         (string first, string? second, string? third) = await GetMemberMrisAsync();
@@ -284,6 +294,7 @@ public class CreateConversationDiagnosticTests : IClassFixture<IntegrationTestFi
     // =========================================================================
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Diagnostic")]
     public async Task ChannelThread_WithActivity()
     {
         DiagnosticResult result = await SendDiagnosticRequestAsync("Channel Thread: with activity", new()
@@ -300,6 +311,7 @@ public class CreateConversationDiagnosticTests : IClassFixture<IntegrationTestFi
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Diagnostic")]
     public async Task ChannelThread_NoActivity()
     {
         DiagnosticResult result = await SendDiagnosticRequestAsync("Channel Thread: without activity", new()
@@ -312,6 +324,7 @@ public class CreateConversationDiagnosticTests : IClassFixture<IntegrationTestFi
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Diagnostic")]
     public async Task ChannelThread_WithMembersAndActivity()
     {
         (string memberMri, _, _) = await GetMemberMrisAsync();

--- a/core/test/IntegrationTests/CreateConversationTests.cs
+++ b/core/test/IntegrationTests/CreateConversationTests.cs
@@ -43,6 +43,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
     #region Personal Chat (1:1) — Core ConversationClient
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Conversations")]
     public async Task Core_CreatePersonalChat()
     {
         (string memberMri, _) = await GetMemberMrisAsync();
@@ -63,6 +64,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Conversations")]
     public async Task Core_CreatePersonalChat_AndSendMessage()
     {
         (string memberMri, _) = await GetMemberMrisAsync();
@@ -93,6 +95,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Conversations")]
     public async Task Core_CreatePersonalChat_WithInitialActivity()
     {
         (string memberMri, _) = await GetMemberMrisAsync();
@@ -121,6 +124,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
     #region Group Chat — Core ConversationClient
 
     [Fact]
+    [Trait("Category", "Conversations")]
     public async Task Core_CreateGroupChat()
     {
         (string first, string? second) = await GetMemberMrisAsync();
@@ -153,6 +157,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact]
+    [Trait("Category", "Conversations")]
     public async Task Core_CreateGroupChat_AndSendMessage()
     {
         (string first, string? second) = await GetMemberMrisAsync();
@@ -198,6 +203,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
     #region Channel Thread — Core ConversationClient
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Conversations")]
     public async Task Core_CreateChannelThread()
     {
         ConversationParameters parameters = new()
@@ -224,6 +230,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
     #region Personal Chat — ApiClient
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Conversations")]
     public async Task ApiClient_CreatePersonalChat()
     {
         (string memberMri, _) = await GetMemberMrisAsync();
@@ -243,6 +250,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Conversations")]
     public async Task ApiClient_CreatePersonalChat_AndSendViaActivities()
     {
         (string memberMri, _) = await GetMemberMrisAsync();
@@ -273,6 +281,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
     #region Group Chat — ApiClient
 
     [Fact]
+    [Trait("Category", "Conversations")]
     public async Task ApiClient_CreateGroupChat()
     {
         (string first, string? second) = await GetMemberMrisAsync();
@@ -308,6 +317,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
     #region Channel Thread — ApiClient
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Conversations")]
     public async Task ApiClient_CreateChannelThread()
     {
         ConversationParameters parameters = new()
@@ -329,6 +339,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact(Timeout = 5000)]
+    [Trait("Category", "Conversations")]
     public async Task ApiClient_CreateChannelThread_AndReply()
     {
         ConversationParameters parameters = new()

--- a/core/test/IntegrationTests/README.md
+++ b/core/test/IntegrationTests/README.md
@@ -60,15 +60,41 @@ Place your `.runsettings` files in the `.runsettings/` directory (gitignored).
 ## Running Tests
 
 ```bash
-# From core/test directory
+# All tests
 dotnet test IntegrationTests/IntegrationTests.csproj \
   --settings IntegrationTests/.runsettings/botid-prod.runsettings -v d
+
+# By category
+dotnet test IntegrationTests/IntegrationTests.csproj \
+  --settings IntegrationTests/.runsettings/botid-prod.runsettings \
+  --filter "Category=Activities"
+
+# Exclude slow diagnostic tests
+dotnet test IntegrationTests/IntegrationTests.csproj \
+  --settings IntegrationTests/.runsettings/botid-prod.runsettings \
+  --filter "Category!=Diagnostic"
 
 # With TRX output for CI
 dotnet test IntegrationTests/IntegrationTests.csproj \
   --settings IntegrationTests/.runsettings/botid-prod.runsettings \
   --logger "trx;LogFileName=botid-prod.trx"
 ```
+
+### Trait Categories
+
+| Category | Tests | Description |
+|----------|-------|-------------|
+| `Activities` | 14 | Send, update, delete, reply (including targeted) |
+| `Members` | 7 | Get members, paged, by ID |
+| `Conversations` | 11 | Create 1:1, group, channel thread |
+| `Reactions` | 1 | Add and delete reactions |
+| `Teams` | 6 | Get team details, channels |
+| `Meetings` | 3 | Get participant, meeting details |
+| `Bots` | 2 | Sign-in URL and resource |
+| `Users` | 3 | Token get, status, sign-out |
+| `Client` | 1 | ForServiceUrl scoped client |
+| `Diagnostic` | 13 | Conversation creation matrix |
+| `ErrorHandling` | 3 | Error cases (compat layer) |
 
 ## Architecture
 

--- a/core/test/IntegrationTests/README.md
+++ b/core/test/IntegrationTests/README.md
@@ -60,7 +60,7 @@ Place your `.runsettings` files in the `.runsettings/` directory (gitignored).
 ## Running Tests
 
 ```bash
-# All tests
+# From core/test/ directory:
 dotnet test IntegrationTests/IntegrationTests.csproj \
   --settings IntegrationTests/.runsettings/botid-prod.runsettings -v d
 
@@ -85,7 +85,7 @@ dotnet test IntegrationTests/IntegrationTests.csproj \
 | Category | Tests | Description |
 |----------|-------|-------------|
 | `Activities` | 14 | Send, update, delete, reply (including targeted) |
-| `Members` | 7 | Get members, paged, by ID |
+| `Members` | 11 | Get members, paged, by ID |
 | `Conversations` | 11 | Create 1:1, group, channel thread |
 | `Reactions` | 1 | Add and delete reactions |
 | `Teams` | 6 | Get team details, channels |


### PR DESCRIPTION
Adds `[Trait("Category", "...")]` to all 68 integration tests for selective CI filtering.

**Categories:** Activities, Members, Conversations, Reactions, Teams, Meetings, Bots, Users, Client, Diagnostic, ErrorHandling

**Usage:**
```bash
# Run only activities tests
dotnet test --filter "Category=Activities"

# Exclude slow diagnostic matrix
dotnet test --filter "Category!=Diagnostic"
```

Follow-up to #570.