### PR TITLE
Remove ExperimentalTeamsQuotedReplies markers

### DIFF
--- a/Libraries/Microsoft.Teams.Api/Activities/Activity.Convertible.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Activity.Convertible.cs
@@ -27,9 +27,9 @@ public partial class Activity : IConvertible
         if (type == ActivityType.Command.ToType()) return ToCommand();
         if (type == ActivityType.CommandResult.ToType()) return ToCommandResult();
         if (type == ActivityType.ConversationUpdate.ToType()) return ToConversationUpdate();
-        #pragma warning disable CS0618
+#pragma warning disable CS0618
         if (type == ActivityType.EndOfConversation.ToType()) return ToEndOfConversation();
-        #pragma warning restore CS0618
+#pragma warning restore CS0618
         if (type == ActivityType.InstallUpdate.ToType()) return ToInstallUpdate();
         if (type == ActivityType.Typing.ToType()) return ToTyping();
         if (type == ActivityType.Message.ToType()) return ToMessage();

--- a/Libraries/Microsoft.Teams.Api/Activities/Activity.JsonConverter.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Activity.JsonConverter.cs
@@ -64,9 +64,9 @@ public partial class Activity
                 "messageDelete" => element.Deserialize<MessageDeleteActivity>(options),
                 "messageReaction" => element.Deserialize<MessageReactionActivity>(options),
                 "conversationUpdate" => element.Deserialize<ConversationUpdateActivity>(options),
-                #pragma warning disable CS0618
+#pragma warning disable CS0618
                 "endOfConversation" => element.Deserialize<EndOfConversationActivity>(options),
-                #pragma warning restore CS0618
+#pragma warning restore CS0618
                 "installationUpdate" => element.Deserialize<InstallUpdateActivity>(options),
                 "command" => element.Deserialize<CommandActivity>(options),
                 "commandResult" => element.Deserialize<CommandResultActivity>(options),
@@ -122,13 +122,13 @@ public partial class Activity
                 return;
             }
 
-            #pragma warning disable CS0618
+#pragma warning disable CS0618
             if (value is EndOfConversationActivity endOfConversation)
             {
                 JsonSerializer.Serialize(writer, endOfConversation, options);
                 return;
             }
-            #pragma warning restore CS0618
+#pragma warning restore CS0618
 
             if (value is CommandActivity command)
             {

--- a/Libraries/Microsoft.Teams.Api/Activities/Activity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Activity.cs
@@ -19,9 +19,9 @@ public partial class ActivityType(string value) : StringEnum(value)
         if (IsCommand) return typeof(CommandActivity);
         if (IsCommandResult) return typeof(CommandResultActivity);
         if (IsConversationUpdate) return typeof(ConversationUpdateActivity);
-        #pragma warning disable CS0618
+#pragma warning disable CS0618
         if (IsEndOfConversation) return typeof(EndOfConversationActivity);
-        #pragma warning restore CS0618
+#pragma warning restore CS0618
         if (IsInstallUpdate) return typeof(InstallUpdateActivity);
         if (IsMessage) return typeof(MessageActivity);
         if (IsMessageUpdate) return typeof(MessageUpdateActivity);
@@ -181,9 +181,9 @@ public partial class Activity : IActivity
         From = activity.From;
         Recipient = activity.Recipient;
         Conversation = activity.Conversation;
-        #pragma warning disable CS0618
+#pragma warning disable CS0618
         RelatesTo = activity.RelatesTo;
-        #pragma warning restore CS0618
+#pragma warning restore CS0618
         ServiceUrl = activity.ServiceUrl;
         Locale = activity.Locale;
         Timestamp = activity.Timestamp;
@@ -227,9 +227,9 @@ public partial class Activity : IActivity
     [Obsolete("This will be removed by end of summer 2026.")]
     public virtual Activity WithRelatesTo(ConversationReference value)
     {
-        #pragma warning disable CS0618
+#pragma warning disable CS0618
         RelatesTo = value;
-        #pragma warning restore CS0618
+#pragma warning restore CS0618
         return this;
     }
 
@@ -506,9 +506,9 @@ public partial class Activity : IActivity
     public MessageDeleteActivity ToMessageDelete() => (MessageDeleteActivity)this;
     public MessageReactionActivity ToMessageReaction() => (MessageReactionActivity)this;
     public ConversationUpdateActivity ToConversationUpdate() => (ConversationUpdateActivity)this;
-    #pragma warning disable CS0618
+#pragma warning disable CS0618
     public EndOfConversationActivity ToEndOfConversation() => (EndOfConversationActivity)this;
-    #pragma warning restore CS0618
+#pragma warning restore CS0618
     public EventActivity ToEvent() => (EventActivity)this;
     public InvokeActivity ToInvoke() => (InvokeActivity)this;
 
@@ -520,9 +520,9 @@ public partial class Activity : IActivity
         From ??= from.From;
         Recipient ??= from.Recipient;
         Conversation ??= from.Conversation;
-        #pragma warning disable CS0618
+#pragma warning disable CS0618
         RelatesTo ??= from.RelatesTo;
-        #pragma warning restore CS0618
+#pragma warning restore CS0618
         ServiceUrl ??= from.ServiceUrl;
         Locale ??= from.Locale;
         Timestamp ??= from.Timestamp;

--- a/Libraries/Microsoft.Teams.Api/Activities/Message/MessageActivity.cs
+++ b/Libraries/Microsoft.Teams.Api/Activities/Message/MessageActivity.cs
@@ -77,14 +77,11 @@ public class MessageActivity : Activity
     /// <summary>
     /// Get all quoted reply entities from this message.
     /// </summary>
-    [Experimental("ExperimentalTeamsQuotedReplies")]
-#pragma warning disable ExperimentalTeamsQuotedReplies
     public IReadOnlyList<QuotedReplyEntity> GetQuotedMessages()
     {
         return Entities?.OfType<QuotedReplyEntity>().ToList()
             ?? new List<QuotedReplyEntity>();
     }
-#pragma warning restore ExperimentalTeamsQuotedReplies
 
     public MessageActivity() : base(ActivityType.Message)
     {
@@ -105,18 +102,18 @@ public class MessageActivity : Activity
     [Obsolete("This will be removed by end of summer 2026.")]
     public MessageActivity WithSpeak(string speak)
     {
-        #pragma warning disable CS0618
+#pragma warning disable CS0618
         Speak = speak;
-        #pragma warning restore CS0618
+#pragma warning restore CS0618
         return this;
     }
 
     [Obsolete("This will be removed by end of summer 2026.")]
     public MessageActivity WithInputHint(InputHint inputHint)
     {
-        #pragma warning disable CS0618
+#pragma warning disable CS0618
         InputHint = inputHint;
-        #pragma warning restore CS0618
+#pragma warning restore CS0618
         return this;
     }
 
@@ -147,9 +144,9 @@ public class MessageActivity : Activity
     [Obsolete("This will be removed by end of summer 2026.")]
     public MessageActivity WithImportance(Importance importance)
     {
-        #pragma warning disable CS0618
+#pragma warning disable CS0618
         Importance = importance;
-        #pragma warning restore CS0618
+#pragma warning restore CS0618
         return this;
     }
 
@@ -162,9 +159,9 @@ public class MessageActivity : Activity
     [Obsolete("This will be removed by end of summer 2026.")]
     public MessageActivity WithExpiration(DateTime expiration)
     {
-        #pragma warning disable CS0618
+#pragma warning disable CS0618
         Expiration = expiration;
-        #pragma warning restore CS0618
+#pragma warning restore CS0618
         return this;
     }
 
@@ -194,8 +191,6 @@ public class MessageActivity : Activity
     /// </summary>
     /// <param name="messageId">the ID of the message to quote</param>
     /// <param name="text">optional text, appended to the quoted message placeholder</param>
-    [Experimental("ExperimentalTeamsQuotedReplies")]
-#pragma warning disable ExperimentalTeamsQuotedReplies
     public MessageActivity AddQuote(string messageId, string? text = null)
     {
         Entities ??= new List<IEntity>();
@@ -210,14 +205,11 @@ public class MessageActivity : Activity
         }
         return this;
     }
-#pragma warning restore ExperimentalTeamsQuotedReplies
 
     /// <summary>
     /// Prepend a QuotedReply entity and placeholder before existing text.
     /// Used by Reply()/Quote() for quote-above-response.
     /// </summary>
-    [Experimental("ExperimentalTeamsQuotedReplies")]
-#pragma warning disable ExperimentalTeamsQuotedReplies
     public MessageActivity PrependQuote(string messageId)
     {
         Entities ??= new List<IEntity>();
@@ -230,7 +222,6 @@ public class MessageActivity : Activity
         Text = hasText ? $"{placeholder} {Text}" : placeholder;
         return this;
     }
-#pragma warning restore ExperimentalTeamsQuotedReplies
 
 
     public MessageActivity AddAttachment(params Attachment[] value)
@@ -303,12 +294,12 @@ public class MessageActivity : Activity
         base.Merge(from);
 
         Text ??= from.Text;
-        #pragma warning disable CS0618
+#pragma warning disable CS0618
         Speak ??= from.Speak;
         InputHint ??= from.InputHint;
         Importance ??= from.Importance;
         Expiration ??= from.Expiration;
-        #pragma warning restore CS0618
+#pragma warning restore CS0618
         Summary ??= from.Summary;
         TextFormat ??= from.TextFormat;
         AttachmentLayout ??= from.AttachmentLayout;

--- a/Libraries/Microsoft.Teams.Api/Entities/Entity.cs
+++ b/Libraries/Microsoft.Teams.Api/Entities/Entity.cs
@@ -117,12 +117,10 @@ public class Entity : IEntity
                 "message" or "https://schema.org/Message" => (Entity?)element.Deserialize<IMessageEntity>(options),
                 "ProductInfo" => element.Deserialize<ProductInfoEntity>(options),
                 "streaminfo" => element.Deserialize<StreamInfoEntity>(options),
-                #pragma warning disable ExperimentalTeamsTargeted
+#pragma warning disable ExperimentalTeamsTargeted
                 "targetedMessageInfo" => element.Deserialize<TargetedMessageInfoEntity>(options),
-                #pragma warning restore ExperimentalTeamsTargeted
-                #pragma warning disable ExperimentalTeamsQuotedReplies
+#pragma warning restore ExperimentalTeamsTargeted
                 "quotedReply" => element.Deserialize<QuotedReplyEntity>(options),
-                #pragma warning restore ExperimentalTeamsQuotedReplies
                 _ => null
             };
 
@@ -167,21 +165,19 @@ public class Entity : IEntity
                 return;
             }
 
-            #pragma warning disable ExperimentalTeamsTargeted
+#pragma warning disable ExperimentalTeamsTargeted
             if (value is TargetedMessageInfoEntity targetedMessageInfo)
             {
                 JsonSerializer.Serialize(writer, targetedMessageInfo, options);
                 return;
             }
-            #pragma warning restore ExperimentalTeamsTargeted
+#pragma warning restore ExperimentalTeamsTargeted
 
-            #pragma warning disable ExperimentalTeamsQuotedReplies
             if (value is QuotedReplyEntity quotedReply)
             {
                 JsonSerializer.Serialize(writer, quotedReply, options);
                 return;
             }
-            #pragma warning restore ExperimentalTeamsQuotedReplies
 
             JsonSerializer.Serialize(writer, value.ToJsonObject(options), options);
         }

--- a/Libraries/Microsoft.Teams.Api/Entities/QuotedReplyEntity.cs
+++ b/Libraries/Microsoft.Teams.Api/Entities/QuotedReplyEntity.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Teams.Api.Entities;
 
-[Experimental("ExperimentalTeamsQuotedReplies")]
 public class QuotedReplyEntity : Entity
 {
     [JsonPropertyName("quotedReply")]
@@ -16,7 +14,6 @@ public class QuotedReplyEntity : Entity
     public QuotedReplyEntity() : base("quotedReply") { }
 }
 
-[Experimental("ExperimentalTeamsQuotedReplies")]
 public class QuotedReplyData
 {
     [JsonPropertyName("messageId")]

--- a/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ConversationEndActivity.cs
+++ b/Libraries/Microsoft.Teams.Apps/Activities/Conversations/ConversationEndActivity.cs
@@ -10,18 +10,18 @@ public static partial class Conversation
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true)]
     [Obsolete("This will be removed by end of summer 2026.")]
-    #pragma warning disable CS0618
+#pragma warning disable CS0618
     public class EndAttribute() : ActivityAttribute(ActivityType.EndOfConversation, typeof(EndOfConversationActivity))
     {
         public override object Coerce(IContext<IActivity> context) => context.ToActivityType<EndOfConversationActivity>();
     }
-    #pragma warning restore CS0618
+#pragma warning restore CS0618
 }
 
 public static partial class AppActivityExtensions
 {
     [Obsolete("Use the handler with the cancellation token. This will be removed by end of summer 2026.")]
-    #pragma warning disable CS0618
+#pragma warning disable CS0618
     public static App OnConversationEnd(this App app, Func<IContext<EndOfConversationActivity>, Task> handler)
     {
         app.Router.Register(new Route()
@@ -38,10 +38,10 @@ public static partial class AppActivityExtensions
 
         return app;
     }
-    #pragma warning restore CS0618
+#pragma warning restore CS0618
 
     [Obsolete("This will be removed by end of summer 2026.")]
-    #pragma warning disable CS0618
+#pragma warning disable CS0618
     public static App OnConversationEnd(this App app, Func<IContext<EndOfConversationActivity>, CancellationToken, Task> handler)
     {
         app.Router.Register(new Route()
@@ -58,5 +58,5 @@ public static partial class AppActivityExtensions
 
         return app;
     }
-    #pragma warning restore CS0618
+#pragma warning restore CS0618
 }

--- a/Libraries/Microsoft.Teams.Apps/Contexts/Context.Send.cs
+++ b/Libraries/Microsoft.Teams.Apps/Contexts/Context.Send.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.Teams.Api.Activities;
 
@@ -64,7 +63,6 @@ public partial interface IContext<TActivity>
     /// <param name="messageId">the ID of the message to quote</param>
     /// <param name="activity">the activity to send — a quote placeholder for messageId will be prepended to its text</param>
     /// <param name="cancellationToken">optional cancellation token</param>
-    [Experimental("ExperimentalTeamsQuotedReplies")]
     public Task<T> Quote<T>(string messageId, T activity, CancellationToken cancellationToken = default) where T : IActivity;
 
     /// <summary>
@@ -74,7 +72,6 @@ public partial interface IContext<TActivity>
     /// <param name="messageId">the ID of the message to quote</param>
     /// <param name="text">the response text, appended to the quoted message placeholder</param>
     /// <param name="cancellationToken">optional cancellation token</param>
-    [Experimental("ExperimentalTeamsQuotedReplies")]
     public Task<MessageActivity> Quote(string messageId, string text, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -91,12 +88,12 @@ public partial class Context<TActivity> : IContext<TActivity>
     {
         // Auto-populate targetedMessageInfo entity for prompt preview
         // when the incoming activity was a targeted message (reactive flow).
-        #pragma warning disable ExperimentalTeamsTargeted
+#pragma warning disable ExperimentalTeamsTargeted
         if (activity is MessageActivity messageActivity && Activity.Recipient?.IsTargeted == true && Activity.Id is not null)
         {
             messageActivity.AddTargetedMessageInfo(Activity.Id);
         }
-        #pragma warning restore ExperimentalTeamsTargeted
+#pragma warning restore ExperimentalTeamsTargeted
 
         var res = await Sender.Send(activity, Ref, cancellationToken);
         await OnActivitySent(res, ToActivityType<IActivity>());
@@ -113,7 +110,6 @@ public partial class Context<TActivity> : IContext<TActivity>
         return Send(new MessageActivity().AddAttachment(card), cancellationToken);
     }
 
-#pragma warning disable ExperimentalTeamsQuotedReplies
     public Task<T> Reply<T>(T activity, CancellationToken cancellationToken = default) where T : IActivity
     {
         if (Activity.Id != null)
@@ -123,7 +119,6 @@ public partial class Context<TActivity> : IContext<TActivity>
 
         return Send(activity, cancellationToken);
     }
-#pragma warning restore ExperimentalTeamsQuotedReplies
 
     public Task<MessageActivity> Reply(string text, CancellationToken cancellationToken = default)
     {
@@ -135,8 +130,6 @@ public partial class Context<TActivity> : IContext<TActivity>
         return Reply(new MessageActivity().AddAttachment(card), cancellationToken);
     }
 
-    [Experimental("ExperimentalTeamsQuotedReplies")]
-#pragma warning disable ExperimentalTeamsQuotedReplies
     public Task<T> Quote<T>(string messageId, T activity, CancellationToken cancellationToken = default) where T : IActivity
     {
         if (activity is MessageActivity message)
@@ -146,9 +139,7 @@ public partial class Context<TActivity> : IContext<TActivity>
 
         return Send(activity, cancellationToken);
     }
-#pragma warning restore ExperimentalTeamsQuotedReplies
 
-    [Experimental("ExperimentalTeamsQuotedReplies")]
     public Task<MessageActivity> Quote(string messageId, string text, CancellationToken cancellationToken = default)
     {
         return Quote(messageId, new MessageActivity(text), cancellationToken);

--- a/Samples/Samples.Quoting/Samples.Quoting.csproj
+++ b/Samples/Samples.Quoting/Samples.Quoting.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <NoWarn>$(NoWarn);ExperimentalTeamsQuotedReplies</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Microsoft.Teams.Api.Tests/Microsoft.Teams.Api.Tests.csproj
+++ b/Tests/Microsoft.Teams.Api.Tests/Microsoft.Teams.Api.Tests.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
-    <NoWarn>$(NoWarn);ExperimentalTeamsTargeted;ExperimentalTeamsQuotedReplies</NoWarn>
+    <NoWarn>$(NoWarn);ExperimentalTeamsTargeted</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Microsoft.Teams.Apps.Tests/Microsoft.Teams.Apps.Tests.csproj
+++ b/Tests/Microsoft.Teams.Apps.Tests/Microsoft.Teams.Apps.Tests.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <NoWarn>$(NoWarn);CS0618;ExperimentalTeamsTargeted;ExperimentalTeamsQuotedReplies</NoWarn>
+        <NoWarn>$(NoWarn);CS0618;ExperimentalTeamsTargeted</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/core/docs/MigrationGuide.md
+++ b/core/docs/MigrationGuide.md
@@ -182,7 +182,7 @@ Entity getter helpers are exposed via entity-scoped extension methods:
 ```csharp
 // Retrieve entity collections
 activity.GetMentions();             // IEnumerable<MentionEntity>
-activity.GetQuotedMessages();       // IEnumerable<QuotedReplyEntity> (ExperimentalTeamsQuotedReplies)
+activity.GetQuotedMessages();       // IEnumerable<QuotedReplyEntity>
 activity.GetSensitivityLabels();    // IEnumerable<SensitiveUsageEntity>
 
 // Retrieve single entities

--- a/core/samples/Quoting/Quoting.csproj
+++ b/core/samples/Quoting/Quoting.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <NoWarn>$(NoWarn);ExperimentalTeamsQuotedReplies</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.Teams.Apps.Api.Clients;
 using Microsoft.Teams.Apps.OAuth;
@@ -164,7 +163,6 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="text">The response text, appended to the quoted message placeholder.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>The response from sending the activity.</returns>
-    [Experimental("ExperimentalTeamsQuotedReplies")]
     public Task<SendActivityResponse?> Quote(string messageId, string text, CancellationToken cancellationToken = default)
         => Quote(messageId, new MessageActivity(text), cancellationToken);
 
@@ -176,7 +174,6 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="activity">The activity to send. For <see cref="MessageActivity"/>, a quote placeholder for messageId is prepended to its text. Other activity types are sent as-is without quoting.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>The response from sending the activity.</returns>
-    [Experimental("ExperimentalTeamsQuotedReplies")]
     public Task<SendActivityResponse?> Quote(string messageId, TeamsActivity activity, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);

--- a/core/src/Microsoft.Teams.Apps/Microsoft.Teams.Apps.csproj
+++ b/core/src/Microsoft.Teams.Apps/Microsoft.Teams.Apps.csproj
@@ -7,7 +7,7 @@
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<NoWarn>$(NoWarn);ExperimentalTeamsQuotedReplies;ExperimentalTeamsTargeted</NoWarn>
+		<NoWarn>$(NoWarn);ExperimentalTeamsTargeted</NoWarn>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/core/src/Microsoft.Teams.Apps/Schema/Entities/QuotedReplyEntity.Extensions.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/Entities/QuotedReplyEntity.Extensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Security;
 
 namespace Microsoft.Teams.Apps.Schema.Entities;
@@ -9,7 +8,6 @@ namespace Microsoft.Teams.Apps.Schema.Entities;
 /// <summary>
 /// Quoted reply entity extension methods.
 /// </summary>
-[Experimental("ExperimentalTeamsQuotedReplies")]
 public static class QuotedReplyEntityExtensions
 {
     /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Schema/Entities/QuotedReplyEntity.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/Entities/QuotedReplyEntity.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Teams.Apps.Schema.Entities;
@@ -9,7 +8,6 @@ namespace Microsoft.Teams.Apps.Schema.Entities;
 /// <summary>
 /// Represents a quoted reply entity in a Teams activity.
 /// </summary>
-[Experimental("ExperimentalTeamsQuotedReplies")]
 public class QuotedReplyEntity : Entity
 {
     /// <summary>
@@ -41,7 +39,6 @@ public class QuotedReplyEntity : Entity
 /// <summary>
 /// Data for a quoted reply entity.
 /// </summary>
-[Experimental("ExperimentalTeamsQuotedReplies")]
 public class QuotedReplyData
 {
     /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Schema/MessageActivityExtensions.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/MessageActivityExtensions.cs
@@ -302,7 +302,6 @@ public static class MessageActivityExtensions
     /// <param name="messageId">The ID of the message being quoted.</param>
     /// <param name="text">Optional text to append after the quote placeholder.</param>
     /// <returns>The message activity for chaining.</returns>
-    [Experimental("ExperimentalTeamsQuotedReplies")]
     public static MessageActivity AddQuote(this MessageActivity message, string messageId, string? text = null)
     {
         ArgumentNullException.ThrowIfNull(message);
@@ -319,7 +318,6 @@ public static class MessageActivityExtensions
     /// <param name="message">The message activity.</param>
     /// <param name="messageId">The ID of the message being quoted.</param>
     /// <returns>The message activity for chaining.</returns>
-    [Experimental("ExperimentalTeamsQuotedReplies")]
     public static MessageActivity PrependQuote(this MessageActivity message, string messageId)
     {
         ArgumentNullException.ThrowIfNull(message);

--- a/core/src/Microsoft.Teams.Apps/Schema/TeamsActivityBuilder.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/TeamsActivityBuilder.cs
@@ -263,7 +263,6 @@ public class TeamsActivityBuilder : CoreActivityBuilder<TeamsActivity, TeamsActi
     /// <param name="text">Optional text, appended to the quoted message placeholder.</param>
     /// <returns>The builder instance for chaining.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the activity type is not Message.</exception>
-    [Experimental("ExperimentalTeamsQuotedReplies")]
     public TeamsActivityBuilder AddQuote(string messageId, string? text = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(messageId);

--- a/core/test/Microsoft.Teams.Apps.UnitTests/Microsoft.Teams.Apps.UnitTests.csproj
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/Microsoft.Teams.Apps.UnitTests.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);ExperimentalTeamsTargeted;ExperimentalTeamsQuotedReplies</NoWarn>
+    <NoWarn>$(NoWarn);ExperimentalTeamsTargeted</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Quoted replies are now GA. Removes all `[Experimental("ExperimentalTeamsQuotedReplies")]` attributes, `#pragma warning disable/restore` pairs, and `NoWarn` entries from csproj files.

## Changes
Across both `Libraries/` and `core/`:
- Removed `[Experimental]` attributes from classes and methods
- Removed pragma warning disable/restore pairs
- Cleaned up `NoWarn` entries in csproj files (preserving other warnings like `ExperimentalTeamsTargeted`)
- Updated `core/docs/MigrationGuide.md`

All tests pass (696/696). Format check passes.