### PR TITLE
Add optional TenantId to AgenticIdentity

### DIFF
--- a/core/src/Microsoft.Teams.Apps/Diagnostics/TeamsBaggageBuilder.cs
+++ b/core/src/Microsoft.Teams.Apps/Diagnostics/TeamsBaggageBuilder.cs
@@ -96,7 +96,7 @@ public sealed class TeamsBaggageBuilder
     /// <summary>
     /// Populates every baggage key reachable from <c>ctx.Activity</c> — including the Apps-only keys
     /// backed by <see cref="TeamsChannelAccount"/>. Tenant fallback uses the typed
-    /// <see cref="TeamsChannelData"/> when <see cref="Core.Schema.ChannelAccount.TenantId"/> is null.
+    /// <see cref="TeamsChannelData"/> when <see cref="TeamsChannelAccount.TenantId"/> is null.
     /// </summary>
     public TeamsBaggageBuilder FromTeamsContext<TActivity>(Context<TActivity> ctx) where TActivity : TeamsActivity
     {

--- a/core/src/Microsoft.Teams.Apps/Diagnostics/TeamsBaggageBuilder.cs
+++ b/core/src/Microsoft.Teams.Apps/Diagnostics/TeamsBaggageBuilder.cs
@@ -96,7 +96,7 @@ public sealed class TeamsBaggageBuilder
     /// <summary>
     /// Populates every baggage key reachable from <c>ctx.Activity</c> — including the Apps-only keys
     /// backed by <see cref="TeamsChannelAccount"/>. Tenant fallback uses the typed
-    /// <see cref="TeamsChannelData"/> when <see cref="TeamsChannelAccount.TenantId"/> is null.
+    /// <see cref="TeamsChannelData"/> when <see cref="Microsoft.Teams.Core.Schema.ChannelAccount.TenantId"/> is null.
     /// </summary>
     public TeamsBaggageBuilder FromTeamsContext<TActivity>(Context<TActivity> ctx) where TActivity : TeamsActivity
     {

--- a/core/src/Microsoft.Teams.Apps/Diagnostics/TeamsBaggageBuilder.cs
+++ b/core/src/Microsoft.Teams.Apps/Diagnostics/TeamsBaggageBuilder.cs
@@ -96,7 +96,7 @@ public sealed class TeamsBaggageBuilder
     /// <summary>
     /// Populates every baggage key reachable from <c>ctx.Activity</c> — including the Apps-only keys
     /// backed by <see cref="TeamsChannelAccount"/>. Tenant fallback uses the typed
-    /// <see cref="TeamsChannelData"/> when <see cref="TeamsChannelAccount.TenantId"/> is null.
+    /// <see cref="TeamsChannelData"/> when <see cref="Core.Schema.ChannelAccount.TenantId"/> is null.
     /// </summary>
     public TeamsBaggageBuilder FromTeamsContext<TActivity>(Context<TActivity> ctx) where TActivity : TeamsActivity
     {

--- a/core/src/Microsoft.Teams.Apps/Schema/TeamsChannelAccount.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/TeamsChannelAccount.cs
@@ -54,7 +54,7 @@ public class TeamsChannelAccount : ChannelAccount
         result.Email = result.Properties.Extract<string>("email");
         result.UserPrincipalName = result.Properties.Extract<string>("userPrincipalName");
         result.UserRole = result.Properties.Extract<string>("userRole");
-        result.TenantId = result.Properties.Extract<string>("tenantId");
+        result.TenantId = channelAccount.TenantId;
         if (string.IsNullOrEmpty(result.AadObjectId))
         {
             result.AadObjectId = result.ObjectId;

--- a/core/src/Microsoft.Teams.Apps/Schema/TeamsChannelAccount.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/TeamsChannelAccount.cs
@@ -103,4 +103,10 @@ public class TeamsChannelAccount : ChannelAccount
     /// </summary>
     [JsonPropertyName("userRole")]
     public string? UserRole { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Microsoft Entra tenant ID associated with this account.
+    /// </summary>
+    [JsonPropertyName("tenantId")]
+    public new string? TenantId { get; set; }
 }

--- a/core/src/Microsoft.Teams.Apps/Schema/TeamsChannelAccount.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/TeamsChannelAccount.cs
@@ -103,10 +103,4 @@ public class TeamsChannelAccount : ChannelAccount
     /// </summary>
     [JsonPropertyName("userRole")]
     public string? UserRole { get; set; }
-
-    /// <summary>
-    /// Gets or sets the Microsoft Entra tenant ID associated with this account.
-    /// </summary>
-    [JsonPropertyName("tenantId")]
-    public string? TenantId { get; set; }
 }

--- a/core/src/Microsoft.Teams.Apps/Schema/TeamsChannelAccount.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/TeamsChannelAccount.cs
@@ -103,10 +103,4 @@ public class TeamsChannelAccount : ChannelAccount
     /// </summary>
     [JsonPropertyName("userRole")]
     public string? UserRole { get; set; }
-
-    /// <summary>
-    /// Gets or sets the Microsoft Entra tenant ID associated with this account.
-    /// </summary>
-    [JsonPropertyName("tenantId")]
-    public new string? TenantId { get; set; }
 }

--- a/core/src/Microsoft.Teams.Core/Schema/AgenticIdentity.cs
+++ b/core/src/Microsoft.Teams.Core/Schema/AgenticIdentity.cs
@@ -18,6 +18,11 @@ public sealed class AgenticIdentity
     public string? AgenticUserId { get; set; }
 
     /// <summary>
+    /// Tenant ID associated with the agentic identity.
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>
     /// Agentic application blueprint ID.
     /// </summary>
     public string? AgenticAppBlueprintId { get; set; }
@@ -37,7 +42,8 @@ public sealed class AgenticIdentity
         {
             AgenticAppId = account.AgenticAppId,
             AgenticUserId = account.AgenticUserId,
-            AgenticAppBlueprintId = account.AgenticAppBlueprintId
+            AgenticAppBlueprintId = account.AgenticAppBlueprintId,
+            TenantId = account.TenantId
         };
     }
 }

--- a/core/src/Microsoft.Teams.Core/Schema/ChannelAccount.cs
+++ b/core/src/Microsoft.Teams.Core/Schema/ChannelAccount.cs
@@ -50,6 +50,12 @@ public class ChannelAccount()
     public string? AgenticAppBlueprintId { get; set; }
 
     /// <summary>
+    /// Gets or sets the tenant ID associated with the account.
+    /// </summary>
+    [JsonPropertyName("tenantId")]
+    public string? TenantId { get; set; }
+
+    /// <summary>
     /// Gets the extension data dictionary for storing additional properties not defined in the schema.
     /// </summary>
     [JsonExtensionData]
@@ -71,7 +77,8 @@ public class ChannelAccount()
         {
             AgenticAppId = AgenticAppId,
             AgenticUserId = AgenticUserId,
-            AgenticAppBlueprintId = AgenticAppBlueprintId
+            AgenticAppBlueprintId = AgenticAppBlueprintId,
+            TenantId = TenantId
         };
     }
 }

--- a/core/test/Microsoft.Teams.Core.UnitTests/Schema/CoreActivityTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Schema/CoreActivityTests.cs
@@ -330,4 +330,49 @@ public class CoreCoreActivityTests
         Assert.Equal("user-123", activity.Recipient.Id);
         Assert.True(activity.Recipient.IsTargeted);
     }
+
+    [Fact]
+    public void AgenticIdentity_IncludesTenantId_FromRecipient()
+    {
+        string json = """
+        {
+            "type": "message",
+            "recipient": {
+                "id": "28:bot-id",
+                "agenticAppId": "agentic-app",
+                "agenticUserId": "agentic-user",
+                "agenticAppBlueprintId": "blueprint",
+                "tenantId": "tenant-abc"
+            }
+        }
+        """;
+
+        CoreActivity activity = CoreActivity.FromJsonString(json);
+
+        AgenticIdentity? identity = activity.Recipient?.GetAgenticIdentity();
+        Assert.NotNull(identity);
+        Assert.Equal("agentic-app", identity!.AgenticAppId);
+        Assert.Equal("agentic-user", identity.AgenticUserId);
+        Assert.Equal("blueprint", identity.AgenticAppBlueprintId);
+        Assert.Equal("tenant-abc", identity.TenantId);
+    }
+
+    [Fact]
+    public void AgenticIdentity_TenantIdAlone_DoesNotCreateIdentity()
+    {
+        string json = """
+        {
+            "type": "message",
+            "recipient": {
+                "id": "user-123",
+                "tenantId": "tenant-abc"
+            }
+        }
+        """;
+
+        CoreActivity activity = CoreActivity.FromJsonString(json);
+
+        Assert.Equal("tenant-abc", activity.Recipient?.TenantId);
+        Assert.Null(activity.Recipient?.GetAgenticIdentity());
+    }
 }


### PR DESCRIPTION
## Summary

Adds an optional tenant id to `AgenticIdentity`, mirroring [`tenant_id` in teams.py](https://github.com/microsoft/teams.py/blob/b65a9976d5a6f15a5f6c4130ce9f0665824e6a40/packages/api/src/microsoft_teams/api/models/agentic_identity.py#L15).

The tenant arrives on the wire as `tenantId` on the inbound activity's account (alongside `agenticAppId` / `agenticUserId` / `agenticAppBlueprintId`), so the change wires it through end-to-end.

## Changes

- **`AgenticIdentity`** — new optional `TenantId` property; `FromAccount` now maps it.
- **`ChannelAccount`** — added typed `tenantId` JSON property (the wire source); `GetAgenticIdentity()` now populates `TenantId`. A `tenantId` alone still does not fabricate an agentic identity.
- **`TeamsChannelAccount`** — removed its duplicate `tenantId`, now inherited from the base `ChannelAccount` (same JSON name, no behavior change). Updated the related doc cref in `TeamsBaggageBuilder`.
- **Tests** — added unit tests covering the wire → identity mapping and the tenant-only case.

## Verification

- 169 Core + 354 Apps unit tests pass.
- Verified live against a real agentic invoke: the recipient's `tenantId` flowed correctly into the parsed `AgenticIdentity.TenantId`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>