### PR TITLE
Fix misleading unauthenticated-requests startup warning

### DIFF
--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/HostApplicationBuilder.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/HostApplicationBuilder.cs
@@ -128,13 +128,22 @@ public static class HostApplicationBuilderExtensions
         {
             teamsValidationSettings.AddDefaultAudiences(settings.ClientId);
         }
+        else if (skipAuth)
+        {
+            // No Teams:ClientId configured and skipAuth is set, so the authorization
+            // policy bypasses authentication and the bot will accept anonymous traffic.
+            // The warning routes through whatever logging pipeline the consumer set up.
+            LogFromServices(builder.Services, l => l.LogWarning(
+                "No Teams:ClientId configured and skipAuth is enabled. Bot will accept unauthenticated requests on the messaging endpoint."));
+        }
         else
         {
-            // No Teams:ClientId configured; warn the consumer their bot will accept
-            // anonymous traffic. The warning routes through whatever logging
-            // pipeline the consumer set up.
+            // No Teams:ClientId configured and skipAuth is not set, so the authorization
+            // policy rejects every request to the messaging endpoint. Warn the consumer
+            // their bot will not receive traffic until credentials are configured (or
+            // skipAuth: true is passed to AddTeams(...) for local development).
             LogFromServices(builder.Services, l => l.LogWarning(
-                "No Teams:ClientId configured. Bot will accept unauthenticated requests on /api/messages."));
+                "No Teams:ClientId configured. Bot will reject all requests on the messaging endpoint until credentials are configured."));
         }
 
         builder.Services.


### PR DESCRIPTION
## Why

When `Teams:ClientId` is not configured, the ASP.NET Core plugin logged a startup warning saying the bot *"will accept unauthenticated requests"*. That text is misleading: the authorization policy actually rejects every request in that case (`policy.RequireAssertion(_ => false)`) unless `skipAuth: true` is passed. A developer reading the warning would believe their bot is wide open when it is in fact refusing all traffic.

## What changed

`AddTeamsTokenAuthentication` now makes the warning `skipAuth`-aware so it matches the real authorization policy:

- **No `ClientId` + `skipAuth: true`** (the only case where auth is actually bypassed): warns that the bot will accept unauthenticated requests.
- **No `ClientId` + `skipAuth: false`**: warns that the bot will reject all requests until credentials are configured.

The hardcoded `/api/messages` path was also removed in favor of a generic "messaging endpoint" reference, since the route is configured elsewhere and not known at this call site.

## Notes

Text-only change to the warning strings and their comments; no behavioral change to the authorization policy itself. Existing `HostApplicationBuilderTests` still pass and the project builds clean.