### PR TITLE
Bump Microsoft.OpenApi in affected samples

### DIFF
--- a/Samples/Deprecated.Controllers/Deprecated.Controllers.csproj
+++ b/Samples/Deprecated.Controllers/Deprecated.Controllers.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Samples.Dialogs/Samples.Dialogs.csproj
+++ b/Samples/Samples.Dialogs/Samples.Dialogs.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Add direct `Microsoft.OpenApi` 2.7.5 references to `Samples/Deprecated.Controllers` and `Samples/Samples.Dialogs`
- Keep existing `Microsoft.AspNetCore.OpenApi` versions unchanged
- Limit dependency changes to the projects restoring vulnerable `Microsoft.OpenApi` 2.0.0

## Validation
- `dotnet restore Samples/Deprecated.Controllers/Deprecated.Controllers.csproj --no-cache --force-evaluate -v minimal`
- `dotnet restore Samples/Samples.Dialogs/Samples.Dialogs.csproj --no-cache --force-evaluate -v minimal`
- `dotnet build Samples/Deprecated.Controllers/Deprecated.Controllers.csproj --no-restore -v minimal`
- `dotnet build Samples/Samples.Dialogs/Samples.Dialogs.csproj --no-restore -v minimal`