### PR TITLE
Bump @azure/msal-browser to ^5.14.0 in TabApp web sample

### DIFF
--- a/core/samples/TabApp/Web/package-lock.json
+++ b/core/samples/TabApp/Web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "tabsapp-web",
       "version": "1.0.0",
       "dependencies": {
-        "@azure/msal-browser": "^3.0.0",
+        "@azure/msal-browser": "^5.14.0",
         "@microsoft/teams-js": "^2.32.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -22,21 +22,21 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.30.0.tgz",
-      "integrity": "sha512-I0XlIGVdM4E9kYP5eTjgW8fgATdzwxJvQ6bm2PNiHaZhEuUz47NYw1xHthC9R+lXz4i9zbShS0VdLyxd7n0GGA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.14.0.tgz",
+      "integrity": "sha512-Dfl7hPZe9/JJwRhFFXHq2z1oHYBuGubmff3kWXOsd1AGgyXlqjNYAWuN/1JL/ZrcZBs8TKMjGSil6Rcc7E8VPQ==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "14.16.1"
+        "@azure/msal-common": "16.9.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "14.16.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.1.tgz",
-      "integrity": "sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w==",
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.9.0.tgz",
+      "integrity": "sha512-1MWGjqgUCRAYgLmVFZKp7fs3Rg1TFvIMgywY8ze2olNVvLlJoRThuoziWSDJuwwyJI5L4rnLb9Tyt5D9GvSLPw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"

--- a/core/samples/TabApp/Web/package.json
+++ b/core/samples/TabApp/Web/package.json
@@ -7,7 +7,7 @@
     "build": "tsc --noEmit && vite build"
   },
   "dependencies": {
-    "@azure/msal-browser": "^3.0.0",
+    "@azure/msal-browser": "^5.14.0",
     "@microsoft/teams-js": "^2.32.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"


### PR DESCRIPTION
Updates `@azure/msal-browser` from `^3.0.0` (resolved 3.30.0) to `^5.14.0` in `core/samples/TabApp/Web` to address internal security finding **MVS-2026-vmmw-f85q** flagged by the 1ES/Breeze scanner (not a public CVE, so it doesn't surface in npm audit / GitHub advisories).

### Changes
- `core/samples/TabApp/Web/package.json`: `@azure/msal-browser` `^3.0.0` -> `^5.14.0`
- `core/samples/TabApp/Web/package-lock.json`: regenerated (msal-browser 5.14.0, msal-common 16.9.0)

### Validation
- The sample's MSAL API usage (`createNestablePublicClientApplication`, `acquireTokenSilent`/`acquireTokenPopup`, `getAllAccounts`, `InteractionRequiredAuthError`) is unchanged across the major bump.
- `tsc --noEmit` and `vite build` both pass.

Scope limited to `core/samples/TabApp/Web`; the other web sample (`Samples/Samples.Tab/Web`) already resolves msal-browser 4.22.0 transitively.
