### PR TITLE
Use recipient agentic identity defaults

### DIFF
--- a/core/src/Microsoft.Teams.Apps.BotBuilder/ActivitySchemaMapper.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/ActivitySchemaMapper.cs
@@ -8,6 +8,7 @@ using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
 using Microsoft.Teams.Core.Schema;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Teams.Apps.BotBuilder;
 
@@ -69,6 +70,10 @@ public static class ActivitySchemaMapper
             Name = account.Name
         };
 
+        if (!string.IsNullOrEmpty(account.BotId))
+        {
+            channelAccount.Properties.Add("botId", account.BotId);
+        }
 
         if (account.Properties.TryGetValue("aadObjectId", out object? aadObjectId))
         {
@@ -205,6 +210,11 @@ public static class ActivitySchemaMapper
         ArgumentNullException.ThrowIfNull(account);
 
         Microsoft.Teams.Core.Schema.ChannelAccount result = new() { Id = account.Id, Name = account.Name };
+
+        if (account.Properties is not null && account.Properties.TryGetValue("botId", out JToken? botId))
+        {
+            result.BotId = GetStringValue(botId);
+        }
 
         if (!string.IsNullOrEmpty(account.AadObjectId))
         {

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsApiClient.cs
@@ -45,10 +45,10 @@ public static class TeamsApiClient
             ?? throw new InvalidOperationException("ServiceUrl is required.");
     }
 
-    private static AgenticIdentity GetIdentity(ITurnContext turnContext)
+    private static AgenticIdentity? GetIdentity(ITurnContext turnContext)
     {
         CoreActivity coreActivity = turnContext.Activity.FromBotFrameworkActivity();
-        return AgenticIdentity.FromAccount(coreActivity.From) ?? new AgenticIdentity();
+        return AgenticIdentity.FromAccount(coreActivity.Recipient);
     }
 
     #endregion
@@ -87,7 +87,7 @@ public static class TeamsApiClient
 
             ConversationClient client = GetConversationClient(turnContext);
             Uri serviceUrl = new(GetServiceUrl(turnContext));
-            AgenticIdentity identity = GetIdentity(turnContext);
+            AgenticIdentity? identity = GetIdentity(turnContext);
 
             Core.Schema.ChannelAccount result = await client.GetConversationMemberAsync<Core.Schema.ChannelAccount>(
                 conversationId, userId, serviceUrl, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
@@ -121,7 +121,7 @@ public static class TeamsApiClient
 
             ConversationClient client = GetConversationClient(turnContext);
             Uri serviceUrl = new(GetServiceUrl(turnContext));
-            AgenticIdentity identity = GetIdentity(turnContext);
+            AgenticIdentity? identity = GetIdentity(turnContext);
 
             IList<Core.Schema.ChannelAccount> members = await client.GetConversationMembersAsync(
                 conversationId, serviceUrl, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
@@ -158,7 +158,7 @@ public static class TeamsApiClient
 
             ConversationClient client = GetConversationClient(turnContext);
             Uri serviceUrl = new(GetServiceUrl(turnContext));
-            AgenticIdentity identity = GetIdentity(turnContext);
+            AgenticIdentity? identity = GetIdentity(turnContext);
 
             Core.PagedMembersResult pagedMembers = await client.GetConversationPagedMembersAsync(
                 conversationId, serviceUrl, pageSize, continuationToken, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
@@ -192,7 +192,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity identity = GetIdentity(turnContext);
+        AgenticIdentity? identity = GetIdentity(turnContext);
 
         Core.Schema.ChannelAccount result = await client.GetConversationMemberAsync<Core.Schema.ChannelAccount>(
             t, userId, serviceUrl, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
@@ -220,7 +220,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity identity = GetIdentity(turnContext);
+        AgenticIdentity? identity = GetIdentity(turnContext);
 
         IList<Core.Schema.ChannelAccount> members = await client.GetConversationMembersAsync(
             t, serviceUrl, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
@@ -251,7 +251,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity identity = GetIdentity(turnContext);
+        AgenticIdentity? identity = GetIdentity(turnContext);
 
         Core.PagedMembersResult pagedMembers = await client.GetConversationPagedMembersAsync(
             t, serviceUrl, pageSize, continuationToken, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
@@ -280,7 +280,7 @@ public static class TeamsApiClient
             ?? throw new InvalidOperationException("The meetingId can only be null if turnContext is within the scope of a MS Teams Meeting.");
 
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
 
         ConversationClient client = GetConversationClient(turnContext);
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v1/meetings/{Uri.EscapeDataString(meetingId)}";
@@ -319,7 +319,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v1/meetings/{Uri.EscapeDataString(meetingId)}/participants/{Uri.EscapeDataString(participantId)}?tenantId={Uri.EscapeDataString(tenantId)}";
 
@@ -353,7 +353,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v1/meetings/{Uri.EscapeDataString(meetingId)}/notification";
         string body = JsonConvert.SerializeObject(notification);
@@ -387,7 +387,7 @@ public static class TeamsApiClient
             ?? throw new InvalidOperationException("This method is only valid within the scope of MS Teams Team.");
 
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity identity = GetIdentity(turnContext);
+        AgenticIdentity? identity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/teams/{Uri.EscapeDataString(t)}";
 
@@ -419,7 +419,7 @@ public static class TeamsApiClient
             ?? throw new InvalidOperationException("This method is only valid within the scope of MS Teams Team.");
 
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity identity = GetIdentity(turnContext);
+        AgenticIdentity? identity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/teams/{Uri.EscapeDataString(t)}/conversations";
 
@@ -461,7 +461,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/users/";
         SendMessageToUsersRequest request = new()
@@ -503,7 +503,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/channels/";
         SendMessageToUsersRequest request = new()
         {
@@ -545,7 +545,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
         if (activity is not Activity teamActivity)
             throw new ArgumentException("Expected a Bot Framework Activity instance.", nameof(activity));
         CoreActivity coreActivity = teamActivity.FromBotFrameworkActivity();
@@ -588,7 +588,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
         if (activity is not Activity tenantActivity)
             throw new ArgumentException("Expected a Bot Framework Activity instance.", nameof(activity));
         CoreActivity coreActivity = tenantActivity.FromBotFrameworkActivity();
@@ -684,7 +684,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/{Uri.EscapeDataString(operationId)}";
 
 
@@ -715,7 +715,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/failedentries/{Uri.EscapeDataString(operationId)}";
 
@@ -749,7 +749,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/{Uri.EscapeDataString(operationId)}";
 

--- a/core/src/Microsoft.Teams.Core/Http/BotRequestContext.cs
+++ b/core/src/Microsoft.Teams.Core/Http/BotRequestContext.cs
@@ -53,7 +53,7 @@ public record BotRequestContext
     /// <param name="activity">The inbound activity, or null.</param>
     /// <returns>The context, or null when nothing could be derived.</returns>
     public static BotRequestContext? FromInboundActivity(CoreActivity? activity)
-        => Build(Schema.AgenticIdentity.FromAccount(activity?.Recipient), NormalizeAppId(activity?.Recipient?.BotId));
+        => Build(Schema.AgenticIdentity.FromAccount(activity?.Recipient), NormalizeAppId(activity?.Recipient?.BotId ?? activity?.Recipient?.Id));
 
     /// <summary>
     /// Builds context carrying only the supplied agentic identity.

--- a/core/src/Microsoft.Teams.Core/Http/BotRequestContext.cs
+++ b/core/src/Microsoft.Teams.Core/Http/BotRequestContext.cs
@@ -53,7 +53,7 @@ public record BotRequestContext
     /// <param name="activity">The inbound activity, or null.</param>
     /// <returns>The context, or null when nothing could be derived.</returns>
     public static BotRequestContext? FromInboundActivity(CoreActivity? activity)
-        => Build(Schema.AgenticIdentity.FromAccount(activity?.Recipient), NormalizeAppId(activity?.Recipient?.Id));
+        => Build(Schema.AgenticIdentity.FromAccount(activity?.Recipient), NormalizeAppId(activity?.Recipient?.BotId));
 
     /// <summary>
     /// Builds context carrying only the supplied agentic identity.

--- a/core/src/Microsoft.Teams.Core/Schema/ChannelAccount.cs
+++ b/core/src/Microsoft.Teams.Core/Schema/ChannelAccount.cs
@@ -19,6 +19,12 @@ public class ChannelAccount()
     public string? Id { get; set; }
 
     /// <summary>
+    /// Gets or sets the bot application ID associated with the account.
+    /// </summary>
+    [JsonPropertyName("botId")]
+    public string? BotId { get; set; }
+
+    /// <summary>
     /// Gets or sets the display name of the channel account.
     /// </summary>
     [JsonPropertyName("name")]

--- a/core/src/Microsoft.Teams.Core/Schema/CoreActivity.cs
+++ b/core/src/Microsoft.Teams.Core/Schema/CoreActivity.cs
@@ -170,11 +170,13 @@ public class CoreActivity
     private static ChannelAccount CloneChannelAccount(ChannelAccount source) => new()
     {
         Id = source.Id,
+        BotId = source.BotId,
         Name = source.Name,
         IsTargeted = source.IsTargeted,
         AgenticAppId = source.AgenticAppId,
         AgenticUserId = source.AgenticUserId,
         AgenticAppBlueprintId = source.AgenticAppBlueprintId,
+        TenantId = source.TenantId,
         Properties = new ExtendedPropertiesDictionary(source.Properties)
     };
 #pragma warning restore ExperimentalTeamsTargeted

--- a/core/src/Microsoft.Teams.Core/UserTokenClient.cs
+++ b/core/src/Microsoft.Teams.Core/UserTokenClient.cs
@@ -28,8 +28,6 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     private readonly string _apiEndpoint = configuration["UserTokenApiEndpoint"] ?? "https://token.botframework.com";
     private readonly JsonSerializerOptions _defaultOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
-    internal AgenticIdentity? AgenticIdentity { get; set; }
-
     /// <summary>
     /// Gets the token status for each connection for the given user.
     /// </summary>
@@ -39,6 +37,18 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
     public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include = null, CancellationToken cancellationToken = default)
+        => await GetTokenStatusAsync(userId, channelId, include, requestContext: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the token status for each connection for the given user.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="include">The optional include parameter.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
+    public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -56,7 +66,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/GetTokenStatus",
             queryParams,
             body: null,
-            CreateRequestOptions("getting token status"),
+            CreateRequestOptions("getting token status", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false);
 
         if (result == null || result.Count == 0)
@@ -77,6 +87,19 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
     public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code = null, CancellationToken cancellationToken = default)
+        => await GetTokenAsync(userId, connectionName, channelId, code, requestContext: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the user token for a particular connection.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="code">The optional code.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
+    public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -96,7 +119,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/GetToken",
             queryParams,
             body: null,
-            CreateRequestOptions("getting token", returnNullOnNotFound: true),
+            CreateRequestOptions("getting token", returnNullOnNotFound: true, requestContext: requestContext),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -111,6 +134,20 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
     public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect = null, CancellationToken cancellationToken = default)
+        => GetSignInResourceAsync(userId, connectionName, channelId, finalRedirect, requestContext: null, cancellationToken);
+
+    /// <summary>
+    /// Get the token or raw signin link to be sent to the user for signin for a connection.
+    /// Builds the state parameter internally from the userId and connectionName.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
+    public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         var tokenExchangeState = new
         {
@@ -124,7 +161,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
         string state = Convert.ToBase64String(Encoding.UTF8.GetBytes(tokenExchangeStateJson));
 
         Uri? finalRedirectUri = finalRedirect is not null ? new Uri(finalRedirect) : null;
-        return GetSignInResourceAsync(state, finalRedirect: finalRedirectUri, cancellationToken: cancellationToken);
+        return GetSignInResourceAsync(state, codeChallenge: null, emulatorUrl: null, finalRedirect: finalRedirectUri, requestContext: requestContext, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -137,6 +174,19 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The sign-in URL, or null if not available.</returns>
     public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
+        => await GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, requestContext: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the sign-in URL for the given state.
+    /// </summary>
+    /// <param name="state">The encoded state parameter.</param>
+    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
+    /// <param name="emulatorUrl">The optional emulator URL.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The sign-in URL, or null if not available.</returns>
+    public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new() { { "state", state } };
 
@@ -153,7 +203,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/botsignin/GetSignInUrl",
             queryParams,
             body: null,
-            CreateRequestOptions("getting sign-in URL"),
+            CreateRequestOptions("getting sign-in URL", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -167,6 +217,19 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The sign-in resource result.</returns>
     public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
+        => await GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, requestContext: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the sign-in resource for the given state.
+    /// </summary>
+    /// <param name="state">The encoded state parameter.</param>
+    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
+    /// <param name="emulatorUrl">The optional emulator URL.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The sign-in resource result.</returns>
+    public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new() { { "state", state } };
 
@@ -183,7 +246,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/botsignin/GetSignInResource",
             queryParams,
             body: null,
-            CreateRequestOptions("getting sign-in resource"),
+            CreateRequestOptions("getting sign-in resource", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -196,6 +259,18 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="exchangeToken">The token to exchange.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, CancellationToken cancellationToken = default)
+        => await ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, requestContext: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Exchanges a token for another token.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="exchangeToken">The token to exchange.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -215,7 +290,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/exchange",
             queryParams,
             JsonSerializer.Serialize(tokenExchangeRequest),
-            CreateRequestOptions("exchanging token"),
+            CreateRequestOptions("exchanging token", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -228,6 +303,18 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
     /// <returns>A task that represents the asynchronous sign-out operation.</returns>
     public virtual async Task SignOutUserAsync(string userId, string? connectionName = null, string? channelId = null, CancellationToken cancellationToken = default)
+        => await SignOutUserAsync(userId, connectionName, channelId, requestContext: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Signs the user out of a connection, revoking their OAuth token.
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user to sign out. Cannot be null or empty.</param>
+    /// <param name="connectionName">Optional name of the OAuth connection to sign out from. If null, signs out from all connections.</param>
+    /// <param name="channelId">Optional channel identifier. If provided, limits sign-out to tokens for this channel.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous sign-out operation.</returns>
+    public virtual async Task SignOutUserAsync(string userId, string? connectionName, string? channelId, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -250,7 +337,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/SignOut",
             queryParams,
             body: null,
-            CreateRequestOptions("signing out user"),
+            CreateRequestOptions("signing out user", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -264,6 +351,19 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
     public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls = null, CancellationToken cancellationToken = default)
+        => await GetAadTokensAsync(userId, connectionName, channelId, resourceUrls, requestContext: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets AAD tokens for a user.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="resourceUrls">The resource URLs.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
+    public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         var body = new
         {
@@ -279,14 +379,14 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/GetAadTokens",
             queryParams: null,
             JsonSerializer.Serialize(body),
-            CreateRequestOptions("getting AAD tokens"),
+            CreateRequestOptions("getting AAD tokens", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false))!;
     }
 
-    private BotRequestOptions CreateRequestOptions(string operationDescription, bool returnNullOnNotFound = false) =>
+    private static BotRequestOptions CreateRequestOptions(string operationDescription, bool returnNullOnNotFound = false, BotRequestContext? requestContext = null) =>
         new()
         {
-            RequestContext = BotRequestContext.FromAgenticIdentity(AgenticIdentity),
+            RequestContext = requestContext,
             OperationDescription = operationDescription,
             ReturnNullOnNotFound = returnNullOnNotFound
         };

--- a/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatActivityTests.cs
+++ b/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatActivityTests.cs
@@ -7,6 +7,7 @@ using AdaptiveCards;
 using Microsoft.Bot.Schema;
 using Microsoft.Teams.Core.Schema;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
 {
@@ -312,6 +313,17 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
         }
 
         [Fact]
+        public void FromCompatChannelAccount_MapsBotId()
+        {
+            Microsoft.Bot.Schema.ChannelAccount account = new() { Id = "bot-account-id" };
+            account.Properties["botId"] = "28:bot-app-id";
+
+            Microsoft.Teams.Core.Schema.ChannelAccount result = account.FromCompatChannelAccount();
+
+            Assert.Equal("28:bot-app-id", result.BotId);
+        }
+
+        [Fact]
         public void FromCompatChannelAccount_MapsAadObjectIdToProperties()
         {
             Microsoft.Bot.Schema.ChannelAccount account = new() { Id = "user-1", AadObjectId = "aad-123" };
@@ -349,6 +361,17 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
         {
             Microsoft.Bot.Schema.ChannelAccount? account = null;
             Assert.Throws<ArgumentNullException>(() => account!.FromCompatChannelAccount());
+        }
+
+        [Fact]
+        public void ToCompatChannelAccount_MapsBotId()
+        {
+            Microsoft.Teams.Core.Schema.ChannelAccount account = new() { Id = "bot-account-id", BotId = "28:bot-app-id" };
+
+            Microsoft.Bot.Schema.ChannelAccount result = account.ToCompatChannelAccount();
+
+            Assert.True(result.Properties.TryGetValue("botId", out JToken? botId));
+            Assert.Equal("28:bot-app-id", botId?.ToString());
         }
     }
 

--- a/core/test/Microsoft.Teams.Core.UnitTests/Http/BotRequestContextTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Http/BotRequestContextTests.cs
@@ -115,7 +115,7 @@ public class BotRequestContextTests
         {
             Type = ActivityType.Message,
             From = new ChannelAccount { Id = "user-id" },
-            Recipient = new ChannelAccount { Id = "28:recipient-bot-id", AgenticUserId = "agentic-user" },
+            Recipient = new ChannelAccount { Id = "recipient-account-id", BotId = "28:recipient-bot-id", AgenticUserId = "agentic-user" },
         };
 
         BotRequestContext? ctx = BotRequestContext.FromInboundActivity(activity);
@@ -133,7 +133,7 @@ public class BotRequestContextTests
         {
             Type = ActivityType.Message,
             From = new ChannelAccount { Id = "user-id", AgenticUserId = "agentic-user" },
-            Recipient = new ChannelAccount { Id = "28:recipient-bot-id" },
+            Recipient = new ChannelAccount { Id = "recipient-account-id", BotId = "28:recipient-bot-id" },
         };
 
         BotRequestContext? ctx = BotRequestContext.FromInboundActivity(activity);

--- a/core/test/Microsoft.Teams.Core.UnitTests/Http/BotRequestContextTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Http/BotRequestContextTests.cs
@@ -143,6 +143,40 @@ public class BotRequestContextTests
         Assert.Null(ctx.AgenticIdentity);
     }
 
+    [Fact]
+    public void FromInboundActivity_FallsBackToRecipientId_WhenBotIdAbsent()
+    {
+        // Standard (non-agentic) inbound activity: SMBA does not populate BotId, but Recipient.Id
+        // carries the Teams-style "28:<appId>" value.
+        CoreActivity activity = new()
+        {
+            Type = ActivityType.Message,
+            From = new ChannelAccount { Id = "user-id" },
+            Recipient = new ChannelAccount { Id = "28:recipient-app-id" },
+        };
+
+        BotRequestContext? ctx = BotRequestContext.FromInboundActivity(activity);
+
+        Assert.NotNull(ctx);
+        Assert.Equal("recipient-app-id", ctx!.BotAppId);
+    }
+
+    [Fact]
+    public void FromInboundActivity_PrefersBotId_WhenBothPresent()
+    {
+        CoreActivity activity = new()
+        {
+            Type = ActivityType.Message,
+            From = new ChannelAccount { Id = "user-id" },
+            Recipient = new ChannelAccount { Id = "28:recipient-account-id", BotId = "28:recipient-bot-id" },
+        };
+
+        BotRequestContext? ctx = BotRequestContext.FromInboundActivity(activity);
+
+        Assert.NotNull(ctx);
+        Assert.Equal("recipient-bot-id", ctx!.BotAppId);
+    }
+
     // ---- Merge -------------------------------------------------------------
 
     [Fact]

--- a/core/test/Microsoft.Teams.Core.UnitTests/UserTokenClientTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/UserTokenClientTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Teams.Core.Http;
+using Microsoft.Teams.Core.Schema;
+
+namespace Microsoft.Teams.Core.UnitTests;
+
+public class UserTokenClientTests
+{
+    [Fact]
+    public async Task GetTokenAsync_WithRequestContext_StampsRequestOptions()
+    {
+        CapturingHandler handler = new();
+        UserTokenClient client = CreateClient(handler);
+        AgenticIdentity identity = new()
+        {
+            AgenticAppId = "agentic-app",
+            AgenticUserId = "agentic-user",
+            AgenticAppBlueprintId = "agentic-blueprint",
+        };
+        BotRequestContext requestContext = new()
+        {
+            AgenticIdentity = identity,
+            BotAppId = "bot-app",
+        };
+
+        await client.GetTokenAsync("user", "connection", "msteams", code: null, requestContext);
+
+        Assert.NotNull(handler.Request);
+        Assert.True(handler.Request.Options.TryGetValue(new HttpRequestOptionsKey<object?>(BotRequestContext.AgenticIdentityKey), out object? identityValue));
+        Assert.Same(identity, identityValue);
+        Assert.True(handler.Request.Options.TryGetValue(new HttpRequestOptionsKey<object?>(BotRequestContext.BotAppIdKey), out object? botAppIdValue));
+        Assert.Equal("bot-app", botAppIdValue);
+    }
+
+    private static UserTokenClient CreateClient(HttpMessageHandler handler)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["UserTokenApiEndpoint"] = "https://token.test"
+            })
+            .Build();
+
+        return new UserTokenClient(new HttpClient(handler), configuration, NullLogger<UserTokenClient>.Instance);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Request { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            HttpResponseMessage response = new(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"connectionName":"connection","token":"token"}""", Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add typed `botId` support on core channel accounts and preserve it through cloning/BotBuilder mapping
- Derive inbound bot app id from `recipient.botId` while deriving agentic identity from inbound recipient
- Update BotBuilder compat to use recipient agentic identity and avoid empty identity defaults

## Validation
- `dotnet test core/test/Microsoft.Teams.Core.UnitTests/Microsoft.Teams.Core.UnitTests.csproj --filter BotRequestContextTests --verbosity minimal`
- `dotnet test core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/Microsoft.Teams.Apps.BotBuilder.UnitTests.csproj --verbosity minimal`