### PR TITLE
feat(apps): streaming error handling and reusable streams for TeamsStreamingWriter

### DIFF
--- a/core/samples/StreamingBot/Program.cs
+++ b/core/samples/StreamingBot/Program.cs
@@ -25,6 +25,15 @@ TeamsBotApplication teamsApp = webApp.UseTeamsBotApplication();
 teamsApp.OnMessage(async (context, cancellationToken) =>
 {
     TeamsStreamingWriter writer = TeamsStreamingWriter.CreateFromContext(context);
+
+    // Send "multi-stream" to demo reusing the same writer for a second streamed message
+    // after FinalizeResponseAsync (stream reuse). This path does not call OpenAI.
+    if ((context.Activity.Text ?? string.Empty).Replace("-", " ").Contains("multi stream", StringComparison.OrdinalIgnoreCase))
+    {
+        await RunMultiStreamDemoAsync(writer, cancellationToken);
+        return;
+    }
+
     await writer.SendInformativeUpdateAsync("Thinking…", cancellationToken);
     await Task.Delay(500, cancellationToken);
     await writer.SendInformativeUpdateAsync("Thinking again !!!", cancellationToken);
@@ -90,5 +99,83 @@ teamsApp.OnMessageSubmitAction(async (context, cancellationToken) =>
 
     return new InvokeResponse(200);
 });
+
+static async Task RunMultiStreamDemoAsync(TeamsStreamingWriter writer, CancellationToken cancellationToken)
+{
+    string[] firstStreamMessages =
+    [
+        "[stream 1] Starting the first streamed response. ",
+        "[stream 1] This is using the default writer instance. ",
+        "[stream 1] Next the handler will finalize the current streamed message.",
+    ];
+
+    string[] secondStreamMessages =
+    [
+        "[stream 2] Reusing the writer after finalize reopens the stream. ",
+        "[stream 2] This should render after stream 1's final Adaptive Card message. ",
+        "[stream 2] The handler finalizes this stream at the end.",
+    ];
+
+    // Stream 1: informative placeholder, streamed text chunks, then an Adaptive Card
+    // carried on the final message.
+    await writer.SendInformativeUpdateAsync("Starting stream 1...", cancellationToken);
+    await Task.Delay(1000, cancellationToken);
+
+    foreach (string message in firstStreamMessages)
+    {
+        await Task.Delay(500, cancellationToken);
+        await writer.AppendResponseAsync(message, cancellationToken);
+    }
+
+    await writer.AppendResponseAsync("Adaptive Card emitted as part of stream 1.", cancellationToken);
+
+    // A null Text lets the writer fill in the accumulated streamed text; the attachment
+    // rides along on the final message.
+    MessageActivity stream1Final = new();
+    stream1Final.AddAttachment(CreateSimpleCard());
+    await writer.FinalizeResponseAsync(stream1Final, cancellationToken);
+
+    await Task.Delay(2000, cancellationToken);
+
+    // Stream 2: reuse the same writer after finalize — the informative update reopens the stream.
+    await writer.SendInformativeUpdateAsync("Starting stream 2...", cancellationToken);
+    await Task.Delay(1000, cancellationToken);
+
+    foreach (string message in secondStreamMessages)
+    {
+        await Task.Delay(500, cancellationToken);
+        await writer.AppendResponseAsync(message, cancellationToken);
+    }
+
+    await writer.FinalizeResponseAsync(cancellationToken: cancellationToken);
+}
+
+static TeamsAttachment CreateSimpleCard()
+{
+    return TeamsAttachment.CreateBuilder()
+        .WithAdaptiveCard(new JsonObject
+        {
+            ["type"] = "AdaptiveCard",
+            ["version"] = "1.5",
+            ["body"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["type"] = "TextBlock",
+                    ["text"] = "Simple Adaptive Card",
+                    ["weight"] = "Bolder",
+                    ["size"] = "Large",
+                    ["wrap"] = true,
+                },
+                new JsonObject
+                {
+                    ["type"] = "TextBlock",
+                    ["text"] = "If you can see this card, basic Adaptive Card delivery is working.",
+                    ["wrap"] = true,
+                }
+            }
+        })
+        .Build();
+}
 
 webApp.Run();

--- a/core/src/Microsoft.Teams.Apps/TeamsStreamingExceptions.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsStreamingExceptions.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Teams.Apps;
+
+/// <summary>
+/// Base class for streaming errors (HTTP 403) that should not be retried.
+/// See the Teams streaming error codes:
+/// https://learn.microsoft.com/en-us/microsoftteams/platform/bots/streaming-ux?tabs=csharp#error-codes
+/// </summary>
+public class TerminalStreamException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TerminalStreamException"/> class.
+    /// </summary>
+    public TerminalStreamException() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TerminalStreamException"/> class with a message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public TerminalStreamException(string? message) : base(message) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TerminalStreamException"/> class with a message and inner exception.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public TerminalStreamException(string? message, Exception? innerException) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Raised when the bot failed to complete streaming within the two-minute limit.
+/// </summary>
+public class StreamTimedOutException : TerminalStreamException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamTimedOutException"/> class.
+    /// </summary>
+    public StreamTimedOutException() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamTimedOutException"/> class with a message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public StreamTimedOutException(string? message) : base(message) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamTimedOutException"/> class with a message and inner exception.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public StreamTimedOutException(string? message, Exception? innerException) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Raised when streaming is not allowed for this user or bot.
+/// </summary>
+public class StreamNotAllowedException : TerminalStreamException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamNotAllowedException"/> class.
+    /// </summary>
+    public StreamNotAllowedException() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamNotAllowedException"/> class with a message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public StreamNotAllowedException(string? message) : base(message) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamNotAllowedException"/> class with a message and inner exception.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public StreamNotAllowedException(string? message, Exception? innerException) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Raised when Teams cancels a stream (for example, when the user presses the Stop button).
+/// </summary>
+public class StreamCancelledException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamCancelledException"/> class.
+    /// </summary>
+    public StreamCancelledException() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamCancelledException"/> class with a message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public StreamCancelledException(string? message) : base(message) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamCancelledException"/> class with a message and inner exception.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public StreamCancelledException(string? message, Exception? innerException) : base(message, innerException) { }
+}

--- a/core/src/Microsoft.Teams.Apps/TeamsStreamingWriter.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsStreamingWriter.cs
@@ -310,7 +310,7 @@ public sealed class TeamsStreamingWriter
         {
             _cancelled = true;
             _logger.LogWarning("The streaming was stopped by the user (streamId '{StreamId}').", _streamId);
-            throw new StreamCancelledException(message);
+            throw new StreamCancelledException(message, ex);
         }
     }
 

--- a/core/src/Microsoft.Teams.Apps/TeamsStreamingWriter.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsStreamingWriter.cs
@@ -36,6 +36,15 @@ namespace Microsoft.Teams.Apps;
 ///     final.AddFeedback(FeedbackTypes.Default);
 ///     await writer.FinalizeResponseAsync(final);
 /// </code>
+///
+/// The writer is reusable: appending or sending an informative update after
+/// <see cref="FinalizeResponseAsync"/> reopens the stream on the same instance and starts a new
+/// streamed message. Finalizing is idempotent until the next append/informative update.
+///
+/// Streaming errors are surfaced per the Teams streaming error codes: cancellation and the
+/// two-minute timeout are handled gracefully (a timed-out stream finalizes by updating the
+/// original message in place), while <see cref="StreamNotAllowedException"/> and other
+/// <see cref="TerminalStreamException"/> errors propagate to the caller.
 /// </remarks>
 public sealed class TeamsStreamingWriter
 {
@@ -51,8 +60,20 @@ public sealed class TeamsStreamingWriter
     private int _sequence;
     private bool _finalized;
     private bool _cancelled;
+    private bool _timedOut;
     private readonly System.Text.StringBuilder _accumulated = new();
     private DateTime _lastChunkSent = DateTime.MinValue;
+
+    /// <summary>
+    /// Whether the stream has been cancelled, for example when the user pressed the Stop button.
+    /// </summary>
+    public bool Cancelled => _cancelled;
+
+    /// <summary>
+    /// Whether streaming exceeded the two-minute limit. When true, the final message is
+    /// sent by updating the original streamed message in place rather than as a streamed chunk.
+    /// </summary>
+    public bool TimedOut => _timedOut;
 
     internal TeamsStreamingWriter(ConversationClient client, TeamsActivity reference, ILogger? logger = null)
     {
@@ -77,12 +98,19 @@ public sealed class TeamsStreamingWriter
     /// </summary>
     public async Task SendInformativeUpdateAsync(string text, CancellationToken cancellationToken = default)
     {
+        // Sending after finalize reopens the stream on the same instance, starting a new streamed message.
+        if (_finalized)
+            ResetForNextStream();
+
+        if (_cancelled)
+            return;
+
         if (_lastChunkSent > DateTime.MinValue)
             throw new InvalidOperationException("Cannot send an informative update after streaming has started.");
 
         _sequence++;
         _logger.LogDebug("Sending informative streaming update (sequence {Sequence}).", _sequence);
-        SendActivityResponse? response = await _client.SendActivityAsync(BuildActivity(text, StreamTypes.Informative), cancellationToken: cancellationToken).ConfigureAwait(false);
+        SendActivityResponse? response = await TrySendChunkAsync(BuildActivity(text, StreamTypes.Informative), cancellationToken).ConfigureAwait(false);
         _streamId ??= response?.Id;
         _logger.LogDebug("Stream started with streamId '{StreamId}'.", _streamId);
     }
@@ -91,16 +119,25 @@ public sealed class TeamsStreamingWriter
     /// Appends <paramref name="chunk"/> to the accumulated text and sends the
     /// full accumulated text as an intermediate streaming update (streamType = "streaming").
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if <see cref="FinalizeResponseAsync"/> has already been called.</exception>
+    /// <remarks>
+    /// Appending after <see cref="FinalizeResponseAsync"/> reopens the stream on the same
+    /// instance, starting a new streamed message.
+    /// </remarks>
     public async Task AppendResponseAsync(string chunk, CancellationToken cancellationToken = default)
     {
+        // Appending after finalize reopens the stream on the same instance, starting a new streamed message.
         if (_finalized)
-            throw new InvalidOperationException("Cannot append after FinalizeResponseAsync has been called.");
+            ResetForNextStream();
 
         if (_cancelled)
             return;
 
         _accumulated.Append(chunk);
+
+        // Once the stream has timed out, stop sending chunks; the accumulated text is sent
+        // by FinalizeResponseAsync, which updates the original message in place.
+        if (_timedOut)
+            return;
 
         if (DateTime.UtcNow - _lastChunkSent < _minChunkInterval)
         {
@@ -109,20 +146,13 @@ public sealed class TeamsStreamingWriter
         }
 
         _sequence++;
-        try
-        {
-            _logger.LogDebug("Sending streaming chunk (sequence {Sequence}, accumulated {Length} chars).", _sequence, _accumulated.Length);
-            SendActivityResponse? response = await _client.SendActivityAsync(BuildActivity(_accumulated.ToString(), StreamTypes.Streaming), cancellationToken: cancellationToken).ConfigureAwait(false);
-            _streamId ??= response?.Id;
-            _lastChunkSent = DateTime.UtcNow;
-        }
-        catch (HttpRequestException ex) when (
-            ex.StatusCode is HttpStatusCode.Gone or HttpStatusCode.NoContent
-            || ex.Message.Contains("Content stream was cancelled", StringComparison.OrdinalIgnoreCase))
-        {
-            _logger.LogWarning("Stream cancelled by user (streamId '{StreamId}').", _streamId);
-            _cancelled = true;
-        }
+        _logger.LogDebug("Sending streaming chunk (sequence {Sequence}, accumulated {Length} chars).", _sequence, _accumulated.Length);
+        SendActivityResponse? response = await TrySendChunkAsync(BuildActivity(_accumulated.ToString(), StreamTypes.Streaming), cancellationToken).ConfigureAwait(false);
+        if (_cancelled || _timedOut)
+            return;
+
+        _streamId ??= response?.Id;
+        _lastChunkSent = DateTime.UtcNow;
     }
 
     /// <summary>
@@ -135,14 +165,19 @@ public sealed class TeamsStreamingWriter
     /// (pass <c>""</c> explicitly to send an attachment-only reply).
     /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <remarks>
+    /// Finalizing is idempotent until the next append or informative update reopens the stream.
+    /// If streaming exceeded the two-minute limit, the final content updates the original
+    /// streamed message in place instead of sending a new streamed chunk.
+    /// </remarks>
     /// <exception cref="InvalidOperationException">
-    /// Thrown if <see cref="FinalizeResponseAsync"/> has already been called, or if the final
-    /// activity has neither text nor attachments.
+    /// Thrown if the final activity has neither text nor attachments.
     /// </exception>
     public async Task FinalizeResponseAsync(MessageActivity? final = null, CancellationToken cancellationToken = default)
     {
+        // Finalizing is idempotent until the next append/informative reopens the stream.
         if (_finalized)
-            throw new InvalidOperationException("Cannot finalize after FinalizeResponseAsync has already been called.");
+            return;
 
         if (_cancelled)
             return;
@@ -153,6 +188,15 @@ public sealed class TeamsStreamingWriter
         if (string.IsNullOrEmpty(final.Text) && (final.Attachments == null || final.Attachments.Count == 0))
             throw new InvalidOperationException(
                 "Cannot finalize with no content. Stream text via AppendResponseAsync, or provide attachments on the final MessageActivity.");
+
+        // Streaming already tripped the two-minute limit; update the original message in place.
+        if (_timedOut)
+        {
+            await SendFinalInPlaceAsync(final, cancellationToken).ConfigureAwait(false);
+            _finalized = true;
+            _logger.LogDebug("Stream finalized in place after timeout (streamId '{StreamId}').", _streamId);
+            return;
+        }
 
         StreamInfoEntity streamInfo = new() { StreamType = StreamTypes.Final };
         if (_streamId != null) streamInfo.StreamId = _streamId;
@@ -165,10 +209,156 @@ public sealed class TeamsStreamingWriter
         _logger.LogDebug("Finalizing stream (streamId '{StreamId}', {Length} chars, {Sequences} sequences).",
             _streamId, final.Text?.Length ?? 0, _sequence);
 
-        await _client.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _client.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            try
+            {
+                ThrowIfStreamError(ex);
+                throw;
+            }
+            catch (StreamTimedOutException)
+            {
+                // The final streamed send tripped the two-minute limit. Update the original
+                // message in place with the buffered content: reuse the id and drop the
+                // stream markers so this routes to an update, not a new streamed chunk.
+                await SendFinalInPlaceAsync(final, cancellationToken).ConfigureAwait(false);
+            }
+            catch (StreamCancelledException)
+            {
+                // Cancelled during the final send; nothing more to send.
+            }
+        }
 
         _finalized = true;
         _logger.LogDebug("Stream finalized (streamId '{StreamId}').", _streamId);
+    }
+
+    /// <summary>
+    /// Sends a streaming chunk, swallowing soft-stop conditions (cancellation and the
+    /// two-minute timeout) by flagging state and returning. Terminal streaming errors
+    /// (<see cref="StreamNotAllowedException"/>, <see cref="TerminalStreamException"/>) and
+    /// non-streaming errors propagate.
+    /// </summary>
+    private async Task<SendActivityResponse?> TrySendChunkAsync(TeamsActivity activity, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _client.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            try
+            {
+                ThrowIfStreamError(ex);
+            }
+            catch (StreamCancelledException)
+            {
+                return null; // soft stop: FinalizeResponseAsync returns without sending.
+            }
+            catch (StreamTimedOutException)
+            {
+                return null; // soft stop: FinalizeResponseAsync updates the message in place.
+            }
+
+            // Non-streaming error: rethrow the original exception.
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Maps a failed streaming send to a typed streaming exception. Cancellation and the
+    /// two-minute timeout also flag internal state so callers can stop the send loop.
+    /// Non-streaming failures fall through so the caller can rethrow the original exception.
+    /// See https://learn.microsoft.com/en-us/microsoftteams/platform/bots/streaming-ux?tabs=csharp#error-codes.
+    /// </summary>
+    private void ThrowIfStreamError(HttpRequestException ex)
+    {
+        string message = ex.Message ?? string.Empty;
+
+        if (ex.StatusCode == HttpStatusCode.Forbidden)
+        {
+            if (message.Contains("exceeded streaming time", StringComparison.OrdinalIgnoreCase))
+            {
+                _timedOut = true;
+                _logger.LogWarning("The bot failed to complete streaming within the two-minute limit (streamId '{StreamId}').", _streamId);
+                throw new StreamTimedOutException(message);
+            }
+
+            if (message.Contains("cancel", StringComparison.OrdinalIgnoreCase))
+            {
+                _cancelled = true;
+                _logger.LogWarning("The streaming was stopped by the user (streamId '{StreamId}').", _streamId);
+                throw new StreamCancelledException(message);
+            }
+
+            if (message.Contains("not allowed", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning("The streaming API isn't allowed for the user or bot (streamId '{StreamId}').", _streamId);
+                throw new StreamNotAllowedException(message);
+            }
+
+            _logger.LogWarning("Teams returned a streaming error (streamId '{StreamId}'): {Message}", _streamId, message);
+            throw new TerminalStreamException(message);
+        }
+
+        // Preserve the historical treatment of Gone/NoContent as a user cancellation.
+        if (ex.StatusCode is HttpStatusCode.Gone or HttpStatusCode.NoContent)
+        {
+            _cancelled = true;
+            _logger.LogWarning("The streaming was stopped by the user (streamId '{StreamId}').", _streamId);
+            throw new StreamCancelledException(message);
+        }
+    }
+
+    /// <summary>
+    /// Sends the buffered content as a plain final message by updating the original streamed
+    /// message in place. Drops the <c>streaminfo</c> entity and stream channel data so the
+    /// send routes through the update path (reusing the streamId) instead of creating a
+    /// duplicate streamed chunk.
+    /// </summary>
+    private async Task SendFinalInPlaceAsync(MessageActivity final, CancellationToken cancellationToken)
+    {
+        // Drop streaming markers so Teams treats this as a normal message edit.
+        final.Entities?.RemoveAll(e => e is StreamInfoEntity);
+        if (final.ChannelData?.Properties is { } props)
+        {
+            props.Remove("streamId");
+            props.Remove("streamType");
+            props.Remove("streamSequence");
+        }
+
+        TeamsActivity activity = new TeamsActivityBuilder(final)
+            .WithConversationReference(_reference)
+            .Build();
+
+        if (_streamId != null)
+        {
+            _logger.LogDebug("Updating original streamed message in place after timeout (streamId '{StreamId}').", _streamId);
+            await _client.UpdateActivityAsync(_conversationId, _streamId, activity, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            // No streamed message exists yet; send the buffered content as a normal message.
+            await _client.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Prepares the writer to start a new stream cycle after finalize. The cancelled flag is
+    /// sticky: once a stream is cancelled it stays cancelled across reuse.
+    /// </summary>
+    private void ResetForNextStream()
+    {
+        _streamId = null;
+        _sequence = 0;
+        _finalized = false;
+        _timedOut = false;
+        _accumulated.Clear();
+        _lastChunkSent = DateTime.MinValue;
     }
 
     private TeamsActivity BuildActivity(string text, string streamType)

--- a/core/src/Microsoft.Teams.Apps/TeamsStreamingWriter.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsStreamingWriter.cs
@@ -98,12 +98,15 @@ public sealed class TeamsStreamingWriter
     /// </summary>
     public async Task SendInformativeUpdateAsync(string text, CancellationToken cancellationToken = default)
     {
-        // Sending after finalize reopens the stream on the same instance, starting a new streamed message.
-        if (_finalized)
-            ResetForNextStream();
-
         if (_cancelled)
             return;
+
+        // Sending after finalize reopens the stream on the same instance, starting a new streamed message.
+        if (_finalized)
+        {
+            _logger.LogDebug("Reopening stream after finalize for a new informative update.");
+            ResetForNextStream();
+        }
 
         if (_lastChunkSent > DateTime.MinValue)
             throw new InvalidOperationException("Cannot send an informative update after streaming has started.");
@@ -125,12 +128,15 @@ public sealed class TeamsStreamingWriter
     /// </remarks>
     public async Task AppendResponseAsync(string chunk, CancellationToken cancellationToken = default)
     {
-        // Appending after finalize reopens the stream on the same instance, starting a new streamed message.
-        if (_finalized)
-            ResetForNextStream();
-
         if (_cancelled)
             return;
+
+        // Appending after finalize reopens the stream on the same instance, starting a new streamed message.
+        if (_finalized)
+        {
+            _logger.LogDebug("Reopening stream after finalize for a new streamed message.");
+            ResetForNextStream();
+        }
 
         _accumulated.Append(chunk);
 
@@ -148,10 +154,11 @@ public sealed class TeamsStreamingWriter
         _sequence++;
         _logger.LogDebug("Sending streaming chunk (sequence {Sequence}, accumulated {Length} chars).", _sequence, _accumulated.Length);
         SendActivityResponse? response = await TrySendChunkAsync(BuildActivity(_accumulated.ToString(), StreamTypes.Streaming), cancellationToken).ConfigureAwait(false);
+        _streamId ??= response?.Id;
+
         if (_cancelled || _timedOut)
             return;
 
-        _streamId ??= response?.Id;
         _lastChunkSent = DateTime.UtcNow;
     }
 
@@ -230,6 +237,7 @@ public sealed class TeamsStreamingWriter
             catch (StreamCancelledException)
             {
                 // Cancelled during the final send; nothing more to send.
+                _logger.LogDebug("Stream cancelled during finalize; no final message sent (streamId '{StreamId}').", _streamId);
             }
         }
 
@@ -257,10 +265,12 @@ public sealed class TeamsStreamingWriter
             }
             catch (StreamCancelledException)
             {
+                _logger.LogDebug("Chunk send stopped: stream cancelled (streamId '{StreamId}').", _streamId);
                 return null; // soft stop: FinalizeResponseAsync returns without sending.
             }
             catch (StreamTimedOutException)
             {
+                _logger.LogDebug("Chunk send stopped: stream timed out (streamId '{StreamId}').", _streamId);
                 return null; // soft stop: FinalizeResponseAsync updates the message in place.
             }
 

--- a/core/src/Microsoft.Teams.Apps/TeamsStreamingWriter.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsStreamingWriter.cs
@@ -285,24 +285,24 @@ public sealed class TeamsStreamingWriter
             {
                 _timedOut = true;
                 _logger.LogWarning("The bot failed to complete streaming within the two-minute limit (streamId '{StreamId}').", _streamId);
-                throw new StreamTimedOutException(message);
+                throw new StreamTimedOutException(message, ex);
             }
 
             if (message.Contains("cancel", StringComparison.OrdinalIgnoreCase))
             {
                 _cancelled = true;
                 _logger.LogWarning("The streaming was stopped by the user (streamId '{StreamId}').", _streamId);
-                throw new StreamCancelledException(message);
+                throw new StreamCancelledException(message, ex);
             }
 
             if (message.Contains("not allowed", StringComparison.OrdinalIgnoreCase))
             {
                 _logger.LogWarning("The streaming API isn't allowed for the user or bot (streamId '{StreamId}').", _streamId);
-                throw new StreamNotAllowedException(message);
+                throw new StreamNotAllowedException(message, ex);
             }
 
             _logger.LogWarning("Teams returned a streaming error (streamId '{StreamId}'): {Message}", _streamId, message);
-            throw new TerminalStreamException(message);
+            throw new TerminalStreamException(message, ex);
         }
 
         // Preserve the historical treatment of Gone/NoContent as a user cancellation.

--- a/core/test/Microsoft.Teams.Apps.UnitTests/TeamsStreamingWriterTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/TeamsStreamingWriterTests.cs
@@ -269,7 +269,9 @@ public class TeamsStreamingWriterTests
         (TeamsStreamingWriter writer, FakeHttpMessageHandler handler) = CreateWriter();
         handler.EnqueueResponse("{\"error\":{\"message\":\"Content stream is not allowed\"}}", HttpStatusCode.Forbidden);
 
-        await Assert.ThrowsAsync<StreamNotAllowedException>(() => writer.AppendResponseAsync("hi"));
+        StreamNotAllowedException ex = await Assert.ThrowsAsync<StreamNotAllowedException>(() => writer.AppendResponseAsync("hi"));
+        // The original HttpRequestException is preserved as the inner exception for diagnostics.
+        Assert.IsType<HttpRequestException>(ex.InnerException);
     }
 
     [Fact]
@@ -278,7 +280,8 @@ public class TeamsStreamingWriterTests
         (TeamsStreamingWriter writer, FakeHttpMessageHandler handler) = CreateWriter();
         handler.EnqueueResponse("{\"error\":{\"message\":\"Message size too large\"}}", HttpStatusCode.Forbidden);
 
-        await Assert.ThrowsAsync<TerminalStreamException>(() => writer.AppendResponseAsync("hi"));
+        TerminalStreamException ex = await Assert.ThrowsAsync<TerminalStreamException>(() => writer.AppendResponseAsync("hi"));
+        Assert.IsType<HttpRequestException>(ex.InnerException);
     }
 
     [Fact]

--- a/core/test/Microsoft.Teams.Apps.UnitTests/TeamsStreamingWriterTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/TeamsStreamingWriterTests.cs
@@ -59,25 +59,37 @@ public class TeamsStreamingWriterTests
     // ── Guard conditions ──────────────────────────────────────────────────────
 
     [Fact]
-    public async Task AppendAsync_AfterFinalizeAsync_ThrowsInvalidOperationException()
+    public async Task AppendAsync_AfterFinalizeAsync_ReopensStreamForNextMessage()
     {
-        (TeamsStreamingWriter writer, _) = CreateWriter();
+        (TeamsStreamingWriter writer, FakeHttpMessageHandler handler) = CreateWriter();
 
         await writer.AppendResponseAsync("Hello");
         await writer.FinalizeResponseAsync();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => writer.AppendResponseAsync("Too late"));
+        // Appending after finalize reopens the stream on the same instance instead of throwing.
+        await writer.AppendResponseAsync("Second message");
+        await writer.FinalizeResponseAsync();
+
+        int finalCount = handler.RequestBodies.Count(b => b.Contains("\"streamType\": \"final\"", StringComparison.Ordinal));
+        Assert.Equal(2, finalCount);
+        // The reopened cycle only carries the second message's text (accumulated text was reset).
+        Assert.Contains("Second message", handler.RequestBodies.Last());
     }
 
     [Fact]
-    public async Task FinalizeAsync_CalledTwice_ThrowsInvalidOperationException()
+    public async Task FinalizeAsync_CalledTwice_IsIdempotent()
     {
-        (TeamsStreamingWriter writer, _) = CreateWriter();
+        (TeamsStreamingWriter writer, FakeHttpMessageHandler handler) = CreateWriter();
 
         await writer.AppendResponseAsync("Hello");
         await writer.FinalizeResponseAsync();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => writer.FinalizeResponseAsync());
+        int countAfterFirstFinalize = handler.RequestBodies.Count;
+
+        // A second finalize is a no-op until the next append/informative reopens the stream.
+        await writer.FinalizeResponseAsync();
+
+        Assert.Equal(countAfterFirstFinalize, handler.RequestBodies.Count);
     }
 
     // ── Informative-first path ────────────────────────────────────────────────
@@ -247,5 +259,97 @@ public class TeamsStreamingWriterTests
         Assert.Null(streamIds[0]);
         Assert.NotNull(streamIds[1]);
         Assert.Equal(streamIds[1], streamIds[2]);
+    }
+
+    // ── Error handling (HTTP 403) ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task AppendAsync_403NotAllowed_ThrowsStreamNotAllowedException()
+    {
+        (TeamsStreamingWriter writer, FakeHttpMessageHandler handler) = CreateWriter();
+        handler.EnqueueResponse("{\"error\":{\"message\":\"Content stream is not allowed\"}}", HttpStatusCode.Forbidden);
+
+        await Assert.ThrowsAsync<StreamNotAllowedException>(() => writer.AppendResponseAsync("hi"));
+    }
+
+    [Fact]
+    public async Task AppendAsync_403UnknownMessage_ThrowsTerminalStreamException()
+    {
+        (TeamsStreamingWriter writer, FakeHttpMessageHandler handler) = CreateWriter();
+        handler.EnqueueResponse("{\"error\":{\"message\":\"Message size too large\"}}", HttpStatusCode.Forbidden);
+
+        await Assert.ThrowsAsync<TerminalStreamException>(() => writer.AppendResponseAsync("hi"));
+    }
+
+    [Fact]
+    public async Task AppendAsync_403Cancelled_IsSwallowedAndFlagsCancelled()
+    {
+        (TeamsStreamingWriter writer, FakeHttpMessageHandler handler) = CreateWriter();
+        handler.EnqueueResponse("{\"error\":{\"message\":\"Content stream was canceled by user\"}}", HttpStatusCode.Forbidden);
+
+        // Cancellation is swallowed, not thrown.
+        await writer.AppendResponseAsync("hi");
+
+        Assert.True(writer.Cancelled);
+
+        // Finalize sends nothing once the stream is cancelled.
+        int countBeforeFinalize = handler.Requests.Count;
+        await writer.FinalizeResponseAsync();
+        Assert.Equal(countBeforeFinalize, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task FinalizeAsync_AfterStreamingTimeout_UpdatesOriginalMessageInPlace()
+    {
+        (TeamsStreamingWriter writer, FakeHttpMessageHandler handler) = CreateWriter();
+
+        // Informative send assigns the streamId that the in-place update will target.
+        handler.EnqueueResponse("{\"id\":\"stream-1\"}");
+        await writer.SendInformativeUpdateAsync("Thinking…");
+
+        // The next chunk trips the two-minute limit.
+        handler.EnqueueResponse(
+            "{\"error\":{\"message\":\"Content stream finished due to exceeded streaming time.\"}}",
+            HttpStatusCode.Forbidden);
+        await writer.AppendResponseAsync("Final answer");
+
+        Assert.True(writer.TimedOut);
+
+        await writer.FinalizeResponseAsync();
+
+        // Finalize updates the original streamed message in place: a PUT to the streamId,
+        // carrying the buffered text without any stream markers.
+        HttpRequestMessage lastRequest = handler.Requests.Last();
+        Assert.Equal(HttpMethod.Put, lastRequest.Method);
+        Assert.EndsWith("/activities/stream-1", lastRequest.RequestUri!.AbsolutePath);
+
+        string lastBody = handler.RequestBodies.Last();
+        Assert.Contains("Final answer", lastBody);
+        Assert.DoesNotContain("\"streamType\": \"final\"", lastBody);
+        Assert.DoesNotContain("streaminfo", lastBody);
+    }
+
+    [Fact]
+    public async Task FinalizeAsync_WhenFinalSendTimesOut_FallsBackToInPlaceUpdate()
+    {
+        (TeamsStreamingWriter writer, FakeHttpMessageHandler handler) = CreateWriter();
+
+        // First chunk streams fine and assigns the streamId.
+        handler.EnqueueResponse("{\"id\":\"stream-1\"}");
+        await writer.AppendResponseAsync("Buffered answer");
+
+        // The final streamed send itself trips the two-minute limit.
+        handler.EnqueueResponse(
+            "{\"error\":{\"message\":\"Content stream finished due to exceeded streaming time.\"}}",
+            HttpStatusCode.Forbidden);
+        await writer.FinalizeResponseAsync();
+
+        Assert.True(writer.TimedOut);
+
+        // The final send fell back to updating the original message in place.
+        HttpRequestMessage lastRequest = handler.Requests.Last();
+        Assert.Equal(HttpMethod.Put, lastRequest.Method);
+        Assert.EndsWith("/activities/stream-1", lastRequest.RequestUri!.AbsolutePath);
+        Assert.Contains("Buffered answer", handler.RequestBodies.Last());
     }
 }


### PR DESCRIPTION
## Summary

Ports two merged **teams.py** PRs to the .NET `core` streaming writer (`TeamsStreamingWriter`), adapted to its `Append`/`Finalize` API surface:

- microsoft/teams.py#453 — streaming error handling for the 2-minute timeout & "content stream not allowed"
- microsoft/teams.py#495 — support resetting (reusing) response streams

## Streaming error handling (port of #453)

- New exception types in `TeamsStreamingExceptions.cs`: `TerminalStreamException` (base) with `StreamTimedOutException`, `StreamNotAllowedException`, and `StreamCancelledException`.
- The send path now classifies the `403` response body instead of only matching cancellation:
  - `exceeded streaming time` → timed out (flagged, swallowed)
  - `cancel` → cancelled (flagged, swallowed)
  - `not allowed` → `StreamNotAllowedException` (propagates)
  - anything else → `TerminalStreamException` (propagates)
- On a two-minute timeout, `FinalizeResponseAsync` updates the **original streamed message in place** via `UpdateActivityAsync` — it reuses the `streamId` and drops the `streaminfo` entity + stream channel data so the send routes through an update rather than posting a duplicate.
- Cancellation and timeout are swallowed (graceful stop, consistent with the writer's prior cancel behavior); not-allowed and terminal errors surface to the caller.

## Reusable streams (port of #495)

- Appending or sending an informative update after `FinalizeResponseAsync` **reopens the stream on the same writer instance**, starting a new streamed message. The `cancelled` flag stays sticky across reuse.
- `FinalizeResponseAsync` is **idempotent** until the next append/informative update.

## Sample

`core/samples/StreamingBot` gains a `multi-stream` path (no OpenAI required): it streams text, emits an Adaptive Card as the stream 1 final message, finalizes, then reuses the writer for a second streamed message — mirroring the teams.py/teams.ts example.

## Tests

- `TeamsStreamingWriterTests` — 2 existing tests updated to assert reuse/idempotency (previously asserted throw), plus 5 new tests: 403 message → exception mapping, streaming-timeout in-place update, and final-send-timeout fallback to in-place update.
- Full `Microsoft.Teams.Apps.UnitTests` suite passes (359 tests, net10.0); build and `dotnet format` clean on the changed files.
- The `multi-stream` reuse flow was verified end-to-end against a live Teams bot.

## Notes

- Core streaming has no retry wrapper around sends, so #453's `nonRetryable` retry option has no analog here — nothing to port for that piece.
- The Adaptive Card in the sample is built as a raw `JsonObject` because core serializes streamed activities with a source-generated JSON context that does not support the typed `Microsoft.Teams.Cards` models directly.
