### PR TITLE
Thread BotRequestContext through Apps API clients and OAuth flows

### DIFF
--- a/core/src/Microsoft.Teams.Apps.BotBuilder/ActivitySchemaMapper.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/ActivitySchemaMapper.cs
@@ -8,6 +8,7 @@ using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
 using Microsoft.Teams.Core.Schema;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Teams.Apps.BotBuilder;
 
@@ -69,6 +70,10 @@ public static class ActivitySchemaMapper
             Name = account.Name
         };
 
+        if (!string.IsNullOrEmpty(account.BotId))
+        {
+            channelAccount.Properties.Add("botId", account.BotId);
+        }
 
         if (account.Properties.TryGetValue("aadObjectId", out object? aadObjectId))
         {
@@ -205,6 +210,11 @@ public static class ActivitySchemaMapper
         ArgumentNullException.ThrowIfNull(account);
 
         Microsoft.Teams.Core.Schema.ChannelAccount result = new() { Id = account.Id, Name = account.Name };
+
+        if (account.Properties is not null && account.Properties.TryGetValue("botId", out JToken? botId))
+        {
+            result.BotId = GetStringValue(botId);
+        }
 
         if (!string.IsNullOrEmpty(account.AadObjectId))
         {

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsApiClient.cs
@@ -45,10 +45,10 @@ public static class TeamsApiClient
             ?? throw new InvalidOperationException("ServiceUrl is required.");
     }
 
-    private static AgenticIdentity GetIdentity(ITurnContext turnContext)
+    private static AgenticIdentity? GetIdentity(ITurnContext turnContext)
     {
         CoreActivity coreActivity = turnContext.Activity.FromBotFrameworkActivity();
-        return AgenticIdentity.FromAccount(coreActivity.From) ?? new AgenticIdentity();
+        return AgenticIdentity.FromAccount(coreActivity.Recipient);
     }
 
     #endregion
@@ -87,7 +87,7 @@ public static class TeamsApiClient
 
             ConversationClient client = GetConversationClient(turnContext);
             Uri serviceUrl = new(GetServiceUrl(turnContext));
-            AgenticIdentity identity = GetIdentity(turnContext);
+            AgenticIdentity? identity = GetIdentity(turnContext);
 
             Core.Schema.ChannelAccount result = await client.GetConversationMemberAsync<Core.Schema.ChannelAccount>(
                 conversationId, userId, serviceUrl, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
@@ -121,7 +121,7 @@ public static class TeamsApiClient
 
             ConversationClient client = GetConversationClient(turnContext);
             Uri serviceUrl = new(GetServiceUrl(turnContext));
-            AgenticIdentity identity = GetIdentity(turnContext);
+            AgenticIdentity? identity = GetIdentity(turnContext);
 
             IList<Core.Schema.ChannelAccount> members = await client.GetConversationMembersAsync(
                 conversationId, serviceUrl, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
@@ -158,7 +158,7 @@ public static class TeamsApiClient
 
             ConversationClient client = GetConversationClient(turnContext);
             Uri serviceUrl = new(GetServiceUrl(turnContext));
-            AgenticIdentity identity = GetIdentity(turnContext);
+            AgenticIdentity? identity = GetIdentity(turnContext);
 
             Core.PagedMembersResult pagedMembers = await client.GetConversationPagedMembersAsync(
                 conversationId, serviceUrl, pageSize, continuationToken, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
@@ -192,7 +192,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity identity = GetIdentity(turnContext);
+        AgenticIdentity? identity = GetIdentity(turnContext);
 
         Core.Schema.ChannelAccount result = await client.GetConversationMemberAsync<Core.Schema.ChannelAccount>(
             t, userId, serviceUrl, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
@@ -220,7 +220,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity identity = GetIdentity(turnContext);
+        AgenticIdentity? identity = GetIdentity(turnContext);
 
         IList<Core.Schema.ChannelAccount> members = await client.GetConversationMembersAsync(
             t, serviceUrl, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
@@ -251,7 +251,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity identity = GetIdentity(turnContext);
+        AgenticIdentity? identity = GetIdentity(turnContext);
 
         Core.PagedMembersResult pagedMembers = await client.GetConversationPagedMembersAsync(
             t, serviceUrl, pageSize, continuationToken, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
@@ -280,7 +280,7 @@ public static class TeamsApiClient
             ?? throw new InvalidOperationException("The meetingId can only be null if turnContext is within the scope of a MS Teams Meeting.");
 
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
 
         ConversationClient client = GetConversationClient(turnContext);
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v1/meetings/{Uri.EscapeDataString(meetingId)}";
@@ -319,7 +319,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v1/meetings/{Uri.EscapeDataString(meetingId)}/participants/{Uri.EscapeDataString(participantId)}?tenantId={Uri.EscapeDataString(tenantId)}";
 
@@ -353,7 +353,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v1/meetings/{Uri.EscapeDataString(meetingId)}/notification";
         string body = JsonConvert.SerializeObject(notification);
@@ -387,7 +387,7 @@ public static class TeamsApiClient
             ?? throw new InvalidOperationException("This method is only valid within the scope of MS Teams Team.");
 
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity identity = GetIdentity(turnContext);
+        AgenticIdentity? identity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/teams/{Uri.EscapeDataString(t)}";
 
@@ -419,7 +419,7 @@ public static class TeamsApiClient
             ?? throw new InvalidOperationException("This method is only valid within the scope of MS Teams Team.");
 
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity identity = GetIdentity(turnContext);
+        AgenticIdentity? identity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/teams/{Uri.EscapeDataString(t)}/conversations";
 
@@ -461,7 +461,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/users/";
         SendMessageToUsersRequest request = new()
@@ -503,7 +503,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/channels/";
         SendMessageToUsersRequest request = new()
         {
@@ -545,7 +545,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
         if (activity is not Activity teamActivity)
             throw new ArgumentException("Expected a Bot Framework Activity instance.", nameof(activity));
         CoreActivity coreActivity = teamActivity.FromBotFrameworkActivity();
@@ -588,7 +588,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
         if (activity is not Activity tenantActivity)
             throw new ArgumentException("Expected a Bot Framework Activity instance.", nameof(activity));
         CoreActivity coreActivity = tenantActivity.FromBotFrameworkActivity();
@@ -684,7 +684,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/{Uri.EscapeDataString(operationId)}";
 
 
@@ -715,7 +715,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/failedentries/{Uri.EscapeDataString(operationId)}";
 
@@ -749,7 +749,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity agenticIdentity = GetIdentity(turnContext);
+        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/{Uri.EscapeDataString(operationId)}";
 

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ActivityClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ActivityClient.cs
@@ -18,11 +18,13 @@ public class ActivityClient
 {
     private readonly CoreConversationClient _client;
     private readonly Uri _serviceUrl;
+    private readonly BotRequestContext? _requestContext;
 
-    internal ActivityClient(Uri serviceUrl, CoreConversationClient client)
+    internal ActivityClient(Uri serviceUrl, CoreConversationClient client, BotRequestContext? requestContext = null)
     {
         _serviceUrl = serviceUrl;
         _client = client;
+        _requestContext = requestContext;
     }
 
     /// <summary>
@@ -30,10 +32,18 @@ public class ActivityClient
     /// </summary>
     public Task<SendActivityResponse?> CreateAsync(string conversationId, CoreActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
+        return CreateAsync(conversationId, activity, requestContext: null, additionalHeaders, cancellationToken);
+    }
+
+    /// <summary>
+    /// Create a new activity in a conversation.
+    /// </summary>
+    public Task<SendActivityResponse?> CreateAsync(string conversationId, CoreActivity activity, BotRequestContext? requestContext, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
         ArgumentNullException.ThrowIfNull(activity);
         activity.ServiceUrl ??= _serviceUrl;
         activity.Conversation ??= new Conversation(conversationId);
-        return _client.SendActivityAsync(activity, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.SendActivityAsync(activity, requestContext: BotRequestContext.Merge(_requestContext, requestContext), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -41,9 +51,17 @@ public class ActivityClient
     /// </summary>
     public Task<UpdateActivityResponse> UpdateAsync(string conversationId, string id, CoreActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
+        return UpdateAsync(conversationId, id, activity, requestContext: null, additionalHeaders, cancellationToken);
+    }
+
+    /// <summary>
+    /// Update an existing activity in a conversation.
+    /// </summary>
+    public Task<UpdateActivityResponse> UpdateAsync(string conversationId, string id, CoreActivity activity, BotRequestContext? requestContext, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
         ArgumentNullException.ThrowIfNull(activity);
         activity.ServiceUrl ??= _serviceUrl;
-        return _client.UpdateActivityAsync(conversationId, id, activity, requestContext: BotRequestContext.FromActivity(activity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.UpdateActivityAsync(conversationId, id, activity, requestContext: BotRequestContext.Merge(BotRequestContext.Merge(_requestContext, requestContext), BotRequestContext.FromActivity(activity)), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -51,11 +69,19 @@ public class ActivityClient
     /// </summary>
     public Task<SendActivityResponse?> ReplyAsync(string conversationId, string id, CoreActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
+        return ReplyAsync(conversationId, id, activity, requestContext: null, additionalHeaders, cancellationToken);
+    }
+
+    /// <summary>
+    /// Reply to an existing activity in a conversation.
+    /// </summary>
+    public Task<SendActivityResponse?> ReplyAsync(string conversationId, string id, CoreActivity activity, BotRequestContext? requestContext, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
         ArgumentNullException.ThrowIfNull(activity);
         activity.ReplyToId = id;
         activity.ServiceUrl ??= _serviceUrl;
         activity.Conversation ??= new Conversation(conversationId);
-        return _client.SendActivityAsync(activity, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.SendActivityAsync(activity, requestContext: BotRequestContext.Merge(_requestContext, requestContext), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -63,7 +89,7 @@ public class ActivityClient
     /// </summary>
     public Task DeleteAsync(string conversationId, string id, AgenticIdentity? agenticIdentity = null, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
-        return _client.DeleteActivityAsync(conversationId, id, _serviceUrl, requestContext: BotRequestContext.FromAgenticIdentity(agenticIdentity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.DeleteActivityAsync(conversationId, id, _serviceUrl, requestContext: BotRequestContext.Merge(_requestContext, BotRequestContext.FromAgenticIdentity(agenticIdentity)), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ApiClient.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Core.Http;
 
 using CoreConversationClient = Microsoft.Teams.Core.ConversationClient;
@@ -20,13 +21,14 @@ namespace Microsoft.Teams.Apps.Api.Clients;
 /// <list type="bullet">
 /// <item><b>DI-friendly (no serviceUrl)</b> — Use <see cref="ApiClient(HttpClient, CoreConversationClient, CoreUserTokenClient, ILogger)"/>
 /// and call <see cref="ForServiceUrl"/> per-request to create a scoped instance.</item>
-/// <item><b>Fully initialized</b> — Use <see cref="ApiClient(Uri, HttpClient, CoreConversationClient, CoreUserTokenClient, ILogger)"/>
+/// <item><b>Fully initialized</b> — Use the service URL constructor
 /// when the service URL is known upfront.</item>
 /// </list>
 /// </remarks>
 public class ApiClient
 {
     private readonly BotHttpClient _http;
+    private readonly BotRequestContext? _requestContext;
 
     internal CoreConversationClient ConversationClient { get; }
 
@@ -50,7 +52,7 @@ public class ApiClient
     /// Client for user token operations (OAuth SSO, sign-in resources).
     /// Lazily created over the underlying <see cref="UserTokenClient"/>; serviceUrl-independent.
     /// </summary>
-    public virtual UserTokenApiClient UserToken => _userToken ??= new UserTokenApiClient(UserTokenClient);
+    public virtual UserTokenApiClient UserToken => _userToken ??= new UserTokenApiClient(UserTokenClient, _requestContext);
 
     /// <summary>
     /// Client for team operations.
@@ -96,7 +98,8 @@ public class ApiClient
     /// <param name="conversationClient">The core conversation client for conversation/activity/member operations.</param>
     /// <param name="userTokenClient">The core user token client for sign-in and token operations.</param>
     /// <param name="logger">Optional logger.</param>
-    internal ApiClient(Uri serviceUrl, HttpClient httpClient, CoreConversationClient conversationClient, CoreUserTokenClient userTokenClient, ILogger? logger = null)
+    /// <param name="requestContext">Optional default request context used when an API method does not receive one.</param>
+    internal ApiClient(Uri serviceUrl, HttpClient httpClient, CoreConversationClient conversationClient, CoreUserTokenClient userTokenClient, ILogger? logger = null, BotRequestContext? requestContext = null)
     {
         ArgumentNullException.ThrowIfNull(serviceUrl);
         ArgumentNullException.ThrowIfNull(httpClient);
@@ -104,24 +107,40 @@ public class ApiClient
         ArgumentNullException.ThrowIfNull(userTokenClient);
 
         _http = new BotHttpClient(httpClient, logger);
+        _requestContext = requestContext;
         ConversationClient = conversationClient;
         UserTokenClient = userTokenClient;
         ServiceUrl = serviceUrl;
-        Conversations = new ConversationApiClient(serviceUrl, conversationClient);
-        Teams = new TeamClient(serviceUrl.ToString(), _http);
-        Meetings = new MeetingClient(serviceUrl.ToString(), _http);
+        Conversations = new ConversationApiClient(serviceUrl, conversationClient, requestContext);
+        Teams = new TeamClient(serviceUrl.ToString(), _http, requestContext);
+        Meetings = new MeetingClient(serviceUrl.ToString(), _http, requestContext);
     }
 
-    // Private constructor for ForServiceUrl — shares BotHttpClient, ConversationClient, and UserTokenClient
-    private ApiClient(BotHttpClient http, CoreConversationClient conversationClient, CoreUserTokenClient userTokenClient, Uri serviceUrl)
+    // Private constructors for scoped clients — share BotHttpClient, ConversationClient, and UserTokenClient.
+    private ApiClient(BotHttpClient http, CoreConversationClient conversationClient, CoreUserTokenClient userTokenClient, BotRequestContext? requestContext)
     {
         _http = http;
+        _requestContext = requestContext;
+        ConversationClient = conversationClient;
+        UserTokenClient = userTokenClient;
+
+        // ServiceUrl-dependent sub-clients require ForServiceUrl() before use
+        ServiceUrl = null!;
+        Conversations = null!;
+        Teams = null!;
+        Meetings = null!;
+    }
+
+    private ApiClient(BotHttpClient http, CoreConversationClient conversationClient, CoreUserTokenClient userTokenClient, Uri serviceUrl, BotRequestContext? requestContext)
+    {
+        _http = http;
+        _requestContext = requestContext;
         ConversationClient = conversationClient;
         UserTokenClient = userTokenClient;
         ServiceUrl = serviceUrl;
-        Conversations = new ConversationApiClient(serviceUrl, conversationClient);
-        Teams = new TeamClient(serviceUrl.ToString(), http);
-        Meetings = new MeetingClient(serviceUrl.ToString(), http);
+        Conversations = new ConversationApiClient(serviceUrl, conversationClient, requestContext);
+        Teams = new TeamClient(serviceUrl.ToString(), http, requestContext);
+        Meetings = new MeetingClient(serviceUrl.ToString(), http, requestContext);
     }
 
     /// <summary>
@@ -133,6 +152,31 @@ public class ApiClient
     public virtual ApiClient ForServiceUrl(Uri serviceUrl)
     {
         ArgumentNullException.ThrowIfNull(serviceUrl);
-        return new ApiClient(_http, ConversationClient, UserTokenClient, serviceUrl);
+        return new ApiClient(_http, ConversationClient, UserTokenClient, serviceUrl, _requestContext);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="ApiClient"/> scoped to the specified request context.
+    /// </summary>
+    /// <param name="requestContext">The request context used when an API method does not receive one.</param>
+    /// <returns>A new <see cref="ApiClient"/> with the request context applied.</returns>
+    public virtual ApiClient ForRequestContext(BotRequestContext? requestContext)
+    {
+        BotRequestContext? mergedRequestContext = BotRequestContext.Merge(_requestContext, requestContext);
+        return ServiceUrl is null
+            ? new ApiClient(_http, ConversationClient, UserTokenClient, mergedRequestContext)
+            : new ApiClient(_http, ConversationClient, UserTokenClient, ServiceUrl, mergedRequestContext);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="ApiClient"/> scoped to the specified inbound activity.
+    /// </summary>
+    /// <param name="activity">The inbound activity that supplies the service URL and request context.</param>
+    /// <returns>A new <see cref="ApiClient"/> bound to the activity's service URL and request context.</returns>
+    public virtual ApiClient ForActivity(TeamsActivity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        return ForRequestContext(BotRequestContext.FromInboundActivity(activity))
+            .ForServiceUrl(activity.ServiceUrl ?? throw new InvalidOperationException("Activity.ServiceUrl is required to use the Api client."));
     }
 }

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs
@@ -17,6 +17,7 @@ public class ConversationApiClient
 {
     private readonly CoreConversationClient _client;
     private readonly Uri _serviceUrl;
+    private readonly BotRequestContext? _requestContext;
 
     /// <summary>
     /// Client for activity operations.
@@ -33,13 +34,14 @@ public class ConversationApiClient
     /// </summary>
     public ReactionClient Reactions { get; }
 
-    internal ConversationApiClient(Uri serviceUrl, CoreConversationClient client)
+    internal ConversationApiClient(Uri serviceUrl, CoreConversationClient client, BotRequestContext? requestContext = null)
     {
         _serviceUrl = serviceUrl;
         _client = client;
-        Activities = new ActivityClient(serviceUrl, client);
-        Members = new MemberClient(serviceUrl, client);
-        Reactions = new ReactionClient(serviceUrl, client);
+        _requestContext = requestContext;
+        Activities = new ActivityClient(serviceUrl, client, requestContext);
+        Members = new MemberClient(serviceUrl, client, requestContext);
+        Reactions = new ReactionClient(serviceUrl, client, requestContext);
     }
 
     /// <summary>
@@ -47,6 +49,14 @@ public class ConversationApiClient
     /// </summary>
     public Task<CreateConversationResponse> CreateAsync(ConversationParameters request, AgenticIdentity? agenticIdentity = null, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
-        return _client.CreateConversationAsync(request, _serviceUrl, requestContext: BotRequestContext.FromAgenticIdentity(agenticIdentity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return CreateAsync(request, BotRequestContext.FromAgenticIdentity(agenticIdentity), additionalHeaders, cancellationToken);
+    }
+
+    /// <summary>
+    /// Create a new conversation.
+    /// </summary>
+    public Task<CreateConversationResponse> CreateAsync(ConversationParameters request, BotRequestContext? requestContext, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        return _client.CreateConversationAsync(request, _serviceUrl, requestContext: BotRequestContext.Merge(_requestContext, requestContext), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 }

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/MeetingClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/MeetingClient.cs
@@ -14,11 +14,13 @@ public class MeetingClient
 {
     private readonly BotHttpClient _http;
     private readonly string _serviceUrl;
+    private readonly BotRequestContext? _requestContext;
 
-    internal MeetingClient(string serviceUrl, BotHttpClient http)
+    internal MeetingClient(string serviceUrl, BotHttpClient http, BotRequestContext? requestContext = null)
     {
         _serviceUrl = serviceUrl.TrimEnd('/');
         _http = http;
+        _requestContext = requestContext;
     }
 
     /// <summary>
@@ -39,8 +41,8 @@ public class MeetingClient
         return await _http.SendAsync<MeetingParticipant>(HttpMethod.Get, url, body: null, options: CreateRequestOptions(agenticIdentity), cancellationToken).ConfigureAwait(false);
     }
 
-    private static BotRequestOptions? CreateRequestOptions(AgenticIdentity? agenticIdentity) =>
-        agenticIdentity is null ? null : new() { RequestContext = BotRequestContext.FromAgenticIdentity(agenticIdentity) };
+    private BotRequestOptions CreateRequestOptions(AgenticIdentity? agenticIdentity) =>
+        new() { RequestContext = BotRequestContext.Merge(_requestContext, BotRequestContext.FromAgenticIdentity(agenticIdentity)) };
 }
 
 /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/MemberClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/MemberClient.cs
@@ -19,11 +19,13 @@ public class MemberClient
 {
     private readonly CoreConversationClient _client;
     private readonly Uri _serviceUrl;
+    private readonly BotRequestContext? _requestContext;
 
-    internal MemberClient(Uri serviceUrl, CoreConversationClient client)
+    internal MemberClient(Uri serviceUrl, CoreConversationClient client, BotRequestContext? requestContext = null)
     {
         _serviceUrl = serviceUrl;
         _client = client;
+        _requestContext = requestContext;
     }
 
     /// <summary>
@@ -32,7 +34,7 @@ public class MemberClient
     [Obsolete("Use GetPagedAsync instead.")]
     public async Task<IList<TeamsChannelAccount?>> GetAsync(string conversationId, AgenticIdentity? agenticIdentity = null, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
-        IList<ChannelAccount> members = await _client.GetConversationMembersAsync(conversationId, _serviceUrl, requestContext: BotRequestContext.FromAgenticIdentity(agenticIdentity), customHeaders: additionalHeaders, cancellationToken: cancellationToken).ConfigureAwait(false);
+        IList<ChannelAccount> members = await _client.GetConversationMembersAsync(conversationId, _serviceUrl, requestContext: BotRequestContext.Merge(_requestContext, BotRequestContext.FromAgenticIdentity(agenticIdentity)), customHeaders: additionalHeaders, cancellationToken: cancellationToken).ConfigureAwait(false);
         return [.. members.Select(m => TeamsChannelAccount.FromChannelAccount(m))];
     }
 
@@ -52,7 +54,7 @@ public class MemberClient
             _serviceUrl,
             pageSize,
             continuationToken,
-            requestContext: BotRequestContext.FromAgenticIdentity(agenticIdentity),
+            requestContext: BotRequestContext.Merge(_requestContext, BotRequestContext.FromAgenticIdentity(agenticIdentity)),
             customHeaders: additionalHeaders,
             cancellationToken: cancellationToken).ConfigureAwait(false);
         PagedTeamsMembersResult result = new();
@@ -111,7 +113,7 @@ public class MemberClient
     /// </summary>
     public Task<T> GetByIdAsync<T>(string conversationId, string memberId, AgenticIdentity? agenticIdentity = null, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default) where T : ChannelAccount
     {
-        return _client.GetConversationMemberAsync<T>(conversationId, memberId, _serviceUrl, requestContext: BotRequestContext.FromAgenticIdentity(agenticIdentity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.GetConversationMemberAsync<T>(conversationId, memberId, _serviceUrl, requestContext: BotRequestContext.Merge(_requestContext, BotRequestContext.FromAgenticIdentity(agenticIdentity)), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ReactionClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ReactionClient.cs
@@ -15,11 +15,13 @@ public class ReactionClient
 {
     private readonly CoreConversationClient _client;
     private readonly Uri _serviceUrl;
+    private readonly BotRequestContext? _requestContext;
 
-    internal ReactionClient(Uri serviceUrl, CoreConversationClient client)
+    internal ReactionClient(Uri serviceUrl, CoreConversationClient client, BotRequestContext? requestContext = null)
     {
         _serviceUrl = serviceUrl;
         _client = client;
+        _requestContext = requestContext;
     }
 
     /// <summary>
@@ -33,7 +35,7 @@ public class ReactionClient
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     public Task AddAsync(string conversationId, string activityId, string reactionType, AgenticIdentity? agenticIdentity = null, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
-        return _client.AddReactionAsync(conversationId, activityId, reactionType, _serviceUrl, requestContext: BotRequestContext.FromAgenticIdentity(agenticIdentity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.AddReactionAsync(conversationId, activityId, reactionType, _serviceUrl, requestContext: BotRequestContext.Merge(_requestContext, BotRequestContext.FromAgenticIdentity(agenticIdentity)), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -47,6 +49,6 @@ public class ReactionClient
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     public Task DeleteAsync(string conversationId, string activityId, string reactionType, AgenticIdentity? agenticIdentity = null, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
-        return _client.DeleteReactionAsync(conversationId, activityId, reactionType, _serviceUrl, requestContext: BotRequestContext.FromAgenticIdentity(agenticIdentity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.DeleteReactionAsync(conversationId, activityId, reactionType, _serviceUrl, requestContext: BotRequestContext.Merge(_requestContext, BotRequestContext.FromAgenticIdentity(agenticIdentity)), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 }

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/TeamClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/TeamClient.cs
@@ -15,11 +15,13 @@ public class TeamClient
 {
     private readonly BotHttpClient _http;
     private readonly string _serviceUrl;
+    private readonly BotRequestContext? _requestContext;
 
-    internal TeamClient(string serviceUrl, BotHttpClient http)
+    internal TeamClient(string serviceUrl, BotHttpClient http, BotRequestContext? requestContext = null)
     {
         _serviceUrl = serviceUrl.TrimEnd('/');
         _http = http;
+        _requestContext = requestContext;
     }
 
     /// <summary>
@@ -41,8 +43,8 @@ public class TeamClient
         return response?.Conversations;
     }
 
-    private static BotRequestOptions? CreateRequestOptions(AgenticIdentity? agenticIdentity) =>
-        agenticIdentity is null ? null : new() { RequestContext = BotRequestContext.FromAgenticIdentity(agenticIdentity) };
+    private BotRequestOptions CreateRequestOptions(AgenticIdentity? agenticIdentity) =>
+        new() { RequestContext = BotRequestContext.Merge(_requestContext, BotRequestContext.FromAgenticIdentity(agenticIdentity)) };
 
     private sealed class ConversationListResponse
     {

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/UserTokenApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/UserTokenApiClient.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Http;
+using Microsoft.Teams.Core.Schema;
 
 using CoreUserTokenClient = Microsoft.Teams.Core.UserTokenClient;
 
@@ -14,65 +16,112 @@ namespace Microsoft.Teams.Apps.Api.Clients;
 public class UserTokenApiClient
 {
     private readonly CoreUserTokenClient _client;
+    private readonly BotRequestContext? _requestContext;
 
-    internal UserTokenApiClient(CoreUserTokenClient client)
+    internal UserTokenApiClient(CoreUserTokenClient client, BotRequestContext? requestContext = null)
     {
         _client = client;
+        _requestContext = requestContext;
     }
 
     /// <summary>
     /// Get a user token for a connection.
     /// </summary>
     public Task<GetTokenResult?> GetAsync(string userId, string connectionName, string channelId, string? code = null, CancellationToken cancellationToken = default)
+        => GetAsync(userId, connectionName, channelId, code, agenticIdentity: null, cancellationToken);
+
+    /// <summary>
+    /// Get a user token for a connection.
+    /// </summary>
+    public Task<GetTokenResult?> GetAsync(string userId, string connectionName, string channelId, string? code, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
     {
-        return _client.GetTokenAsync(userId, connectionName, channelId, code, cancellationToken);
+        return _client.GetTokenAsync(userId, connectionName, channelId, code, CreateRequestContext(agenticIdentity), cancellationToken);
     }
 
     /// <summary>
     /// Get AAD tokens for specified resources.
     /// </summary>
     public async Task<IDictionary<string, GetTokenResult>?> GetAadAsync(string userId, string connectionName, string channelId, IList<string>? resourceUrls = null, CancellationToken cancellationToken = default)
+        => await GetAadAsync(userId, connectionName, channelId, resourceUrls, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Get AAD tokens for specified resources.
+    /// </summary>
+    public async Task<IDictionary<string, GetTokenResult>?> GetAadAsync(string userId, string connectionName, string channelId, IList<string>? resourceUrls, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
     {
-        return await _client.GetAadTokensAsync(userId, connectionName, channelId, resourceUrls?.ToArray(), cancellationToken).ConfigureAwait(false);
+        return await _client.GetAadTokensAsync(userId, connectionName, channelId, resourceUrls?.ToArray(), CreateRequestContext(agenticIdentity), cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Get the token status for a user's connections.
     /// </summary>
     public async Task<IList<GetTokenStatusResult>?> GetStatusAsync(string userId, string channelId, string? includeFilter = null, CancellationToken cancellationToken = default)
+        => await GetStatusAsync(userId, channelId, includeFilter, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Get the token status for a user's connections.
+    /// </summary>
+    public async Task<IList<GetTokenStatusResult>?> GetStatusAsync(string userId, string channelId, string? includeFilter, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
     {
-        return await _client.GetTokenStatusAsync(userId, channelId, includeFilter, cancellationToken).ConfigureAwait(false);
+        return await _client.GetTokenStatusAsync(userId, channelId, includeFilter, CreateRequestContext(agenticIdentity), cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Sign a user out of a connection.
     /// </summary>
     public Task SignOutAsync(string userId, string connectionName, string channelId, CancellationToken cancellationToken = default)
+        => SignOutAsync(userId, connectionName, channelId, agenticIdentity: null, cancellationToken);
+
+    /// <summary>
+    /// Sign a user out of a connection.
+    /// </summary>
+    public Task SignOutAsync(string userId, string connectionName, string channelId, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
     {
-        return _client.SignOutUserAsync(userId, connectionName, channelId, cancellationToken);
+        return _client.SignOutUserAsync(userId, connectionName, channelId, CreateRequestContext(agenticIdentity), cancellationToken);
     }
 
     /// <summary>
     /// Exchange a token for another token.
     /// </summary>
     public async Task<GetTokenResult?> ExchangeAsync(string userId, string connectionName, string channelId, string exchangeToken, CancellationToken cancellationToken = default)
+        => await ExchangeAsync(userId, connectionName, channelId, exchangeToken, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Exchange a token for another token.
+    /// </summary>
+    public async Task<GetTokenResult?> ExchangeAsync(string userId, string connectionName, string channelId, string exchangeToken, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
     {
-        return await _client.ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, cancellationToken).ConfigureAwait(false);
+        return await _client.ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, CreateRequestContext(agenticIdentity), cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Get the sign-in URL for a connection.
     /// </summary>
     public Task<string?> GetSignInUrlAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
+        => GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, agenticIdentity: null, cancellationToken);
+
+    /// <summary>
+    /// Get the sign-in URL for a connection.
+    /// </summary>
+    public Task<string?> GetSignInUrlAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
     {
-        return _client.GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, cancellationToken);
+        return _client.GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, CreateRequestContext(agenticIdentity), cancellationToken);
     }
 
     /// <summary>
     /// Get the sign-in resource for a connection.
     /// </summary>
     public Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
+        => GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, agenticIdentity: null, cancellationToken);
+
+    /// <summary>
+    /// Get the sign-in resource for a connection.
+    /// </summary>
+    public Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
     {
-        return _client.GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, cancellationToken);
+        return _client.GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, CreateRequestContext(agenticIdentity), cancellationToken);
     }
+
+    private BotRequestContext? CreateRequestContext(AgenticIdentity? agenticIdentity) =>
+        BotRequestContext.Merge(_requestContext, BotRequestContext.FromAgenticIdentity(agenticIdentity));
 }

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -46,10 +46,9 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     private ApiClient? _api;
 
     /// <summary>
-    /// Gets the <see cref="ApiClient"/> scoped to the current activity's service URL.
+    /// Gets the <see cref="ApiClient"/> scoped to the current activity.
     /// </summary>
-    public ApiClient Api => _api ??= TeamsBotApplication.Api.ForServiceUrl(
-        Activity.ServiceUrl ?? throw new InvalidOperationException("Activity.ServiceUrl is required to use the Api client."));
+    public ApiClient Api => _api ??= TeamsBotApplication.Api.ForActivity(Activity);
 
     // ==================== Turn State ====================
 

--- a/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
+++ b/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
@@ -10,6 +10,8 @@ using Microsoft.Teams.Apps.Handlers;
 using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Core;
 using Microsoft.Teams.Core.Diagnostics;
+using Microsoft.Teams.Core.Http;
+using Microsoft.Teams.Core.Schema;
 
 namespace Microsoft.Teams.Apps.OAuth;
 
@@ -108,7 +110,7 @@ public class OAuthFlow
         string result = AppsTelemetry.OAuthResults.Miss;
         try
         {
-            GetTokenResult? tokenResult = await _app.UserTokenClient.GetTokenAsync(userId, _connectionName, channelId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            GetTokenResult? tokenResult = await GetTokenAsync(context, userId, _connectionName, channelId, code: null, cancellationToken).ConfigureAwait(false);
             result = tokenResult?.Token is not null ? AppsTelemetry.OAuthResults.Hit : AppsTelemetry.OAuthResults.Miss;
             span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
             return tokenResult?.Token;
@@ -160,7 +162,7 @@ public class OAuthFlow
         try
         {
             // 1. Try silent token acquisition
-            GetTokenResult? existingToken = await _app.UserTokenClient.GetTokenAsync(userId, _connectionName, channelId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            GetTokenResult? existingToken = await GetTokenAsync(context, userId, _connectionName, channelId, code: null, cancellationToken).ConfigureAwait(false);
             if (existingToken?.Token is not null)
             {
                 _logger.LogDebug("Token found in store for connection '{ConnectionName}', user '{UserId}'.", _connectionName, userId);
@@ -189,8 +191,7 @@ public class OAuthFlow
             };
             string state = Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(tokenExchangeState));
 
-            GetSignInResourceResult signInResource = await _app.UserTokenClient
-                .GetSignInResourceAsync(state, cancellationToken: cancellationToken)
+            GetSignInResourceResult signInResource = await GetSignInResourceAsync(context, state, cancellationToken)
                 .ConfigureAwait(false);
 
             OAuthCard oauthCard = new()
@@ -264,7 +265,7 @@ public class OAuthFlow
         try
         {
             _logger.LogDebug("Signing out user '{UserId}' from connection '{ConnectionName}'.", userId, _connectionName);
-            await _app.UserTokenClient.SignOutUserAsync(userId, _connectionName, channelId, cancellationToken).ConfigureAwait(false);
+            await SignOutUserAsync(context, userId, _connectionName, channelId, cancellationToken).ConfigureAwait(false);
             result = AppsTelemetry.OAuthResults.Success;
             span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
         }
@@ -317,7 +318,7 @@ public class OAuthFlow
         string result = AppsTelemetry.OAuthResults.Failure;
         try
         {
-            IList<GetTokenStatusResult> statuses = await _app.UserTokenClient.GetTokenStatusAsync(userId, channelId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            IList<GetTokenStatusResult> statuses = await GetTokenStatusAsync(context, userId, channelId, include: null, cancellationToken).ConfigureAwait(false);
             result = AppsTelemetry.OAuthResults.Success;
             span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
             return statuses;
@@ -370,9 +371,7 @@ public class OAuthFlow
 
             try
             {
-                GetTokenResult tokenResult = await _app.UserTokenClient
-                    .ExchangeTokenAsync(userId, connectionName, channelId, exchangeValue.Token, cancellationToken)
-                    .ConfigureAwait(false);
+                GetTokenResult tokenResult = await ExchangeTokenAsync(context, userId, connectionName, channelId, exchangeValue.Token, cancellationToken).ConfigureAwait(false);
 
                 if (tokenResult?.Token is not null)
                 {
@@ -505,9 +504,7 @@ public class OAuthFlow
 
             try
             {
-                GetTokenResult? tokenResult = await _app.UserTokenClient
-                    .GetTokenAsync(userId, connectionName, channelId, code: verifyValue.State, cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                GetTokenResult? tokenResult = await GetTokenAsync(context, userId, connectionName, channelId, code: verifyValue.State, cancellationToken).ConfigureAwait(false);
 
                 if (tokenResult?.Token is not null)
                 {
@@ -742,6 +739,36 @@ public class OAuthFlow
                 _pendingSignIns.TryRemove(kvp.Key, out _);
             }
         }
+    }
+
+    private Task<GetTokenResult?> GetTokenAsync<TActivity>(Context<TActivity> context, string userId, string connectionName, string channelId, string? code, CancellationToken cancellationToken) where TActivity : TeamsActivity
+    {
+        BotRequestContext? requestContext = BotRequestContext.FromInboundActivity(context.Activity);
+        return _app.UserTokenClient.GetTokenAsync(userId, connectionName, channelId, code, requestContext, cancellationToken);
+    }
+
+    private Task<GetSignInResourceResult> GetSignInResourceAsync<TActivity>(Context<TActivity> context, string state, CancellationToken cancellationToken) where TActivity : TeamsActivity
+    {
+        BotRequestContext? requestContext = BotRequestContext.FromInboundActivity(context.Activity);
+        return _app.UserTokenClient.GetSignInResourceAsync(state, codeChallenge: null, emulatorUrl: null, finalRedirect: null, requestContext: requestContext, cancellationToken: cancellationToken);
+    }
+
+    private Task SignOutUserAsync<TActivity>(Context<TActivity> context, string userId, string connectionName, string channelId, CancellationToken cancellationToken) where TActivity : TeamsActivity
+    {
+        BotRequestContext? requestContext = BotRequestContext.FromInboundActivity(context.Activity);
+        return _app.UserTokenClient.SignOutUserAsync(userId, connectionName, channelId, requestContext, cancellationToken);
+    }
+
+    private Task<GetTokenStatusResult[]> GetTokenStatusAsync<TActivity>(Context<TActivity> context, string userId, string channelId, string? include, CancellationToken cancellationToken) where TActivity : TeamsActivity
+    {
+        BotRequestContext? requestContext = BotRequestContext.FromInboundActivity(context.Activity);
+        return _app.UserTokenClient.GetTokenStatusAsync(userId, channelId, include, requestContext, cancellationToken);
+    }
+
+    private Task<GetTokenResult> ExchangeTokenAsync<TActivity>(Context<TActivity> context, string userId, string connectionName, string channelId, string? token, CancellationToken cancellationToken) where TActivity : TeamsActivity
+    {
+        BotRequestContext? requestContext = BotRequestContext.FromInboundActivity(context.Activity);
+        return _app.UserTokenClient.ExchangeTokenAsync(userId, connectionName, channelId, token, requestContext, cancellationToken);
     }
 
     private static string GetUserId<TActivity>(Context<TActivity> context) where TActivity : TeamsActivity

--- a/core/src/Microsoft.Teams.Apps/Schema/TeamsChannelAccount.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/TeamsChannelAccount.cs
@@ -46,6 +46,7 @@ public class TeamsChannelAccount : ChannelAccount
         result.AgenticAppId = channelAccount.AgenticAppId;
         result.AgenticUserId = channelAccount.AgenticUserId;
         result.AgenticAppBlueprintId = channelAccount.AgenticAppBlueprintId;
+        result.BotId = channelAccount.BotId;
         result.Properties = new ExtendedPropertiesDictionary(channelAccount.Properties);
         result.AadObjectId = result.Properties.Extract<string>("aadObjectId");
         result.ObjectId = result.Properties.Extract<string>("objectId");

--- a/core/src/Microsoft.Teams.Core/Http/BotRequestContext.cs
+++ b/core/src/Microsoft.Teams.Core/Http/BotRequestContext.cs
@@ -53,7 +53,7 @@ public record BotRequestContext
     /// <param name="activity">The inbound activity, or null.</param>
     /// <returns>The context, or null when nothing could be derived.</returns>
     public static BotRequestContext? FromInboundActivity(CoreActivity? activity)
-        => Build(Schema.AgenticIdentity.FromAccount(activity?.Recipient), NormalizeAppId(activity?.Recipient?.BotId));
+        => Build(Schema.AgenticIdentity.FromAccount(activity?.Recipient), NormalizeAppId(activity?.Recipient?.BotId ?? activity?.Recipient?.Id));
 
     /// <summary>
     /// Builds context carrying only the supplied agentic identity.

--- a/core/src/Microsoft.Teams.Core/Http/BotRequestContext.cs
+++ b/core/src/Microsoft.Teams.Core/Http/BotRequestContext.cs
@@ -53,7 +53,7 @@ public record BotRequestContext
     /// <param name="activity">The inbound activity, or null.</param>
     /// <returns>The context, or null when nothing could be derived.</returns>
     public static BotRequestContext? FromInboundActivity(CoreActivity? activity)
-        => Build(Schema.AgenticIdentity.FromAccount(activity?.Recipient), NormalizeAppId(activity?.Recipient?.Id));
+        => Build(Schema.AgenticIdentity.FromAccount(activity?.Recipient), NormalizeAppId(activity?.Recipient?.BotId));
 
     /// <summary>
     /// Builds context carrying only the supplied agentic identity.

--- a/core/src/Microsoft.Teams.Core/Schema/ChannelAccount.cs
+++ b/core/src/Microsoft.Teams.Core/Schema/ChannelAccount.cs
@@ -19,6 +19,12 @@ public class ChannelAccount()
     public string? Id { get; set; }
 
     /// <summary>
+    /// Gets or sets the bot application ID associated with the account.
+    /// </summary>
+    [JsonPropertyName("botId")]
+    public string? BotId { get; set; }
+
+    /// <summary>
     /// Gets or sets the display name of the channel account.
     /// </summary>
     [JsonPropertyName("name")]

--- a/core/src/Microsoft.Teams.Core/Schema/CoreActivity.cs
+++ b/core/src/Microsoft.Teams.Core/Schema/CoreActivity.cs
@@ -170,11 +170,13 @@ public class CoreActivity
     private static ChannelAccount CloneChannelAccount(ChannelAccount source) => new()
     {
         Id = source.Id,
+        BotId = source.BotId,
         Name = source.Name,
         IsTargeted = source.IsTargeted,
         AgenticAppId = source.AgenticAppId,
         AgenticUserId = source.AgenticUserId,
         AgenticAppBlueprintId = source.AgenticAppBlueprintId,
+        TenantId = source.TenantId,
         Properties = new ExtendedPropertiesDictionary(source.Properties)
     };
 #pragma warning restore ExperimentalTeamsTargeted

--- a/core/src/Microsoft.Teams.Core/UserTokenClient.cs
+++ b/core/src/Microsoft.Teams.Core/UserTokenClient.cs
@@ -37,19 +37,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
     public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include = null, CancellationToken cancellationToken = default)
-        => await GetTokenStatusAsync(userId, channelId, include, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets the token status for each connection for the given user.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="include">The optional include parameter.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
-    public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await GetTokenStatusAsync(userId, channelId, include, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await GetTokenStatusAsync(userId, channelId, include, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Gets the token status for each connection for the given user.
@@ -99,20 +87,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
     public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code = null, CancellationToken cancellationToken = default)
-        => await GetTokenAsync(userId, connectionName, channelId, code, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets the user token for a particular connection.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="connectionName">The connection name.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="code">The optional code.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
-    public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await GetTokenAsync(userId, connectionName, channelId, code, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await GetTokenAsync(userId, connectionName, channelId, code, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Gets the user token for a particular connection.
@@ -159,21 +134,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
     public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect = null, CancellationToken cancellationToken = default)
-        => GetSignInResourceAsync(userId, connectionName, channelId, finalRedirect, agenticIdentity: null, cancellationToken);
-
-    /// <summary>
-    /// Get the token or raw signin link to be sent to the user for signin for a connection.
-    /// Builds the state parameter internally from the userId and connectionName.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="connectionName">The connection name.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="finalRedirect">The optional final redirect URL.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
-    public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => GetSignInResourceAsync(userId, connectionName, channelId, finalRedirect, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken);
+        => GetSignInResourceAsync(userId, connectionName, channelId, finalRedirect, requestContext: null, cancellationToken);
 
     /// <summary>
     /// Get the token or raw signin link to be sent to the user for signin for a connection.
@@ -213,20 +174,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The sign-in URL, or null if not available.</returns>
     public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
-        => await GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets the sign-in URL for the given state.
-    /// </summary>
-    /// <param name="state">The encoded state parameter.</param>
-    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
-    /// <param name="emulatorUrl">The optional emulator URL.</param>
-    /// <param name="finalRedirect">The optional final redirect URL.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The sign-in URL, or null if not available.</returns>
-    public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Gets the sign-in URL for the given state.
@@ -269,20 +217,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The sign-in resource result.</returns>
     public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
-        => await GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets the sign-in resource for the given state.
-    /// </summary>
-    /// <param name="state">The encoded state parameter.</param>
-    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
-    /// <param name="emulatorUrl">The optional emulator URL.</param>
-    /// <param name="finalRedirect">The optional final redirect URL.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The sign-in resource result.</returns>
-    public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Gets the sign-in resource for the given state.
@@ -324,19 +259,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="exchangeToken">The token to exchange.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, CancellationToken cancellationToken = default)
-        => await ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Exchanges a token for another token.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="connectionName">The connection name.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="exchangeToken">The token to exchange.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Exchanges a token for another token.
@@ -380,19 +303,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
     /// <returns>A task that represents the asynchronous sign-out operation.</returns>
     public virtual async Task SignOutUserAsync(string userId, string? connectionName = null, string? channelId = null, CancellationToken cancellationToken = default)
-        => await SignOutUserAsync(userId, connectionName, channelId, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Signs the user out of a connection, revoking their OAuth token.
-    /// </summary>
-    /// <param name="userId">The unique identifier of the user to sign out. Cannot be null or empty.</param>
-    /// <param name="connectionName">Optional name of the OAuth connection to sign out from. If null, signs out from all connections.</param>
-    /// <param name="channelId">Optional channel identifier. If provided, limits sign-out to tokens for this channel.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
-    /// <returns>A task that represents the asynchronous sign-out operation.</returns>
-    public virtual async Task SignOutUserAsync(string userId, string? connectionName, string? channelId, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await SignOutUserAsync(userId, connectionName, channelId, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await SignOutUserAsync(userId, connectionName, channelId, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Signs the user out of a connection, revoking their OAuth token.
@@ -440,20 +351,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
     public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls = null, CancellationToken cancellationToken = default)
-        => await GetAadTokensAsync(userId, connectionName, channelId, resourceUrls, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets AAD tokens for a user.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="connectionName">The connection name.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="resourceUrls">The resource URLs.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
-    public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await GetAadTokensAsync(userId, connectionName, channelId, resourceUrls, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await GetAadTokensAsync(userId, connectionName, channelId, resourceUrls, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Gets AAD tokens for a user.

--- a/core/src/Microsoft.Teams.Core/UserTokenClient.cs
+++ b/core/src/Microsoft.Teams.Core/UserTokenClient.cs
@@ -28,8 +28,6 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     private readonly string _apiEndpoint = configuration["UserTokenApiEndpoint"] ?? "https://token.botframework.com";
     private readonly JsonSerializerOptions _defaultOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
-    internal AgenticIdentity? AgenticIdentity { get; set; }
-
     /// <summary>
     /// Gets the token status for each connection for the given user.
     /// </summary>
@@ -39,6 +37,30 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
     public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include = null, CancellationToken cancellationToken = default)
+        => await GetTokenStatusAsync(userId, channelId, include, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the token status for each connection for the given user.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="include">The optional include parameter.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
+    public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await GetTokenStatusAsync(userId, channelId, include, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the token status for each connection for the given user.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="include">The optional include parameter.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
+    public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -56,7 +78,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/GetTokenStatus",
             queryParams,
             body: null,
-            CreateRequestOptions("getting token status"),
+            CreateRequestOptions("getting token status", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false);
 
         if (result == null || result.Count == 0)
@@ -77,6 +99,32 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
     public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code = null, CancellationToken cancellationToken = default)
+        => await GetTokenAsync(userId, connectionName, channelId, code, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the user token for a particular connection.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="code">The optional code.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
+    public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await GetTokenAsync(userId, connectionName, channelId, code, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the user token for a particular connection.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="code">The optional code.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
+    public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -96,7 +144,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/GetToken",
             queryParams,
             body: null,
-            CreateRequestOptions("getting token", returnNullOnNotFound: true),
+            CreateRequestOptions("getting token", returnNullOnNotFound: true, requestContext: requestContext),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -111,6 +159,34 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
     public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect = null, CancellationToken cancellationToken = default)
+        => GetSignInResourceAsync(userId, connectionName, channelId, finalRedirect, agenticIdentity: null, cancellationToken);
+
+    /// <summary>
+    /// Get the token or raw signin link to be sent to the user for signin for a connection.
+    /// Builds the state parameter internally from the userId and connectionName.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
+    public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => GetSignInResourceAsync(userId, connectionName, channelId, finalRedirect, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken);
+
+    /// <summary>
+    /// Get the token or raw signin link to be sent to the user for signin for a connection.
+    /// Builds the state parameter internally from the userId and connectionName.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
+    public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         var tokenExchangeState = new
         {
@@ -124,7 +200,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
         string state = Convert.ToBase64String(Encoding.UTF8.GetBytes(tokenExchangeStateJson));
 
         Uri? finalRedirectUri = finalRedirect is not null ? new Uri(finalRedirect) : null;
-        return GetSignInResourceAsync(state, finalRedirect: finalRedirectUri, cancellationToken: cancellationToken);
+        return GetSignInResourceAsync(state, codeChallenge: null, emulatorUrl: null, finalRedirect: finalRedirectUri, requestContext: requestContext, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -137,6 +213,32 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The sign-in URL, or null if not available.</returns>
     public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
+        => await GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the sign-in URL for the given state.
+    /// </summary>
+    /// <param name="state">The encoded state parameter.</param>
+    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
+    /// <param name="emulatorUrl">The optional emulator URL.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The sign-in URL, or null if not available.</returns>
+    public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the sign-in URL for the given state.
+    /// </summary>
+    /// <param name="state">The encoded state parameter.</param>
+    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
+    /// <param name="emulatorUrl">The optional emulator URL.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The sign-in URL, or null if not available.</returns>
+    public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new() { { "state", state } };
 
@@ -153,7 +255,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/botsignin/GetSignInUrl",
             queryParams,
             body: null,
-            CreateRequestOptions("getting sign-in URL"),
+            CreateRequestOptions("getting sign-in URL", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -167,6 +269,32 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The sign-in resource result.</returns>
     public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
+        => await GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the sign-in resource for the given state.
+    /// </summary>
+    /// <param name="state">The encoded state parameter.</param>
+    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
+    /// <param name="emulatorUrl">The optional emulator URL.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The sign-in resource result.</returns>
+    public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the sign-in resource for the given state.
+    /// </summary>
+    /// <param name="state">The encoded state parameter.</param>
+    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
+    /// <param name="emulatorUrl">The optional emulator URL.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The sign-in resource result.</returns>
+    public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new() { { "state", state } };
 
@@ -183,7 +311,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/botsignin/GetSignInResource",
             queryParams,
             body: null,
-            CreateRequestOptions("getting sign-in resource"),
+            CreateRequestOptions("getting sign-in resource", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -196,6 +324,30 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="exchangeToken">The token to exchange.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, CancellationToken cancellationToken = default)
+        => await ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Exchanges a token for another token.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="exchangeToken">The token to exchange.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Exchanges a token for another token.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="exchangeToken">The token to exchange.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -215,7 +367,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/exchange",
             queryParams,
             JsonSerializer.Serialize(tokenExchangeRequest),
-            CreateRequestOptions("exchanging token"),
+            CreateRequestOptions("exchanging token", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -228,6 +380,30 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
     /// <returns>A task that represents the asynchronous sign-out operation.</returns>
     public virtual async Task SignOutUserAsync(string userId, string? connectionName = null, string? channelId = null, CancellationToken cancellationToken = default)
+        => await SignOutUserAsync(userId, connectionName, channelId, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Signs the user out of a connection, revoking their OAuth token.
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user to sign out. Cannot be null or empty.</param>
+    /// <param name="connectionName">Optional name of the OAuth connection to sign out from. If null, signs out from all connections.</param>
+    /// <param name="channelId">Optional channel identifier. If provided, limits sign-out to tokens for this channel.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous sign-out operation.</returns>
+    public virtual async Task SignOutUserAsync(string userId, string? connectionName, string? channelId, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await SignOutUserAsync(userId, connectionName, channelId, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Signs the user out of a connection, revoking their OAuth token.
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user to sign out. Cannot be null or empty.</param>
+    /// <param name="connectionName">Optional name of the OAuth connection to sign out from. If null, signs out from all connections.</param>
+    /// <param name="channelId">Optional channel identifier. If provided, limits sign-out to tokens for this channel.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous sign-out operation.</returns>
+    public virtual async Task SignOutUserAsync(string userId, string? connectionName, string? channelId, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -250,7 +426,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/SignOut",
             queryParams,
             body: null,
-            CreateRequestOptions("signing out user"),
+            CreateRequestOptions("signing out user", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -264,6 +440,32 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
     public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls = null, CancellationToken cancellationToken = default)
+        => await GetAadTokensAsync(userId, connectionName, channelId, resourceUrls, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets AAD tokens for a user.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="resourceUrls">The resource URLs.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
+    public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await GetAadTokensAsync(userId, connectionName, channelId, resourceUrls, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets AAD tokens for a user.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="resourceUrls">The resource URLs.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
+    public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         var body = new
         {
@@ -279,14 +481,14 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/GetAadTokens",
             queryParams: null,
             JsonSerializer.Serialize(body),
-            CreateRequestOptions("getting AAD tokens"),
+            CreateRequestOptions("getting AAD tokens", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false))!;
     }
 
-    private BotRequestOptions CreateRequestOptions(string operationDescription, bool returnNullOnNotFound = false) =>
+    private static BotRequestOptions CreateRequestOptions(string operationDescription, bool returnNullOnNotFound = false, BotRequestContext? requestContext = null) =>
         new()
         {
-            RequestContext = BotRequestContext.FromAgenticIdentity(AgenticIdentity),
+            RequestContext = requestContext,
             OperationDescription = operationDescription,
             ReturnNullOnNotFound = returnNullOnNotFound
         };

--- a/core/test/IntegrationTests/ApiClientTests.cs
+++ b/core/test/IntegrationTests/ApiClientTests.cs
@@ -351,8 +351,6 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     [Trait("Category", "Users")]
     public async Task Users_GetSignInUrlAsync()
     {
-        Skip.If(_f.AgenticIdentity is not null, "UserTokenClient does not support agentic identity");
-
         string connectionName = Environment.GetEnvironmentVariable("TEST_CONNECTION_NAME")
             ?? throw new InvalidOperationException("TEST_CONNECTION_NAME not set");
 
@@ -378,8 +376,6 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     [Trait("Category", "Users")]
     public async Task Users_GetSignInResourceAsync()
     {
-        Skip.If(_f.AgenticIdentity is not null, "UserTokenClient does not support agentic identity");
-
         string connectionName = Environment.GetEnvironmentVariable("TEST_CONNECTION_NAME")
             ?? throw new InvalidOperationException("TEST_CONNECTION_NAME not set");
 
@@ -409,8 +405,6 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     [Trait("Category", "Users")]
     public async Task Users_Token_GetStatusAsync()
     {
-        Skip.If(_f.AgenticIdentity is not null, "UserTokenClient does not support agentic identity");
-
         string userId = _f.MemberMri1!;
 
         IList<GetTokenStatusResult>? statuses = await _api.UserToken.GetStatusAsync(userId, "msteams");
@@ -430,8 +424,6 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     [Trait("Category", "Users")]
     public async Task Users_Token_GetAsync()
     {
-        Skip.If(_f.AgenticIdentity is not null, "UserTokenClient does not support agentic identity");
-
         string connectionName = Environment.GetEnvironmentVariable("TEST_CONNECTION_NAME")
             ?? throw new InvalidOperationException("TEST_CONNECTION_NAME not set");
 
@@ -443,8 +435,6 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     [Trait("Category", "Users")]
     public async Task Users_Token_SignOutAsync()
     {
-        Skip.If(_f.AgenticIdentity is not null, "UserTokenClient does not support agentic identity");
-
         string connectionName = Environment.GetEnvironmentVariable("TEST_CONNECTION_NAME")
             ?? throw new InvalidOperationException("TEST_CONNECTION_NAME not set");
 

--- a/core/test/IntegrationTests/IntegrationTestFixture.cs
+++ b/core/test/IntegrationTests/IntegrationTestFixture.cs
@@ -10,6 +10,7 @@ using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Api.Clients;
 using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Http;
 using Microsoft.Teams.Core.Schema;
 using Xunit.Abstractions;
 
@@ -139,7 +140,9 @@ public class IntegrationTestFixture : IAsyncLifetime, IDisposable, ITestOutputHe
 
     public Task DisposeAsync() => Task.CompletedTask;
 
-    public ApiClient ScopedApiClient => ApiClient.ForServiceUrl(ServiceUrl);
+    public ApiClient ScopedApiClient => ApiClient
+        .ForRequestContext(BotRequestContext.FromAgenticIdentity(AgenticIdentity))
+        .ForServiceUrl(ServiceUrl);
 
     public void Dispose()
     {

--- a/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatActivityTests.cs
+++ b/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatActivityTests.cs
@@ -7,6 +7,7 @@ using AdaptiveCards;
 using Microsoft.Bot.Schema;
 using Microsoft.Teams.Core.Schema;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
 {
@@ -312,6 +313,17 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
         }
 
         [Fact]
+        public void FromCompatChannelAccount_MapsBotId()
+        {
+            Microsoft.Bot.Schema.ChannelAccount account = new() { Id = "bot-account-id" };
+            account.Properties["botId"] = "28:bot-app-id";
+
+            Microsoft.Teams.Core.Schema.ChannelAccount result = account.FromCompatChannelAccount();
+
+            Assert.Equal("28:bot-app-id", result.BotId);
+        }
+
+        [Fact]
         public void FromCompatChannelAccount_MapsAadObjectIdToProperties()
         {
             Microsoft.Bot.Schema.ChannelAccount account = new() { Id = "user-1", AadObjectId = "aad-123" };
@@ -349,6 +361,17 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
         {
             Microsoft.Bot.Schema.ChannelAccount? account = null;
             Assert.Throws<ArgumentNullException>(() => account!.FromCompatChannelAccount());
+        }
+
+        [Fact]
+        public void ToCompatChannelAccount_MapsBotId()
+        {
+            Microsoft.Teams.Core.Schema.ChannelAccount account = new() { Id = "bot-account-id", BotId = "28:bot-app-id" };
+
+            Microsoft.Bot.Schema.ChannelAccount result = account.ToCompatChannelAccount();
+
+            Assert.True(result.Properties.TryGetValue("botId", out JToken? botId));
+            Assert.Equal("28:bot-app-id", botId?.ToString());
         }
     }
 

--- a/core/test/Microsoft.Teams.Apps.UnitTests/ApiClientAgenticIdentityTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/ApiClientAgenticIdentityTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Teams.Apps.Api.Clients;
+using Microsoft.Teams.Apps.Schema;
+using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Http;
+using Microsoft.Teams.Core.Schema;
+
+namespace Microsoft.Teams.Apps.UnitTests;
+
+public class ApiClientAgenticIdentityTests
+{
+    [Fact]
+    public async Task ContextApiUserToken_UsesRecipientAgenticIdentityDefault()
+    {
+        CapturingHandler handler = new();
+        UserTokenClient userTokenClient = CreateUserTokenClient(handler);
+        ApiClient apiClient = new(
+            new HttpClient(),
+            new ConversationClient(new HttpClient(), NullLogger<ConversationClient>.Instance),
+            userTokenClient);
+        TeamsBotApplication app = new(
+            apiClient,
+            new Microsoft.AspNetCore.Http.HttpContextAccessor(),
+            NullLogger<TeamsBotApplication>.Instance,
+            new TeamsBotApplicationOptions { AppId = "app-id" });
+        TeamsActivity activity = new()
+        {
+            ServiceUrl = new Uri("https://smba.test"),
+            Recipient = new TeamsChannelAccount
+            {
+                AgenticAppId = "agentic-app",
+                AgenticUserId = "agentic-user",
+                AgenticAppBlueprintId = "agentic-blueprint",
+                BotId = "bot-app-id",
+            }
+        };
+        Context<TeamsActivity> context = new(app, activity);
+
+        await context.Api.UserToken.GetAsync("user", "connection", "msteams");
+
+        Assert.NotNull(handler.Request);
+        Assert.True(handler.Request.Options.TryGetValue(new HttpRequestOptionsKey<object?>(BotRequestContext.AgenticIdentityKey), out object? value));
+        AgenticIdentity identity = Assert.IsType<AgenticIdentity>(value);
+        Assert.Equal("agentic-app", identity.AgenticAppId);
+        Assert.Equal("agentic-user", identity.AgenticUserId);
+        Assert.Equal("agentic-blueprint", identity.AgenticAppBlueprintId);
+        Assert.True(handler.Request.Options.TryGetValue(new HttpRequestOptionsKey<object?>(BotRequestContext.BotAppIdKey), out object? botAppId));
+        Assert.Equal("bot-app-id", botAppId);
+    }
+
+    [Fact]
+    public async Task UserToken_PerMethodAgenticIdentity_OverridesApiClientDefault()
+    {
+        CapturingHandler handler = new();
+        ApiClient apiClient = new(
+            new HttpClient(),
+            new ConversationClient(new HttpClient(), NullLogger<ConversationClient>.Instance),
+            CreateUserTokenClient(handler));
+        AgenticIdentity defaultIdentity = new()
+        {
+            AgenticAppId = "default-app",
+            AgenticUserId = "default-user",
+        };
+        AgenticIdentity methodIdentity = new()
+        {
+            AgenticAppId = "method-app",
+            AgenticUserId = "method-user",
+        };
+
+        await apiClient
+            .ForRequestContext(BotRequestContext.FromAgenticIdentity(defaultIdentity))
+            .ForServiceUrl(new Uri("https://smba.test"))
+            .UserToken
+            .GetAsync("user", "connection", "msteams", code: null, agenticIdentity: methodIdentity);
+
+        Assert.NotNull(handler.Request);
+        Assert.True(handler.Request.Options.TryGetValue(new HttpRequestOptionsKey<object?>(BotRequestContext.AgenticIdentityKey), out object? value));
+        AgenticIdentity identity = Assert.IsType<AgenticIdentity>(value);
+        Assert.Equal("method-app", identity.AgenticAppId);
+        Assert.Equal("method-user", identity.AgenticUserId);
+    }
+
+    [Fact]
+    public void FromChannelAccount_PreservesBotId()
+    {
+        TeamsChannelAccount? account = TeamsChannelAccount.FromChannelAccount(new ChannelAccount
+        {
+            Id = "28:channel-id",
+            BotId = "bot-app-id",
+        });
+
+        Assert.NotNull(account);
+        Assert.Equal("bot-app-id", account.BotId);
+    }
+
+    private static UserTokenClient CreateUserTokenClient(HttpMessageHandler handler)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["UserTokenApiEndpoint"] = "https://token.test"
+            })
+            .Build();
+
+        return new UserTokenClient(new HttpClient(handler), configuration, NullLogger<UserTokenClient>.Instance);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Request { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            HttpResponseMessage response = new(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"connectionName":"connection","token":"token"}""", Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTelemetryTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTelemetryTests.cs
@@ -38,7 +38,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "tok", ConnectionName = GraphConnection });
 
         Context<MessageActivity> ctx = CreateMessageContext(harness);
@@ -64,7 +64,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((GetTokenResult?)null);
 
         Context<MessageActivity> ctx = CreateMessageContext(harness);
@@ -87,7 +87,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "cached", ConnectionName = GraphConnection });
 
         Context<MessageActivity> ctx = CreateMessageContext(harness);
@@ -135,7 +135,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.SignOutUserAsync(TestUserId, GraphConnection, TestChannelId, It.IsAny<CancellationToken>()))
+            .Setup(c => c.SignOutUserAsync(TestUserId, GraphConnection, TestChannelId, It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         Context<MessageActivity> ctx = CreateMessageContext(harness);
@@ -157,7 +157,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenStatusAsync(TestUserId, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenStatusAsync(TestUserId, TestChannelId, null, It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { new GetTokenStatusResult { ConnectionName = GraphConnection, HasToken = true } });
 
         Context<MessageActivity> ctx = CreateMessageContext(harness);
@@ -184,7 +184,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "access", ConnectionName = GraphConnection });
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-success", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -208,7 +208,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "access", ConnectionName = GraphConnection });
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-dup", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -237,7 +237,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Bad request", null, System.Net.HttpStatusCode.BadRequest));
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-bad", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -261,7 +261,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Forbidden", null, System.Net.HttpStatusCode.Forbidden));
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-forbidden", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -310,7 +310,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((GetTokenResult?)null);
 
         Context<InvokeActivity> ctx = CreateInvokeContext(harness);
@@ -333,7 +333,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Bad request", null, System.Net.HttpStatusCode.BadRequest));
 
         Context<InvokeActivity> ctx = CreateInvokeContext(harness);
@@ -357,7 +357,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Forbidden", null, System.Net.HttpStatusCode.Forbidden));
 
         Context<InvokeActivity> ctx = CreateInvokeContext(harness);
@@ -474,13 +474,13 @@ public class OAuthFlowTelemetryTests
 
     private static void SetupSilentTokenReturnsNull(Mock<UserTokenClient> mock)
     {
-        mock.Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+        mock.Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((GetTokenResult?)null);
     }
 
     private static void SetupGetSignInResource(Mock<UserTokenClient> mock)
     {
-        mock.Setup(c => c.GetSignInResourceAsync(It.IsAny<string>(), null, (Uri?)null, (Uri?)null, It.IsAny<CancellationToken>()))
+        mock.Setup(c => c.GetSignInResourceAsync(It.IsAny<string>(), null, (Uri?)null, (Uri?)null, It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetSignInResourceResult
             {
                 SignInLink = "https://login.microsoftonline.com/test",

--- a/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTests.cs
@@ -143,7 +143,7 @@ public class OAuthFlowTests
 
         // Arrange exchange
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "access-token", ConnectionName = GraphConnection });
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "exchange-1", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -173,7 +173,7 @@ public class OAuthFlowTests
 
         // Arrange exchange failure
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "bad-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "bad-token", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Unauthorized", null, System.Net.HttpStatusCode.Unauthorized));
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "exchange-2", ConnectionName = GraphConnection, Token = "bad-token" };
@@ -203,7 +203,7 @@ public class OAuthFlowTests
 
         // Arrange verify state
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "123456", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "123456", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "access-token", ConnectionName = GraphConnection });
 
         SignInVerifyStateValue verifyValue = new() { State = "123456" };
@@ -243,7 +243,7 @@ public class OAuthFlowTests
         TestHarness harness = CreateHarness(GraphConnection);
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Not found", null, System.Net.HttpStatusCode.NotFound));
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-1", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -261,7 +261,7 @@ public class OAuthFlowTests
         TestHarness harness = CreateHarness(GraphConnection);
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Forbidden", null, System.Net.HttpStatusCode.Forbidden));
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-2", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -280,7 +280,7 @@ public class OAuthFlowTests
         TestHarness harness = CreateHarness(GraphConnection);
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "access-token", ConnectionName = GraphConnection });
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "dup-1", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -296,7 +296,7 @@ public class OAuthFlowTests
 
         // ExchangeTokenAsync only called once
         harness.MockUserTokenClient.Verify(
-            c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()),
+            c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -323,7 +323,7 @@ public class OAuthFlowTests
         harness.GraphFlow!.OnSignInFailure((_, _, _) => { failureFired = true; return Task.CompletedTask; });
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "badcode", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "badcode", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((GetTokenResult?)null);
 
         SignInVerifyStateValue verifyValue = new() { State = "badcode" };
@@ -342,7 +342,7 @@ public class OAuthFlowTests
         TestHarness harness = CreateHarness(GraphConnection);
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Bad request", null, System.Net.HttpStatusCode.BadRequest));
 
         SignInVerifyStateValue verifyValue = new() { State = "code" };
@@ -359,7 +359,7 @@ public class OAuthFlowTests
         TestHarness harness = CreateHarness(GraphConnection);
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Forbidden", null, System.Net.HttpStatusCode.Forbidden));
 
         SignInVerifyStateValue verifyValue = new() { State = "code" };
@@ -405,7 +405,7 @@ public class OAuthFlowTests
         });
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Bad request", null, System.Net.HttpStatusCode.BadRequest));
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-fail", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -425,7 +425,7 @@ public class OAuthFlowTests
         TestHarness harness = CreateHarness(GraphConnection);
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "cached-token", ConnectionName = GraphConnection });
 
         Context<MessageActivity> ctx = CreateMessageContext(harness, TestUserId);
@@ -537,13 +537,13 @@ public class OAuthFlowTests
 
     private static void SetupSilentTokenReturnsNull(Mock<UserTokenClient> mock, string connectionName)
     {
-        mock.Setup(c => c.GetTokenAsync(TestUserId, connectionName, TestChannelId, null, It.IsAny<CancellationToken>()))
+        mock.Setup(c => c.GetTokenAsync(TestUserId, connectionName, TestChannelId, null, It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((GetTokenResult?)null);
     }
 
     private static void SetupGetSignInResource(Mock<UserTokenClient> mock)
     {
-        mock.Setup(c => c.GetSignInResourceAsync(It.IsAny<string>(), null, (Uri?)null, (Uri?)null, It.IsAny<CancellationToken>()))
+        mock.Setup(c => c.GetSignInResourceAsync(It.IsAny<string>(), null, (Uri?)null, (Uri?)null, It.IsAny<BotRequestContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetSignInResourceResult
             {
                 SignInLink = "https://login.microsoftonline.com/test",

--- a/core/test/Microsoft.Teams.Core.UnitTests/Http/BotRequestContextTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Http/BotRequestContextTests.cs
@@ -115,7 +115,7 @@ public class BotRequestContextTests
         {
             Type = ActivityType.Message,
             From = new ChannelAccount { Id = "user-id" },
-            Recipient = new ChannelAccount { Id = "28:recipient-bot-id", AgenticUserId = "agentic-user" },
+            Recipient = new ChannelAccount { Id = "recipient-account-id", BotId = "28:recipient-bot-id", AgenticUserId = "agentic-user" },
         };
 
         BotRequestContext? ctx = BotRequestContext.FromInboundActivity(activity);
@@ -133,7 +133,7 @@ public class BotRequestContextTests
         {
             Type = ActivityType.Message,
             From = new ChannelAccount { Id = "user-id", AgenticUserId = "agentic-user" },
-            Recipient = new ChannelAccount { Id = "28:recipient-bot-id" },
+            Recipient = new ChannelAccount { Id = "recipient-account-id", BotId = "28:recipient-bot-id" },
         };
 
         BotRequestContext? ctx = BotRequestContext.FromInboundActivity(activity);

--- a/core/test/Microsoft.Teams.Core.UnitTests/Http/BotRequestContextTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Http/BotRequestContextTests.cs
@@ -143,6 +143,40 @@ public class BotRequestContextTests
         Assert.Null(ctx.AgenticIdentity);
     }
 
+    [Fact]
+    public void FromInboundActivity_FallsBackToRecipientId_WhenBotIdAbsent()
+    {
+        // Standard (non-agentic) inbound activity: SMBA does not populate BotId, but Recipient.Id
+        // carries the Teams-style "28:<appId>" value.
+        CoreActivity activity = new()
+        {
+            Type = ActivityType.Message,
+            From = new ChannelAccount { Id = "user-id" },
+            Recipient = new ChannelAccount { Id = "28:recipient-app-id" },
+        };
+
+        BotRequestContext? ctx = BotRequestContext.FromInboundActivity(activity);
+
+        Assert.NotNull(ctx);
+        Assert.Equal("recipient-app-id", ctx!.BotAppId);
+    }
+
+    [Fact]
+    public void FromInboundActivity_PrefersBotId_WhenBothPresent()
+    {
+        CoreActivity activity = new()
+        {
+            Type = ActivityType.Message,
+            From = new ChannelAccount { Id = "user-id" },
+            Recipient = new ChannelAccount { Id = "28:recipient-account-id", BotId = "28:recipient-bot-id" },
+        };
+
+        BotRequestContext? ctx = BotRequestContext.FromInboundActivity(activity);
+
+        Assert.NotNull(ctx);
+        Assert.Equal("recipient-bot-id", ctx!.BotAppId);
+    }
+
     // ---- Merge -------------------------------------------------------------
 
     [Fact]

--- a/core/test/Microsoft.Teams.Core.UnitTests/UserTokenClientTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/UserTokenClientTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Teams.Core.Http;
+using Microsoft.Teams.Core.Schema;
+
+namespace Microsoft.Teams.Core.UnitTests;
+
+public class UserTokenClientTests
+{
+    [Fact]
+    public async Task GetTokenAsync_WithAgenticIdentity_StampsRequestOption()
+    {
+        CapturingHandler handler = new();
+        UserTokenClient client = CreateClient(handler);
+        AgenticIdentity identity = new()
+        {
+            AgenticAppId = "agentic-app",
+            AgenticUserId = "agentic-user",
+            AgenticAppBlueprintId = "agentic-blueprint",
+        };
+
+        await client.GetTokenAsync("user", "connection", "msteams", code: null, identity);
+
+        Assert.NotNull(handler.Request);
+        Assert.True(handler.Request.Options.TryGetValue(new HttpRequestOptionsKey<object?>(BotRequestContext.AgenticIdentityKey), out object? value));
+        Assert.Same(identity, value);
+    }
+
+    private static UserTokenClient CreateClient(HttpMessageHandler handler)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["UserTokenApiEndpoint"] = "https://token.test"
+            })
+            .Build();
+
+        return new UserTokenClient(new HttpClient(handler), configuration, NullLogger<UserTokenClient>.Instance);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Request { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            HttpResponseMessage response = new(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"connectionName":"connection","token":"token"}""", Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/core/test/Microsoft.Teams.Core.UnitTests/UserTokenClientTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/UserTokenClientTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Teams.Core.UnitTests;
 public class UserTokenClientTests
 {
     [Fact]
-    public async Task GetTokenAsync_WithAgenticIdentity_StampsRequestOption()
+    public async Task GetTokenAsync_WithRequestContext_StampsRequestOptions()
     {
         CapturingHandler handler = new();
         UserTokenClient client = CreateClient(handler);
@@ -23,12 +23,19 @@ public class UserTokenClientTests
             AgenticUserId = "agentic-user",
             AgenticAppBlueprintId = "agentic-blueprint",
         };
+        BotRequestContext requestContext = new()
+        {
+            AgenticIdentity = identity,
+            BotAppId = "bot-app",
+        };
 
-        await client.GetTokenAsync("user", "connection", "msteams", code: null, identity);
+        await client.GetTokenAsync("user", "connection", "msteams", code: null, requestContext);
 
         Assert.NotNull(handler.Request);
-        Assert.True(handler.Request.Options.TryGetValue(new HttpRequestOptionsKey<object?>(BotRequestContext.AgenticIdentityKey), out object? value));
-        Assert.Same(identity, value);
+        Assert.True(handler.Request.Options.TryGetValue(new HttpRequestOptionsKey<object?>(BotRequestContext.AgenticIdentityKey), out object? identityValue));
+        Assert.Same(identity, identityValue);
+        Assert.True(handler.Request.Options.TryGetValue(new HttpRequestOptionsKey<object?>(BotRequestContext.BotAppIdKey), out object? botAppIdValue));
+        Assert.Equal("bot-app", botAppIdValue);
     }
 
     private static UserTokenClient CreateClient(HttpMessageHandler handler)


### PR DESCRIPTION
## Summary

Threads `BotRequestContext` through the **Apps-layer** API clients and OAuth flows so agentic identity / request context flows end-to-end from an inbound activity to outbound Teams API calls.

> **Draft / deferred.** This is the Apps-only top of a stack. It is intentionally held as a draft until the lower layers land.

## Stack

```
main
 └─ #587  Use recipient agentic identity defaults (Core inbound identity)
     └─ #591  Add BotRequestContext overloads to UserTokenClient (Core)
         └─ #589  ← this PR (Apps API clients + OAuth flows)
```

This PR is based on **#591** and depends on both #587 and #591. It contains **no Core changes** — those live in #587 and #591.

## What's in this PR (Apps only)

- `ApiClient`: `ForServiceUrl(Uri)` is URL-only; new `ForRequestContext(BotRequestContext?)` and `ForActivity(TeamsActivity)` (chains both) carry request context onto derived clients.
- `Context.Api` now uses `ForActivity(Activity)` so the ambient request context is scoped to the inbound activity.
- Per-client threading of `BotRequestContext?` through `ActivityClient`, `ConversationApiClient`, `MeetingClient`, `MemberClient`, `ReactionClient`, `TeamClient`, `UserTokenApiClient`.
- `OAuthFlow` helpers forward the nullable `requestContext` directly to the `UserTokenClient` request-context overloads (from #591).
- `TeamsChannelAccount` surfaces `BotId` (relies on `ChannelAccount.BotId` from #587).

## Open question

Should these APIs accept `BotRequestContext` directly instead of `AgenticIdentity`, even though that's a breaking change? Feedback welcome before this comes out of draft.

## Testing

- Apps unit tests: 357 passing on net8.0 and net10.0.