### PR TITLE
Bump core version to 1.0.8-preview

### DIFF
--- a/core/version.json
+++ b/core/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.6-preview.{height}",
+  "version": "1.0.7-preview.{height}",
   "pathFilters": ["."],
   "publicReleaseRefSpec": [
     "^refs/heads/releases/core$"

--- a/core/version.json
+++ b/core/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.7-preview.{height}",
+  "version": "1.0.8-preview.{height}",
   "pathFilters": ["."],
   "publicReleaseRefSpec": [
     "^refs/heads/releases/core$"

--- a/core/version.json
+++ b/core/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.5-preview.{height}",
+  "version": "1.0.6-preview.{height}",
   "pathFilters": ["."],
   "publicReleaseRefSpec": [
     "^refs/heads/releases/core$"


### PR DESCRIPTION
Bump core version for the next release cycle after v1.0.7 release.

- `core/version.json`: `1.0.5-preview.{height}` → `1.0.8-preview.{height}`