### PR TITLE
Fix TeamClient.GetConversationsAsync deserialization

### DIFF
--- a/Libraries/Microsoft.Teams.Api/Clients/TeamClient.cs
+++ b/Libraries/Microsoft.Teams.Api/Clients/TeamClient.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+
 using Microsoft.Teams.Common.Http;
 
 namespace Microsoft.Teams.Api.Clients;
@@ -41,7 +43,13 @@ public class TeamClient : Client
     {
         var token = cancellationToken != default ? cancellationToken : _cancellationToken;
         var request = HttpRequest.Get($"{ServiceUrl}v3/teams/{id}/conversations");
-        var response = await _http.SendAsync<List<Channel>>(request, token).ConfigureAwait(false);
-        return response.Body;
+        var response = await _http.SendAsync<ConversationListResponse>(request, token).ConfigureAwait(false);
+        return response.Body.Conversations ?? [];
+    }
+
+    private sealed class ConversationListResponse
+    {
+        [JsonPropertyName("conversations")]
+        public List<Channel>? Conversations { get; set; }
     }
 }

--- a/Tests/Microsoft.Teams.Api.Tests/Clients/TeamClientTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/Clients/TeamClientTests.cs
@@ -44,37 +44,54 @@ public class TeamClientTests
     [Fact]
     public async Task TeamClient_GetConversationsAsync()
     {
-        var responseMessage = new HttpResponseMessage();
-        responseMessage.Headers.Add("Custom-Header", "HeaderValue");
-        var mockHandler = new Mock<IHttpClient>();
-        mockHandler
-            .Setup(handler => handler.SendAsync<List<Channel>>(It.IsAny<IHttpRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new HttpResponse<List<Channel>>()
-            {
-                Headers = responseMessage.Headers,
-                StatusCode = HttpStatusCode.OK,
-                Body = new List<Channel>
-                {
-                    new Channel { Id = "channel1", Name = "General" },
-                    new Channel { Id = "channel2", Name = "Dev Team" }
-                }
-            });
+        var json = """{"conversations":[{"id":"channel1","name":"General"},{"id":"channel2","name":"Dev Team"}]}""";
+        var handler = new MockHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+        });
+        var httpClient = new Common.Http.HttpClient(new System.Net.Http.HttpClient(handler));
 
         string serviceUrl = "https://serviceurl.com/";
         string teamId = "team123";
-        var teamClient = new TeamClient(serviceUrl, mockHandler.Object);
+        var teamClient = new TeamClient(serviceUrl, httpClient);
 
         var result = await teamClient.GetConversationsAsync(teamId);
 
         Assert.Equal(2, result.Count);
         Assert.Equal("channel1", result[0].Id);
         Assert.Equal("General", result[0].Name);
+        Assert.Equal("channel2", result[1].Id);
+        Assert.Equal("Dev Team", result[1].Name);
 
-        string expectedUrl = "https://serviceurl.com/v3/teams/team123/conversations";
-        HttpMethod expectedMethod = HttpMethod.Get;
-        mockHandler.Verify(x => x.SendAsync<List<Channel>>(
-            It.Is<IHttpRequest>(arg => arg.Url == expectedUrl && arg.Method == expectedMethod),
-            It.IsAny<CancellationToken>()),
-            Times.Once);
+        Assert.Equal(HttpMethod.Get, handler.LastRequest?.Method);
+        Assert.Equal("https://serviceurl.com/v3/teams/team123/conversations", handler.LastRequest?.RequestUri?.ToString());
+    }
+
+    [Fact]
+    public async Task TeamClient_GetConversationsAsync_EmptyList()
+    {
+        var json = """{"conversations":[]}""";
+        var handler = new MockHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+        });
+        var httpClient = new Common.Http.HttpClient(new System.Net.Http.HttpClient(handler));
+        var teamClient = new TeamClient("https://serviceurl.com/", httpClient);
+
+        var result = await teamClient.GetConversationsAsync("team123");
+
+        Assert.Empty(result);
+    }
+
+
+    private class MockHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(response);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes `TeamClient.GetConversationsAsync` which failed to deserialize the response from `GET /v3/teams/{id}/conversations`.

The endpoint returns a wrapper object (`{"conversations": [...]}`), but the method was trying to deserialize directly as `List<Channel>`, causing a `JsonException`.

## Changes

- Added a private `ConversationListResponse` wrapper class for deserialization
- Updated `GetConversationsAsync` to deserialize into the wrapper and return `.Conversations`
- Updated unit test to exercise the real JSON deserialization path (not mocked)
- Added empty list test case

## Notes

- No public API signature change (still returns `Task<List<Channel>>`)
- Already fixed in `core` (`next/core` branch) - this backports the fix to Libraries
- TS and Python SDKs already handle this correctly

Fixes #574
Reported by customer: https://github.com/OfficeDev/Microsoft-Teams-Samples/issues/1969