### PR TITLE
fix: resolve infinite recursion in AddFunction<TBody> overload

### DIFF
--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/ApplicationBuilder.Functions.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/ApplicationBuilder.Functions.cs
@@ -101,17 +101,6 @@ public static partial class ApplicationBuilderExtensions
     /// <param name="handler">The callback to handle the function</param>
     public static IApplicationBuilder AddFunction<TBody>(this IApplicationBuilder builder, string name, Func<IFunctionContext<TBody>, Task<object?>> handler)
     {
-        return builder.AddFunction<TBody>(name, async context => await handler(context).ConfigureAwait(false));
-    }
-
-    /// <summary>
-    /// add/update a function that can be called remotely
-    /// </summary>
-    /// <typeparam name="TBody">The body (data) type</typeparam>
-    /// <param name="name">The unique function name</param>
-    /// <param name="handler">The callback to handle the function</param>
-    public static IApplicationBuilder AddFunction<TBody>(this IApplicationBuilder builder, string name, Func<IFunctionContext<TBody>, object?> handler)
-    {
         builder.UseEndpoints(endpoints =>
         {
             endpoints.MapPost($"/api/functions/{name}", async context =>
@@ -188,12 +177,23 @@ public static partial class ApplicationBuilderExtensions
                 }
 
                 log.Debug(ctx.Data?.ToString());
-                var res = handler(ctx);
+                var res = await handler(ctx).ConfigureAwait(false);
                 log.Debug(res?.ToString());
                 await Results.Json(res).ExecuteAsync(context).ConfigureAwait(false);
             }).RequireAuthorization(EntraTokenAuthConstants.AuthorizationPolicy);
         });
 
         return builder;
+    }
+
+    /// <summary>
+    /// add/update a function that can be called remotely
+    /// </summary>
+    /// <typeparam name="TBody">The body (data) type</typeparam>
+    /// <param name="name">The unique function name</param>
+    /// <param name="handler">The callback to handle the function</param>
+    public static IApplicationBuilder AddFunction<TBody>(this IApplicationBuilder builder, string name, Func<IFunctionContext<TBody>, object?> handler)
+    {
+        return builder.AddFunction<TBody>(name, context => Task.FromResult(handler(context)));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #546

The `AddFunction<TBody>(builder, name, Func<IFunctionContext<TBody>, Task<object?>>)` overload was infinitely recursive -- it wrapped the handler in `async context => await handler(context)` which still returns `Task<object?>`, resolving back to itself via overload resolution. This caused a `StackOverflowException` at runtime.

## Fix

- Moved the base endpoint-registration implementation into the async `Func<IFunctionContext<TBody>, Task<object?>>` overload (properly awaiting the handler)
- Changed the synchronous `Func<IFunctionContext<TBody>, object?>` overload to delegate to the async base via `Task.FromResult(handler(context))`

## Verification

- Build succeeds
- Ran a minimal app using the previously-buggy overload; server responds with 401 (expected, no auth) instead of crashing with StackOverflowException