### PR TITLE
Add BotRequestContext overloads to UserTokenClient

### DIFF
--- a/core/src/Microsoft.Teams.Core/UserTokenClient.cs
+++ b/core/src/Microsoft.Teams.Core/UserTokenClient.cs
@@ -37,19 +37,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
     public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include = null, CancellationToken cancellationToken = default)
-        => await GetTokenStatusAsync(userId, channelId, include, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets the token status for each connection for the given user.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="include">The optional include parameter.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
-    public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await GetTokenStatusAsync(userId, channelId, include, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await GetTokenStatusAsync(userId, channelId, include, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Gets the token status for each connection for the given user.
@@ -99,20 +87,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
     public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code = null, CancellationToken cancellationToken = default)
-        => await GetTokenAsync(userId, connectionName, channelId, code, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets the user token for a particular connection.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="connectionName">The connection name.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="code">The optional code.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
-    public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await GetTokenAsync(userId, connectionName, channelId, code, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await GetTokenAsync(userId, connectionName, channelId, code, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Gets the user token for a particular connection.
@@ -159,21 +134,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
     public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect = null, CancellationToken cancellationToken = default)
-        => GetSignInResourceAsync(userId, connectionName, channelId, finalRedirect, agenticIdentity: null, cancellationToken);
-
-    /// <summary>
-    /// Get the token or raw signin link to be sent to the user for signin for a connection.
-    /// Builds the state parameter internally from the userId and connectionName.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="connectionName">The connection name.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="finalRedirect">The optional final redirect URL.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
-    public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => GetSignInResourceAsync(userId, connectionName, channelId, finalRedirect, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken);
+        => GetSignInResourceAsync(userId, connectionName, channelId, finalRedirect, requestContext: null, cancellationToken);
 
     /// <summary>
     /// Get the token or raw signin link to be sent to the user for signin for a connection.
@@ -213,20 +174,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The sign-in URL, or null if not available.</returns>
     public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
-        => await GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets the sign-in URL for the given state.
-    /// </summary>
-    /// <param name="state">The encoded state parameter.</param>
-    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
-    /// <param name="emulatorUrl">The optional emulator URL.</param>
-    /// <param name="finalRedirect">The optional final redirect URL.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The sign-in URL, or null if not available.</returns>
-    public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Gets the sign-in URL for the given state.
@@ -269,20 +217,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The sign-in resource result.</returns>
     public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
-        => await GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets the sign-in resource for the given state.
-    /// </summary>
-    /// <param name="state">The encoded state parameter.</param>
-    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
-    /// <param name="emulatorUrl">The optional emulator URL.</param>
-    /// <param name="finalRedirect">The optional final redirect URL.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The sign-in resource result.</returns>
-    public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Gets the sign-in resource for the given state.
@@ -324,19 +259,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="exchangeToken">The token to exchange.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, CancellationToken cancellationToken = default)
-        => await ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Exchanges a token for another token.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="connectionName">The connection name.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="exchangeToken">The token to exchange.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Exchanges a token for another token.
@@ -380,19 +303,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
     /// <returns>A task that represents the asynchronous sign-out operation.</returns>
     public virtual async Task SignOutUserAsync(string userId, string? connectionName = null, string? channelId = null, CancellationToken cancellationToken = default)
-        => await SignOutUserAsync(userId, connectionName, channelId, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Signs the user out of a connection, revoking their OAuth token.
-    /// </summary>
-    /// <param name="userId">The unique identifier of the user to sign out. Cannot be null or empty.</param>
-    /// <param name="connectionName">Optional name of the OAuth connection to sign out from. If null, signs out from all connections.</param>
-    /// <param name="channelId">Optional channel identifier. If provided, limits sign-out to tokens for this channel.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
-    /// <returns>A task that represents the asynchronous sign-out operation.</returns>
-    public virtual async Task SignOutUserAsync(string userId, string? connectionName, string? channelId, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await SignOutUserAsync(userId, connectionName, channelId, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await SignOutUserAsync(userId, connectionName, channelId, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Signs the user out of a connection, revoking their OAuth token.
@@ -440,20 +351,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
     public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls = null, CancellationToken cancellationToken = default)
-        => await GetAadTokensAsync(userId, connectionName, channelId, resourceUrls, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets AAD tokens for a user.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="connectionName">The connection name.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="resourceUrls">The resource URLs.</param>
-    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
-    public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
-        => await GetAadTokensAsync(userId, connectionName, channelId, resourceUrls, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+        => await GetAadTokensAsync(userId, connectionName, channelId, resourceUrls, requestContext: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Gets AAD tokens for a user.

--- a/core/src/Microsoft.Teams.Core/UserTokenClient.cs
+++ b/core/src/Microsoft.Teams.Core/UserTokenClient.cs
@@ -28,8 +28,6 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     private readonly string _apiEndpoint = configuration["UserTokenApiEndpoint"] ?? "https://token.botframework.com";
     private readonly JsonSerializerOptions _defaultOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
-    internal AgenticIdentity? AgenticIdentity { get; set; }
-
     /// <summary>
     /// Gets the token status for each connection for the given user.
     /// </summary>
@@ -39,6 +37,30 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
     public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include = null, CancellationToken cancellationToken = default)
+        => await GetTokenStatusAsync(userId, channelId, include, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the token status for each connection for the given user.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="include">The optional include parameter.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
+    public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await GetTokenStatusAsync(userId, channelId, include, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the token status for each connection for the given user.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="include">The optional include parameter.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
+    public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -56,7 +78,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/GetTokenStatus",
             queryParams,
             body: null,
-            CreateRequestOptions("getting token status"),
+            CreateRequestOptions("getting token status", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false);
 
         if (result == null || result.Count == 0)
@@ -77,6 +99,32 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
     public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code = null, CancellationToken cancellationToken = default)
+        => await GetTokenAsync(userId, connectionName, channelId, code, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the user token for a particular connection.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="code">The optional code.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
+    public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await GetTokenAsync(userId, connectionName, channelId, code, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the user token for a particular connection.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="code">The optional code.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
+    public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -96,7 +144,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/GetToken",
             queryParams,
             body: null,
-            CreateRequestOptions("getting token", returnNullOnNotFound: true),
+            CreateRequestOptions("getting token", returnNullOnNotFound: true, requestContext: requestContext),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -111,6 +159,34 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
     public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect = null, CancellationToken cancellationToken = default)
+        => GetSignInResourceAsync(userId, connectionName, channelId, finalRedirect, agenticIdentity: null, cancellationToken);
+
+    /// <summary>
+    /// Get the token or raw signin link to be sent to the user for signin for a connection.
+    /// Builds the state parameter internally from the userId and connectionName.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
+    public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => GetSignInResourceAsync(userId, connectionName, channelId, finalRedirect, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken);
+
+    /// <summary>
+    /// Get the token or raw signin link to be sent to the user for signin for a connection.
+    /// Builds the state parameter internally from the userId and connectionName.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
+    public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         var tokenExchangeState = new
         {
@@ -124,7 +200,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
         string state = Convert.ToBase64String(Encoding.UTF8.GetBytes(tokenExchangeStateJson));
 
         Uri? finalRedirectUri = finalRedirect is not null ? new Uri(finalRedirect) : null;
-        return GetSignInResourceAsync(state, finalRedirect: finalRedirectUri, cancellationToken: cancellationToken);
+        return GetSignInResourceAsync(state, codeChallenge: null, emulatorUrl: null, finalRedirect: finalRedirectUri, requestContext: requestContext, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -137,6 +213,32 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The sign-in URL, or null if not available.</returns>
     public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
+        => await GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the sign-in URL for the given state.
+    /// </summary>
+    /// <param name="state">The encoded state parameter.</param>
+    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
+    /// <param name="emulatorUrl">The optional emulator URL.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The sign-in URL, or null if not available.</returns>
+    public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the sign-in URL for the given state.
+    /// </summary>
+    /// <param name="state">The encoded state parameter.</param>
+    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
+    /// <param name="emulatorUrl">The optional emulator URL.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The sign-in URL, or null if not available.</returns>
+    public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new() { { "state", state } };
 
@@ -153,7 +255,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/botsignin/GetSignInUrl",
             queryParams,
             body: null,
-            CreateRequestOptions("getting sign-in URL"),
+            CreateRequestOptions("getting sign-in URL", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -167,6 +269,32 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The sign-in resource result.</returns>
     public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
+        => await GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the sign-in resource for the given state.
+    /// </summary>
+    /// <param name="state">The encoded state parameter.</param>
+    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
+    /// <param name="emulatorUrl">The optional emulator URL.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The sign-in resource result.</returns>
+    public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets the sign-in resource for the given state.
+    /// </summary>
+    /// <param name="state">The encoded state parameter.</param>
+    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
+    /// <param name="emulatorUrl">The optional emulator URL.</param>
+    /// <param name="finalRedirect">The optional final redirect URL.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The sign-in resource result.</returns>
+    public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new() { { "state", state } };
 
@@ -183,7 +311,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/botsignin/GetSignInResource",
             queryParams,
             body: null,
-            CreateRequestOptions("getting sign-in resource"),
+            CreateRequestOptions("getting sign-in resource", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -196,6 +324,30 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="exchangeToken">The token to exchange.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, CancellationToken cancellationToken = default)
+        => await ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Exchanges a token for another token.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="exchangeToken">The token to exchange.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Exchanges a token for another token.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="exchangeToken">The token to exchange.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -215,7 +367,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/exchange",
             queryParams,
             JsonSerializer.Serialize(tokenExchangeRequest),
-            CreateRequestOptions("exchanging token"),
+            CreateRequestOptions("exchanging token", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -228,6 +380,30 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
     /// <returns>A task that represents the asynchronous sign-out operation.</returns>
     public virtual async Task SignOutUserAsync(string userId, string? connectionName = null, string? channelId = null, CancellationToken cancellationToken = default)
+        => await SignOutUserAsync(userId, connectionName, channelId, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Signs the user out of a connection, revoking their OAuth token.
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user to sign out. Cannot be null or empty.</param>
+    /// <param name="connectionName">Optional name of the OAuth connection to sign out from. If null, signs out from all connections.</param>
+    /// <param name="channelId">Optional channel identifier. If provided, limits sign-out to tokens for this channel.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous sign-out operation.</returns>
+    public virtual async Task SignOutUserAsync(string userId, string? connectionName, string? channelId, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await SignOutUserAsync(userId, connectionName, channelId, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Signs the user out of a connection, revoking their OAuth token.
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user to sign out. Cannot be null or empty.</param>
+    /// <param name="connectionName">Optional name of the OAuth connection to sign out from. If null, signs out from all connections.</param>
+    /// <param name="channelId">Optional channel identifier. If provided, limits sign-out to tokens for this channel.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous sign-out operation.</returns>
+    public virtual async Task SignOutUserAsync(string userId, string? connectionName, string? channelId, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -250,7 +426,7 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/SignOut",
             queryParams,
             body: null,
-            CreateRequestOptions("signing out user"),
+            CreateRequestOptions("signing out user", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -264,6 +440,32 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
     public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls = null, CancellationToken cancellationToken = default)
+        => await GetAadTokensAsync(userId, connectionName, channelId, resourceUrls, agenticIdentity: null, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets AAD tokens for a user.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="resourceUrls">The resource URLs.</param>
+    /// <param name="agenticIdentity">The optional agentic identity for user-delegated token acquisition.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
+    public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls, AgenticIdentity? agenticIdentity, CancellationToken cancellationToken = default)
+        => await GetAadTokensAsync(userId, connectionName, channelId, resourceUrls, BotRequestContext.FromAgenticIdentity(agenticIdentity), cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Gets AAD tokens for a user.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="connectionName">The connection name.</param>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="resourceUrls">The resource URLs.</param>
+    /// <param name="requestContext">Optional per-request properties used for authentication.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
+    public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
     {
         var body = new
         {
@@ -279,14 +481,14 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
             "api/usertoken/GetAadTokens",
             queryParams: null,
             JsonSerializer.Serialize(body),
-            CreateRequestOptions("getting AAD tokens"),
+            CreateRequestOptions("getting AAD tokens", requestContext: requestContext),
             cancellationToken).ConfigureAwait(false))!;
     }
 
-    private BotRequestOptions CreateRequestOptions(string operationDescription, bool returnNullOnNotFound = false) =>
+    private static BotRequestOptions CreateRequestOptions(string operationDescription, bool returnNullOnNotFound = false, BotRequestContext? requestContext = null) =>
         new()
         {
-            RequestContext = BotRequestContext.FromAgenticIdentity(AgenticIdentity),
+            RequestContext = requestContext,
             OperationDescription = operationDescription,
             ReturnNullOnNotFound = returnNullOnNotFound
         };

--- a/core/test/Microsoft.Teams.Core.UnitTests/UserTokenClientTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/UserTokenClientTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Teams.Core.Http;
+using Microsoft.Teams.Core.Schema;
+
+namespace Microsoft.Teams.Core.UnitTests;
+
+public class UserTokenClientTests
+{
+    [Fact]
+    public async Task GetTokenAsync_WithAgenticIdentity_StampsRequestOption()
+    {
+        CapturingHandler handler = new();
+        UserTokenClient client = CreateClient(handler);
+        AgenticIdentity identity = new()
+        {
+            AgenticAppId = "agentic-app",
+            AgenticUserId = "agentic-user",
+            AgenticAppBlueprintId = "agentic-blueprint",
+        };
+
+        await client.GetTokenAsync("user", "connection", "msteams", code: null, identity);
+
+        Assert.NotNull(handler.Request);
+        Assert.True(handler.Request.Options.TryGetValue(new HttpRequestOptionsKey<object?>(BotRequestContext.AgenticIdentityKey), out object? value));
+        Assert.Same(identity, value);
+    }
+
+    private static UserTokenClient CreateClient(HttpMessageHandler handler)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["UserTokenApiEndpoint"] = "https://token.test"
+            })
+            .Build();
+
+        return new UserTokenClient(new HttpClient(handler), configuration, NullLogger<UserTokenClient>.Instance);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Request { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            HttpResponseMessage response = new(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"connectionName":"connection","token":"token"}""", Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/core/test/Microsoft.Teams.Core.UnitTests/UserTokenClientTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/UserTokenClientTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Teams.Core.UnitTests;
 public class UserTokenClientTests
 {
     [Fact]
-    public async Task GetTokenAsync_WithAgenticIdentity_StampsRequestOption()
+    public async Task GetTokenAsync_WithRequestContext_StampsRequestOptions()
     {
         CapturingHandler handler = new();
         UserTokenClient client = CreateClient(handler);
@@ -23,12 +23,19 @@ public class UserTokenClientTests
             AgenticUserId = "agentic-user",
             AgenticAppBlueprintId = "agentic-blueprint",
         };
+        BotRequestContext requestContext = new()
+        {
+            AgenticIdentity = identity,
+            BotAppId = "bot-app",
+        };
 
-        await client.GetTokenAsync("user", "connection", "msteams", code: null, identity);
+        await client.GetTokenAsync("user", "connection", "msteams", code: null, requestContext);
 
         Assert.NotNull(handler.Request);
-        Assert.True(handler.Request.Options.TryGetValue(new HttpRequestOptionsKey<object?>(BotRequestContext.AgenticIdentityKey), out object? value));
-        Assert.Same(identity, value);
+        Assert.True(handler.Request.Options.TryGetValue(new HttpRequestOptionsKey<object?>(BotRequestContext.AgenticIdentityKey), out object? identityValue));
+        Assert.Same(identity, identityValue);
+        Assert.True(handler.Request.Options.TryGetValue(new HttpRequestOptionsKey<object?>(BotRequestContext.BotAppIdKey), out object? botAppIdValue));
+        Assert.Equal("bot-app", botAppIdValue);
     }
 
     private static UserTokenClient CreateClient(HttpMessageHandler handler)


### PR DESCRIPTION
This adds a `BotRequestContext?` overload to every `UserTokenClient` operation — token status, get token, sign-in URL/resource, exchange, sign out, and AAD tokens — alongside the existing plain overloads.

`BotRequestContext` is the canonical per-request context; callers holding an `AgenticIdentity` convert with the public `BotRequestContext.FromAgenticIdentity(...)`. So each operation exposes just two overloads (original + `BotRequestContext?`) rather than a third `AgenticIdentity?` convenience overload.

This is the core-only slice extracted from #589, so the higher-level `Microsoft.Teams.Apps` changes can follow separately. Stacked on #587 (base branch `heyitsaamir-agentic-identity-defaults`).

Includes a unit test for the `BotRequestContext?` overload (verifies both `AgenticIdentity` and `BotAppId` are stamped onto the outbound request options). All Core unit tests pass on net8.0 and net10.0; the Apps project still builds clean against the base overloads.