### PR TITLE
Flow bot request context through BotBuilder compat clients

### DIFF
--- a/core/src/Microsoft.Teams.Apps.BotBuilder/CompatConversations.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/CompatConversations.cs
@@ -353,7 +353,13 @@ namespace Microsoft.Teams.Apps.BotBuilder
                 coreActivity.ServiceUrl = new Uri(ServiceUrl);
             }
 
-            UpdateActivityResponse response = await _client.UpdateActivityAsync(conversationId, activityId, coreActivity, customHeaders: convertedHeaders, cancellationToken: cancellationToken).ConfigureAwait(false);
+            UpdateActivityResponse response = await _client.UpdateActivityAsync(
+                conversationId,
+                activityId,
+                coreActivity,
+                requestContext: RequestContext,
+                customHeaders: convertedHeaders,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
             ResourceResponse resourceResponse = new()
             {

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/CompatUserTokenClient.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/CompatUserTokenClient.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Bot.Schema;
 using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Http;
 
 namespace Microsoft.Teams.Apps.BotBuilder;
 
@@ -19,6 +20,13 @@ namespace Microsoft.Teams.Apps.BotBuilder;
 internal sealed class CompatUserTokenClient(UserTokenClient utc) : Microsoft.Bot.Connector.Authentication.UserTokenClient
 {
     /// <summary>
+    /// Gets or sets the per-request properties captured from the incoming activity (agentic identity,
+    /// bot app id). Threaded into each outbound user token operation and stamped onto the request's
+    /// options for the authentication handler to read.
+    /// </summary>
+    internal BotRequestContext? RequestContext { get; set; }
+
+    /// <summary>
     /// Gets the status of all tokens for a specific user across all configured OAuth connections.
     /// </summary>
     /// <param name="userId">The unique identifier of the user. Cannot be null or empty.</param>
@@ -29,9 +37,18 @@ internal sealed class CompatUserTokenClient(UserTokenClient utc) : Microsoft.Bot
     /// A task that represents the asynchronous operation. The task result contains an array of <see cref="TokenStatus"/>
     /// objects representing the status of each configured connection for the user.
     /// </returns>
-    public async override Task<TokenStatus[]> GetTokenStatusAsync(string userId, string channelId, string includeFilter, CancellationToken cancellationToken)
+    public async override Task<TokenStatus[]> GetTokenStatusAsync(
+        string userId,
+        string channelId,
+        string includeFilter,
+        CancellationToken cancellationToken)
     {
-        GetTokenStatusResult[] res = await utc.GetTokenStatusAsync(userId, channelId, includeFilter, cancellationToken).ConfigureAwait(false);
+        GetTokenStatusResult[] res = await utc.GetTokenStatusAsync(
+            userId,
+            channelId,
+            includeFilter,
+            RequestContext,
+            cancellationToken).ConfigureAwait(false);
         return res.Select(t => new TokenStatus
         {
             ChannelId = channelId,
@@ -53,9 +70,20 @@ internal sealed class CompatUserTokenClient(UserTokenClient utc) : Microsoft.Bot
     /// A task that represents the asynchronous operation. The task result contains a <see cref="TokenResponse"/> with
     /// the OAuth token if available, or null if the user has not completed authentication for this connection.
     /// </returns>
-    public async override Task<TokenResponse?> GetUserTokenAsync(string userId, string connectionName, string channelId, string magicCode, CancellationToken cancellationToken)
+    public async override Task<TokenResponse?> GetUserTokenAsync(
+        string userId,
+        string connectionName,
+        string channelId,
+        string magicCode,
+        CancellationToken cancellationToken)
     {
-        GetTokenResult? res = await utc.GetTokenAsync(userId, connectionName, channelId, magicCode, cancellationToken).ConfigureAwait(false);
+        GetTokenResult? res = await utc.GetTokenAsync(
+            userId,
+            connectionName,
+            channelId,
+            magicCode,
+            RequestContext,
+            cancellationToken).ConfigureAwait(false);
         if (res == null)
         {
             return null;
@@ -81,10 +109,20 @@ internal sealed class CompatUserTokenClient(UserTokenClient utc) : Microsoft.Bot
     /// with the sign-in link and optional token exchange or post resources for completing the OAuth flow.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="activity"/> is null.</exception>
-    public async override Task<SignInResource> GetSignInResourceAsync(string connectionName, Activity activity, string finalRedirect, CancellationToken cancellationToken)
+    public async override Task<SignInResource> GetSignInResourceAsync(
+        string connectionName,
+        Activity activity,
+        string finalRedirect,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        GetSignInResourceResult res = await utc.GetSignInResourceAsync(activity.From.Id, connectionName, activity.ChannelId, finalRedirect, cancellationToken).ConfigureAwait(false);
+        GetSignInResourceResult res = await utc.GetSignInResourceAsync(
+            activity.From.Id,
+            connectionName,
+            activity.ChannelId,
+            finalRedirect,
+            RequestContext,
+            cancellationToken).ConfigureAwait(false);
         SignInResource signInResource = new()
         {
             SignInLink = res!.SignInLink
@@ -123,11 +161,20 @@ internal sealed class CompatUserTokenClient(UserTokenClient utc) : Microsoft.Bot
     /// A task that represents the asynchronous operation. The task result contains a <see cref="TokenResponse"/>
     /// with the exchanged token for the target connection.
     /// </returns>
-    public async override Task<TokenResponse> ExchangeTokenAsync(string userId, string connectionName, string channelId,
-     TokenExchangeRequest exchangeRequest, CancellationToken cancellationToken)
+    public async override Task<TokenResponse> ExchangeTokenAsync(
+        string userId,
+        string connectionName,
+        string channelId,
+        TokenExchangeRequest exchangeRequest,
+        CancellationToken cancellationToken)
     {
-        GetTokenResult resp = await utc.ExchangeTokenAsync(userId, connectionName, channelId, exchangeRequest.Token,
-        cancellationToken).ConfigureAwait(false);
+        GetTokenResult resp = await utc.ExchangeTokenAsync(
+            userId,
+            connectionName,
+            channelId,
+            exchangeRequest.Token,
+            RequestContext,
+            cancellationToken).ConfigureAwait(false);
         return new TokenResponse
         {
             ChannelId = channelId,
@@ -144,9 +191,18 @@ internal sealed class CompatUserTokenClient(UserTokenClient utc) : Microsoft.Bot
     /// <param name="channelId">The channel identifier where the user is interacting. Cannot be null or empty.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
     /// <returns>A task that represents the asynchronous sign-out operation.</returns>
-    public async override Task SignOutUserAsync(string userId, string connectionName, string channelId, CancellationToken cancellationToken)
+    public async override Task SignOutUserAsync(
+        string userId,
+        string connectionName,
+        string channelId,
+        CancellationToken cancellationToken)
     {
-        await utc.SignOutUserAsync(userId, connectionName, channelId, cancellationToken).ConfigureAwait(false);
+        await utc.SignOutUserAsync(
+            userId,
+            connectionName,
+            channelId,
+            RequestContext,
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -161,9 +217,20 @@ internal sealed class CompatUserTokenClient(UserTokenClient utc) : Microsoft.Bot
     /// A task that represents the asynchronous operation. The task result contains a dictionary mapping each
     /// resource URL to its corresponding <see cref="TokenResponse"/>. Returns an empty dictionary if no tokens are available.
     /// </returns>
-    public async override Task<Dictionary<string, TokenResponse>> GetAadTokensAsync(string userId, string connectionName, string[] resourceUrls, string channelId, CancellationToken cancellationToken)
+    public async override Task<Dictionary<string, TokenResponse>> GetAadTokensAsync(
+        string userId,
+        string connectionName,
+        string[] resourceUrls,
+        string channelId,
+        CancellationToken cancellationToken)
     {
-        IDictionary<string, GetTokenResult> res = await utc.GetAadTokensAsync(userId, connectionName, channelId, resourceUrls, cancellationToken).ConfigureAwait(false);
+        IDictionary<string, GetTokenResult> res = await utc.GetAadTokensAsync(
+            userId,
+            connectionName,
+            channelId,
+            resourceUrls,
+            RequestContext,
+            cancellationToken).ConfigureAwait(false);
         return res?.ToDictionary(kvp => kvp.Key, kvp => new TokenResponse
         {
             ChannelId = channelId,

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsApiClient.cs
@@ -45,10 +45,10 @@ public static class TeamsApiClient
             ?? throw new InvalidOperationException("ServiceUrl is required.");
     }
 
-    private static AgenticIdentity? GetIdentity(ITurnContext turnContext)
+    private static BotRequestContext? GetRequestContext(ITurnContext turnContext)
     {
         CoreActivity coreActivity = turnContext.Activity.FromBotFrameworkActivity();
-        return AgenticIdentity.FromAccount(coreActivity.Recipient);
+        return BotRequestContext.FromInboundActivity(coreActivity);
     }
 
     #endregion
@@ -87,10 +87,10 @@ public static class TeamsApiClient
 
             ConversationClient client = GetConversationClient(turnContext);
             Uri serviceUrl = new(GetServiceUrl(turnContext));
-            AgenticIdentity? identity = GetIdentity(turnContext);
+            BotRequestContext? requestContext = GetRequestContext(turnContext);
 
             Core.Schema.ChannelAccount result = await client.GetConversationMemberAsync<Core.Schema.ChannelAccount>(
-                conversationId, userId, serviceUrl, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
+                conversationId, userId, serviceUrl, requestContext, null, cancellationToken).ConfigureAwait(false);
 
             return result.ToCompatTeamsChannelAccount();
         }
@@ -121,10 +121,10 @@ public static class TeamsApiClient
 
             ConversationClient client = GetConversationClient(turnContext);
             Uri serviceUrl = new(GetServiceUrl(turnContext));
-            AgenticIdentity? identity = GetIdentity(turnContext);
+            BotRequestContext? requestContext = GetRequestContext(turnContext);
 
             IList<Core.Schema.ChannelAccount> members = await client.GetConversationMembersAsync(
-                conversationId, serviceUrl, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
+                conversationId, serviceUrl, requestContext, null, cancellationToken).ConfigureAwait(false);
 
             return members.Select(m => m.ToCompatTeamsChannelAccount());
         }
@@ -158,10 +158,10 @@ public static class TeamsApiClient
 
             ConversationClient client = GetConversationClient(turnContext);
             Uri serviceUrl = new(GetServiceUrl(turnContext));
-            AgenticIdentity? identity = GetIdentity(turnContext);
+            BotRequestContext? requestContext = GetRequestContext(turnContext);
 
             Core.PagedMembersResult pagedMembers = await client.GetConversationPagedMembersAsync(
-                conversationId, serviceUrl, pageSize, continuationToken, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
+                conversationId, serviceUrl, pageSize, continuationToken, requestContext, null, cancellationToken).ConfigureAwait(false);
 
             return pagedMembers.ToCompatTeamsPagedMembersResult();
         }
@@ -192,10 +192,10 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? identity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
 
         Core.Schema.ChannelAccount result = await client.GetConversationMemberAsync<Core.Schema.ChannelAccount>(
-            t, userId, serviceUrl, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
+            t, userId, serviceUrl, requestContext, null, cancellationToken).ConfigureAwait(false);
 
         return result.ToCompatTeamsChannelAccount();
     }
@@ -220,10 +220,10 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? identity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
 
         IList<Core.Schema.ChannelAccount> members = await client.GetConversationMembersAsync(
-            t, serviceUrl, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
+            t, serviceUrl, requestContext, null, cancellationToken).ConfigureAwait(false);
 
         return members.Select(m => m.ToCompatTeamsChannelAccount());
     }
@@ -251,10 +251,10 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? identity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
 
         Core.PagedMembersResult pagedMembers = await client.GetConversationPagedMembersAsync(
-            t, serviceUrl, pageSize, continuationToken, BotRequestContext.FromAgenticIdentity(identity), null, cancellationToken).ConfigureAwait(false);
+            t, serviceUrl, pageSize, continuationToken, requestContext, null, cancellationToken).ConfigureAwait(false);
 
         return pagedMembers.ToCompatTeamsPagedMembersResult();
     }
@@ -280,7 +280,7 @@ public static class TeamsApiClient
             ?? throw new InvalidOperationException("The meetingId can only be null if turnContext is within the scope of a MS Teams Meeting.");
 
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
 
         ConversationClient client = GetConversationClient(turnContext);
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v1/meetings/{Uri.EscapeDataString(meetingId)}";
@@ -289,7 +289,7 @@ public static class TeamsApiClient
             HttpMethod.Get,
             url,
             body: null,
-            CreateRequestOptions(agenticIdentity, "fetching meeting info", DefaultCustomHeaders),
+            CreateRequestOptions(requestContext, "fetching meeting info", DefaultCustomHeaders),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -319,7 +319,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v1/meetings/{Uri.EscapeDataString(meetingId)}/participants/{Uri.EscapeDataString(participantId)}?tenantId={Uri.EscapeDataString(tenantId)}";
 
@@ -328,7 +328,7 @@ public static class TeamsApiClient
             HttpMethod.Get,
             url,
             body: null,
-            CreateRequestOptions(agenticIdentity, "fetching meeting participant", DefaultCustomHeaders),
+            CreateRequestOptions(requestContext, "fetching meeting participant", DefaultCustomHeaders),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -353,7 +353,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v1/meetings/{Uri.EscapeDataString(meetingId)}/notification";
         string body = JsonConvert.SerializeObject(notification);
@@ -362,7 +362,7 @@ public static class TeamsApiClient
             HttpMethod.Post,
             url,
             body,
-            CreateRequestOptions(agenticIdentity, "sending meeting notification", DefaultCustomHeaders),
+            CreateRequestOptions(requestContext, "sending meeting notification", DefaultCustomHeaders),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -387,7 +387,7 @@ public static class TeamsApiClient
             ?? throw new InvalidOperationException("This method is only valid within the scope of MS Teams Team.");
 
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? identity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/teams/{Uri.EscapeDataString(t)}";
 
@@ -397,7 +397,7 @@ public static class TeamsApiClient
             HttpMethod.Get,
             url,
             body: null,
-            new BotRequestOptions { RequestContext = BotRequestContext.FromAgenticIdentity(identity) },
+            new BotRequestOptions { RequestContext = requestContext },
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -419,7 +419,7 @@ public static class TeamsApiClient
             ?? throw new InvalidOperationException("This method is only valid within the scope of MS Teams Team.");
 
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? identity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/teams/{Uri.EscapeDataString(t)}/conversations";
 
@@ -429,7 +429,7 @@ public static class TeamsApiClient
             HttpMethod.Get,
             url,
             body: null,
-            new BotRequestOptions { RequestContext = BotRequestContext.FromAgenticIdentity(identity) },
+            new BotRequestOptions { RequestContext = requestContext },
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -461,7 +461,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/users/";
         SendMessageToUsersRequest request = new()
@@ -476,7 +476,7 @@ public static class TeamsApiClient
             HttpMethod.Post,
             url,
             body,
-            CreateRequestOptions(agenticIdentity, "sending message to list of users", DefaultCustomHeaders),
+            CreateRequestOptions(requestContext, "sending message to list of users", DefaultCustomHeaders),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -503,7 +503,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/channels/";
         SendMessageToUsersRequest request = new()
         {
@@ -518,7 +518,7 @@ public static class TeamsApiClient
             HttpMethod.Post,
             url,
             body,
-            CreateRequestOptions(agenticIdentity, "sending message to list of channels", DefaultCustomHeaders),
+            CreateRequestOptions(requestContext, "sending message to list of channels", DefaultCustomHeaders),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -545,7 +545,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
         if (activity is not Activity teamActivity)
             throw new ArgumentException("Expected a Bot Framework Activity instance.", nameof(activity));
         CoreActivity coreActivity = teamActivity.FromBotFrameworkActivity();
@@ -564,7 +564,7 @@ public static class TeamsApiClient
             HttpMethod.Post,
             url,
             body,
-            CreateRequestOptions(agenticIdentity, "sending message to all users in team", DefaultCustomHeaders),
+            CreateRequestOptions(requestContext, "sending message to all users in team", DefaultCustomHeaders),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -588,7 +588,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
         if (activity is not Activity tenantActivity)
             throw new ArgumentException("Expected a Bot Framework Activity instance.", nameof(activity));
         CoreActivity coreActivity = tenantActivity.FromBotFrameworkActivity();
@@ -606,7 +606,7 @@ public static class TeamsApiClient
             HttpMethod.Post,
             url,
             body,
-            CreateRequestOptions(agenticIdentity, "sending message to all users in tenant", DefaultCustomHeaders),
+            CreateRequestOptions(requestContext, "sending message to all users in tenant", DefaultCustomHeaders),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -684,7 +684,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/{Uri.EscapeDataString(operationId)}";
 
 
@@ -692,7 +692,7 @@ public static class TeamsApiClient
             HttpMethod.Get,
             url,
             body: null,
-            CreateRequestOptions(agenticIdentity, "getting operation state", DefaultCustomHeaders),
+            CreateRequestOptions(requestContext, "getting operation state", DefaultCustomHeaders),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -715,7 +715,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/failedentries/{Uri.EscapeDataString(operationId)}";
 
@@ -728,7 +728,7 @@ public static class TeamsApiClient
             HttpMethod.Get,
             url,
             body: null,
-            CreateRequestOptions(agenticIdentity, "getting paged failed entries", DefaultCustomHeaders),
+            CreateRequestOptions(requestContext, "getting paged failed entries", DefaultCustomHeaders),
             cancellationToken).ConfigureAwait(false))!;
     }
 
@@ -749,7 +749,7 @@ public static class TeamsApiClient
 
         ConversationClient client = GetConversationClient(turnContext);
         Uri serviceUrl = new(GetServiceUrl(turnContext));
-        AgenticIdentity? agenticIdentity = GetIdentity(turnContext);
+        BotRequestContext? requestContext = GetRequestContext(turnContext);
 
         string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/batch/conversation/{Uri.EscapeDataString(operationId)}";
 
@@ -757,17 +757,17 @@ public static class TeamsApiClient
             HttpMethod.Delete,
             url,
             body: null,
-            CreateRequestOptions(agenticIdentity, "cancelling operation", DefaultCustomHeaders),
+            CreateRequestOptions(requestContext, "cancelling operation", DefaultCustomHeaders),
             cancellationToken).ConfigureAwait(false);
     }
 
     #endregion
 
 
-    private static BotRequestOptions CreateRequestOptions(AgenticIdentity? agenticIdentity, string operationDescription, CustomHeaders? customHeaders) =>
+    private static BotRequestOptions CreateRequestOptions(BotRequestContext? requestContext, string operationDescription, CustomHeaders? customHeaders) =>
         new()
         {
-            RequestContext = BotRequestContext.FromAgenticIdentity(agenticIdentity),
+            RequestContext = requestContext,
             OperationDescription = operationDescription,
             CustomHeaders = customHeaders
         };

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsBotAdapter.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsBotAdapter.cs
@@ -82,6 +82,8 @@ public class TeamsBotAdapter(
     {
         ArgumentNullException.ThrowIfNull(activities);
         ArgumentNullException.ThrowIfNull(turnContext);
+        Activity inboundActivity = turnContext.Activity
+            ?? throw new InvalidOperationException("Turn context activity is required to send activities.");
 
         ResourceResponse[] responses = new Microsoft.Bot.Schema.ResourceResponse[activities.Length];
 
@@ -103,17 +105,17 @@ public class TeamsBotAdapter(
             CoreActivity coreActivity = activity.FromBotFrameworkActivity();
 
             // Ensure ServiceUrl is set from turn context if not already present
-            if (coreActivity.ServiceUrl == null && !string.IsNullOrWhiteSpace(turnContext.Activity.ServiceUrl))
+            if (coreActivity.ServiceUrl == null && !string.IsNullOrWhiteSpace(inboundActivity.ServiceUrl))
             {
-                coreActivity.ServiceUrl = new Uri(turnContext.Activity.ServiceUrl);
+                coreActivity.ServiceUrl = new Uri(inboundActivity.ServiceUrl);
             }
 
             coreActivity.Conversation ??= new Microsoft.Teams.Core.Schema.Conversation(
-                turnContext.Activity.Conversation?.Id
+                inboundActivity.Conversation?.Id
                 ?? throw new InvalidOperationException("Conversation ID is required to send activities."));
             SendActivityResponse? resp = await botApplication.ConversationClient.SendActivityAsync(
                 coreActivity,
-                BotRequestContext.FromInboundActivity(turnContext.Activity?.FromBotFrameworkActivity()),
+                BotRequestContext.FromInboundActivity(inboundActivity.FromBotFrameworkActivity()),
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             logger?.SendActivitiesResponse(resp?.Id);

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsBotAdapter.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsBotAdapter.cs
@@ -84,6 +84,7 @@ public class TeamsBotAdapter(
         ArgumentNullException.ThrowIfNull(turnContext);
         Activity inboundActivity = turnContext.Activity
             ?? throw new InvalidOperationException("Turn context activity is required to send activities.");
+        BotRequestContext? requestContext = BotRequestContext.FromInboundActivity(inboundActivity.FromBotFrameworkActivity());
 
         ResourceResponse[] responses = new Microsoft.Bot.Schema.ResourceResponse[activities.Length];
 
@@ -115,7 +116,7 @@ public class TeamsBotAdapter(
                 ?? throw new InvalidOperationException("Conversation ID is required to send activities."));
             SendActivityResponse? resp = await botApplication.ConversationClient.SendActivityAsync(
                 coreActivity,
-                BotRequestContext.FromInboundActivity(inboundActivity.FromBotFrameworkActivity()),
+                requestContext,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             logger?.SendActivitiesResponse(resp?.Id);

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsBotAdapter.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsBotAdapter.cs
@@ -111,7 +111,10 @@ public class TeamsBotAdapter(
             coreActivity.Conversation ??= new Microsoft.Teams.Core.Schema.Conversation(
                 turnContext.Activity.Conversation?.Id
                 ?? throw new InvalidOperationException("Conversation ID is required to send activities."));
-            SendActivityResponse? resp = await botApplication.SendActivityAsync(coreActivity, cancellationToken: cancellationToken).ConfigureAwait(false);
+            SendActivityResponse? resp = await botApplication.ConversationClient.SendActivityAsync(
+                coreActivity,
+                BotRequestContext.FromInboundActivity(turnContext.Activity?.FromBotFrameworkActivity()),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
             logger?.SendActivitiesResponse(resp?.Id);
 

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsBotFrameworkHttpAdapter.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsBotFrameworkHttpAdapter.cs
@@ -65,12 +65,14 @@ public class TeamsBotFrameworkHttpAdapter : TeamsBotAdapter, IBotFrameworkHttpAd
         TurnContext? turnContext = null;
         _activityCallback.Value = async (activity, ct) =>
         {
+            BotRequestContext? requestContext = BotRequestContext.FromInboundActivity(activity);
             turnContext = new(this, activity.ToBotFrameworkActivity());
-            turnContext.TurnState.Add<Microsoft.Bot.Connector.Authentication.UserTokenClient>(new CompatUserTokenClient(_teamsBotApplication.UserTokenClient));
+            turnContext.TurnState.Add<Microsoft.Bot.Connector.Authentication.UserTokenClient>(
+                new CompatUserTokenClient(_teamsBotApplication.UserTokenClient) { RequestContext = requestContext });
             CompatConnectorClient connectionClient = new(new CompatConversations(_teamsBotApplication.ConversationClient)
             {
                 ServiceUrl = activity.ServiceUrl?.ToString(),
-                RequestContext = BotRequestContext.FromInboundActivity(activity)
+                RequestContext = requestContext
             });
             turnContext.TurnState.Add<Microsoft.Bot.Connector.IConnectorClient>(connectionClient);
             //turnContext.TurnState.Add<Microsoft.Teams.Apps.TeamsApiClient>(_teamsBotApplication.TeamsApiClient); // TODO: review TeamsInfo needs
@@ -127,8 +129,14 @@ public class TeamsBotFrameworkHttpAdapter : TeamsBotAdapter, IBotFrameworkHttpAd
         ArgumentNullException.ThrowIfNull(callback);
 
         using TurnContext turnContext = new(this, reference.GetContinuationActivity());
-        turnContext.TurnState.Add<Microsoft.Bot.Connector.Authentication.UserTokenClient>(new CompatUserTokenClient(_teamsBotApplication.UserTokenClient));
-        turnContext.TurnState.Add<Microsoft.Bot.Connector.IConnectorClient>(new CompatConnectorClient(new CompatConversations(_teamsBotApplication.ConversationClient) { ServiceUrl = reference.ServiceUrl, RequestContext = BotRequestContext.FromBotAppId(botId) }));
+        BotRequestContext? requestContext = BotRequestContext.FromBotAppId(botId);
+        turnContext.TurnState.Add<Microsoft.Bot.Connector.Authentication.UserTokenClient>(
+            new CompatUserTokenClient(_teamsBotApplication.UserTokenClient) { RequestContext = requestContext });
+        turnContext.TurnState.Add<Microsoft.Bot.Connector.IConnectorClient>(new CompatConnectorClient(new CompatConversations(_teamsBotApplication.ConversationClient)
+        {
+            ServiceUrl = reference.ServiceUrl,
+            RequestContext = requestContext
+        }));
         await RunPipelineAsync(turnContext, callback, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/UserTokenApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/UserTokenApiClient.cs
@@ -25,7 +25,7 @@ public class UserTokenApiClient
     /// </summary>
     public Task<GetTokenResult?> GetAsync(string userId, string connectionName, string channelId, string? code = null, CancellationToken cancellationToken = default)
     {
-        return _client.GetTokenAsync(userId, connectionName, channelId, code, cancellationToken);
+        return _client.GetTokenAsync(userId, connectionName, channelId, code, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -33,7 +33,7 @@ public class UserTokenApiClient
     /// </summary>
     public async Task<IDictionary<string, GetTokenResult>?> GetAadAsync(string userId, string connectionName, string channelId, IList<string>? resourceUrls = null, CancellationToken cancellationToken = default)
     {
-        return await _client.GetAadTokensAsync(userId, connectionName, channelId, resourceUrls?.ToArray(), cancellationToken).ConfigureAwait(false);
+        return await _client.GetAadTokensAsync(userId, connectionName, channelId, resourceUrls?.ToArray(), cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -41,7 +41,7 @@ public class UserTokenApiClient
     /// </summary>
     public async Task<IList<GetTokenStatusResult>?> GetStatusAsync(string userId, string channelId, string? includeFilter = null, CancellationToken cancellationToken = default)
     {
-        return await _client.GetTokenStatusAsync(userId, channelId, includeFilter, cancellationToken).ConfigureAwait(false);
+        return await _client.GetTokenStatusAsync(userId, channelId, includeFilter, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public class UserTokenApiClient
     /// </summary>
     public Task SignOutAsync(string userId, string connectionName, string channelId, CancellationToken cancellationToken = default)
     {
-        return _client.SignOutUserAsync(userId, connectionName, channelId, cancellationToken);
+        return _client.SignOutUserAsync(userId, connectionName, channelId, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -57,7 +57,7 @@ public class UserTokenApiClient
     /// </summary>
     public async Task<GetTokenResult?> ExchangeAsync(string userId, string connectionName, string channelId, string exchangeToken, CancellationToken cancellationToken = default)
     {
-        return await _client.ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, cancellationToken).ConfigureAwait(false);
+        return await _client.ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -65,7 +65,7 @@ public class UserTokenApiClient
     /// </summary>
     public Task<string?> GetSignInUrlAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
     {
-        return _client.GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, cancellationToken);
+        return _client.GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -73,6 +73,6 @@ public class UserTokenApiClient
     /// </summary>
     public Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
     {
-        return _client.GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, cancellationToken);
+        return _client.GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, cancellationToken: cancellationToken);
     }
 }

--- a/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
+++ b/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
@@ -264,7 +264,7 @@ public class OAuthFlow
         try
         {
             _logger.LogDebug("Signing out user '{UserId}' from connection '{ConnectionName}'.", userId, _connectionName);
-            await _app.UserTokenClient.SignOutUserAsync(userId, _connectionName, channelId, cancellationToken).ConfigureAwait(false);
+            await _app.UserTokenClient.SignOutUserAsync(userId, _connectionName, channelId, cancellationToken: cancellationToken).ConfigureAwait(false);
             result = AppsTelemetry.OAuthResults.Success;
             span?.SetTag(AppsTelemetry.Tags.OAuthResult, result);
         }
@@ -371,7 +371,7 @@ public class OAuthFlow
             try
             {
                 GetTokenResult tokenResult = await _app.UserTokenClient
-                    .ExchangeTokenAsync(userId, connectionName, channelId, exchangeValue.Token, cancellationToken)
+                    .ExchangeTokenAsync(userId, connectionName, channelId, exchangeValue.Token, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
 
                 if (tokenResult?.Token is not null)

--- a/core/src/Microsoft.Teams.Core/UserTokenClient.cs
+++ b/core/src/Microsoft.Teams.Core/UserTokenClient.cs
@@ -34,21 +34,10 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="userId">The user ID.</param>
     /// <param name="channelId">The channel ID.</param>
     /// <param name="include">The optional include parameter.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
-    public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include = null, CancellationToken cancellationToken = default)
-        => await GetTokenStatusAsync(userId, channelId, include, requestContext: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets the token status for each connection for the given user.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="include">The optional include parameter.</param>
     /// <param name="requestContext">Optional per-request properties used for authentication.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains an array of token status results for each connection.</returns>
-    public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
+    public virtual async Task<GetTokenStatusResult[]> GetTokenStatusAsync(string userId, string channelId, string? include = null, BotRequestContext? requestContext = null, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -84,22 +73,10 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="connectionName">The connection name.</param>
     /// <param name="channelId">The channel ID.</param>
     /// <param name="code">The optional code.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
-    public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code = null, CancellationToken cancellationToken = default)
-        => await GetTokenAsync(userId, connectionName, channelId, code, requestContext: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets the user token for a particular connection.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="connectionName">The connection name.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="code">The optional code.</param>
     /// <param name="requestContext">Optional per-request properties used for authentication.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains the token, or null if no token is available.</returns>
-    public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
+    public virtual async Task<GetTokenResult?> GetTokenAsync(string userId, string connectionName, string channelId, string? code = null, BotRequestContext? requestContext = null, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -131,23 +108,10 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="connectionName">The connection name.</param>
     /// <param name="channelId">The channel ID.</param>
     /// <param name="finalRedirect">The optional final redirect URL.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
-    public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect = null, CancellationToken cancellationToken = default)
-        => GetSignInResourceAsync(userId, connectionName, channelId, finalRedirect, requestContext: null, cancellationToken);
-
-    /// <summary>
-    /// Get the token or raw signin link to be sent to the user for signin for a connection.
-    /// Builds the state parameter internally from the userId and connectionName.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="connectionName">The connection name.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="finalRedirect">The optional final redirect URL.</param>
     /// <param name="requestContext">Optional per-request properties used for authentication.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains the sign-in resource with the sign-in link and token exchange information.</returns>
-    public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
+    public virtual Task<GetSignInResourceResult> GetSignInResourceAsync(string userId, string connectionName, string channelId, string? finalRedirect = null, BotRequestContext? requestContext = null, CancellationToken cancellationToken = default)
     {
         var tokenExchangeState = new
         {
@@ -171,22 +135,10 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
     /// <param name="emulatorUrl">The optional emulator URL.</param>
     /// <param name="finalRedirect">The optional final redirect URL.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The sign-in URL, or null if not available.</returns>
-    public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
-        => await GetSignInUrlAsync(state, codeChallenge, emulatorUrl, finalRedirect, requestContext: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets the sign-in URL for the given state.
-    /// </summary>
-    /// <param name="state">The encoded state parameter.</param>
-    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
-    /// <param name="emulatorUrl">The optional emulator URL.</param>
-    /// <param name="finalRedirect">The optional final redirect URL.</param>
     /// <param name="requestContext">Optional per-request properties used for authentication.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The sign-in URL, or null if not available.</returns>
-    public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
+    public virtual async Task<string?> GetSignInUrlAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, BotRequestContext? requestContext = null, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new() { { "state", state } };
 
@@ -214,22 +166,10 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
     /// <param name="emulatorUrl">The optional emulator URL.</param>
     /// <param name="finalRedirect">The optional final redirect URL.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The sign-in resource result.</returns>
-    public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, CancellationToken cancellationToken = default)
-        => await GetSignInResourceAsync(state, codeChallenge, emulatorUrl, finalRedirect, requestContext: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets the sign-in resource for the given state.
-    /// </summary>
-    /// <param name="state">The encoded state parameter.</param>
-    /// <param name="codeChallenge">The optional code challenge for PKCE.</param>
-    /// <param name="emulatorUrl">The optional emulator URL.</param>
-    /// <param name="finalRedirect">The optional final redirect URL.</param>
     /// <param name="requestContext">Optional per-request properties used for authentication.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The sign-in resource result.</returns>
-    public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge, Uri? emulatorUrl, Uri? finalRedirect, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
+    public virtual async Task<GetSignInResourceResult> GetSignInResourceAsync(string state, string? codeChallenge = null, Uri? emulatorUrl = null, Uri? finalRedirect = null, BotRequestContext? requestContext = null, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new() { { "state", state } };
 
@@ -257,20 +197,9 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="connectionName">The connection name.</param>
     /// <param name="channelId">The channel ID.</param>
     /// <param name="exchangeToken">The token to exchange.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, CancellationToken cancellationToken = default)
-        => await ExchangeTokenAsync(userId, connectionName, channelId, exchangeToken, requestContext: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Exchanges a token for another token.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="connectionName">The connection name.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="exchangeToken">The token to exchange.</param>
     /// <param name="requestContext">Optional per-request properties used for authentication.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
+    public virtual async Task<GetTokenResult> ExchangeTokenAsync(string userId, string connectionName, string channelId, string? exchangeToken, BotRequestContext? requestContext = null, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -300,21 +229,10 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="userId">The unique identifier of the user to sign out. Cannot be null or empty.</param>
     /// <param name="connectionName">Optional name of the OAuth connection to sign out from. If null, signs out from all connections.</param>
     /// <param name="channelId">Optional channel identifier. If provided, limits sign-out to tokens for this channel.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
-    /// <returns>A task that represents the asynchronous sign-out operation.</returns>
-    public virtual async Task SignOutUserAsync(string userId, string? connectionName = null, string? channelId = null, CancellationToken cancellationToken = default)
-        => await SignOutUserAsync(userId, connectionName, channelId, requestContext: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Signs the user out of a connection, revoking their OAuth token.
-    /// </summary>
-    /// <param name="userId">The unique identifier of the user to sign out. Cannot be null or empty.</param>
-    /// <param name="connectionName">Optional name of the OAuth connection to sign out from. If null, signs out from all connections.</param>
-    /// <param name="channelId">Optional channel identifier. If provided, limits sign-out to tokens for this channel.</param>
     /// <param name="requestContext">Optional per-request properties used for authentication.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
     /// <returns>A task that represents the asynchronous sign-out operation.</returns>
-    public virtual async Task SignOutUserAsync(string userId, string? connectionName, string? channelId, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
+    public virtual async Task SignOutUserAsync(string userId, string? connectionName = null, string? channelId = null, BotRequestContext? requestContext = null, CancellationToken cancellationToken = default)
     {
         Dictionary<string, string?> queryParams = new()
         {
@@ -348,22 +266,10 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
     /// <param name="connectionName">The connection name.</param>
     /// <param name="channelId">The channel ID.</param>
     /// <param name="resourceUrls">The resource URLs.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
-    public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls = null, CancellationToken cancellationToken = default)
-        => await GetAadTokensAsync(userId, connectionName, channelId, resourceUrls, requestContext: null, cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Gets AAD tokens for a user.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="connectionName">The connection name.</param>
-    /// <param name="channelId">The channel ID.</param>
-    /// <param name="resourceUrls">The resource URLs.</param>
     /// <param name="requestContext">Optional per-request properties used for authentication.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains a dictionary mapping resource URLs to their token results.</returns>
-    public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls, BotRequestContext? requestContext, CancellationToken cancellationToken = default)
+    public virtual async Task<IDictionary<string, GetTokenResult>> GetAadTokensAsync(string userId, string connectionName, string channelId, string[]? resourceUrls = null, BotRequestContext? requestContext = null, CancellationToken cancellationToken = default)
     {
         var body = new
         {

--- a/core/test/ABSTokenServiceClient/UserTokenCLIService.cs
+++ b/core/test/ABSTokenServiceClient/UserTokenCLIService.cs
@@ -31,23 +31,23 @@ namespace ABSTokenServiceClient
             try
             {
                 logger.LogInformation("=== Testing GetTokenStatus ===");
-                GetTokenStatusResult[] tokenStatus = await userTokenClient.GetTokenStatusAsync(userId, channelId, null, cancellationToken);
+                GetTokenStatusResult[] tokenStatus = await userTokenClient.GetTokenStatusAsync(userId, channelId, null, cancellationToken: cancellationToken);
                 logger.LogInformation("GetTokenStatus result: {Result}", JsonSerializer.Serialize(tokenStatus, new JsonSerializerOptions { WriteIndented = true }));
 
                 if (tokenStatus[0].HasToken == true)
                 {
-                    GetTokenResult? tokenResponse = await userTokenClient.GetTokenAsync(userId, connectionName, channelId, null, cancellationToken);
+                    GetTokenResult? tokenResponse = await userTokenClient.GetTokenAsync(userId, connectionName, channelId, null, cancellationToken: cancellationToken);
                     logger.LogInformation("GetToken result: {Result}", JsonSerializer.Serialize(tokenResponse, new JsonSerializerOptions { WriteIndented = true }));
                 }
                 else
                 {
-                    GetSignInResourceResult req = await userTokenClient.GetSignInResourceAsync(userId, connectionName, channelId, null, cancellationToken);
+                    GetSignInResourceResult req = await userTokenClient.GetSignInResourceAsync(userId, connectionName, channelId, null, cancellationToken: cancellationToken);
                     logger.LogInformation("GetSignInResource result: {Result}", JsonSerializer.Serialize(req, new JsonSerializerOptions { WriteIndented = true }));
 
                     Console.WriteLine("Code?");
                     string code = Console.ReadLine()!;
 
-                    GetTokenResult? tokenResponse2 = await userTokenClient.GetTokenAsync(userId, connectionName, channelId, code, cancellationToken);
+                    GetTokenResult? tokenResponse2 = await userTokenClient.GetTokenAsync(userId, connectionName, channelId, code, cancellationToken: cancellationToken);
                     logger.LogInformation("GetToken With Code result: {Result}", JsonSerializer.Serialize(tokenResponse2, new JsonSerializerOptions { WriteIndented = true }));
                 }
 
@@ -57,7 +57,7 @@ namespace ABSTokenServiceClient
                 {
                     try
                     {
-                        await userTokenClient.SignOutUserAsync(userId, connectionName, channelId, cancellationToken);
+                        await userTokenClient.SignOutUserAsync(userId, connectionName, channelId, cancellationToken: cancellationToken);
                         logger.LogInformation("SignOutUser completed successfully");
                     }
                     catch (Exception ex)

--- a/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatAdapterTests.cs
+++ b/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatAdapterTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Http;
 using Microsoft.Teams.Core.Schema;
 using Moq;
 
@@ -62,6 +63,51 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             Assert.NotNull(capturedConnectorClient);
             Assert.Equal("CompatConnectorClient", capturedConnectorClient.GetType().Name);
             Assert.IsAssignableFrom<Microsoft.Bot.Connector.IConnectorClient>(capturedConnectorClient);
+        }
+
+        [Fact]
+        public async Task ContinueConversationAsync_UserTokenClientUsesBotRequestContext()
+        {
+            // Arrange
+            Mock<UserTokenClient> mockUserTokenClient = CreateMockUserTokenClient();
+            TeamsBotFrameworkHttpAdapter compatAdapter = CreateCompatAdapter(mockUserTokenClient.Object);
+            ConversationReference conversationReference = new()
+            {
+                ServiceUrl = "https://smba.trafficmanager.net/teams",
+                ChannelId = "msteams",
+                Conversation = new Microsoft.Bot.Schema.ConversationAccount { Id = "test-conversation-id" }
+            };
+
+            mockUserTokenClient
+                .Setup(c => c.GetTokenStatusAsync(
+                    "user-id",
+                    "msteams",
+                    "include",
+                    It.Is<BotRequestContext?>(c => c != null && c.BotAppId == "test-bot-id"),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync([new GetTokenStatusResult { HasToken = true }]);
+
+            BotCallbackHandler callback = async (turnContext, cancellationToken) =>
+            {
+                Microsoft.Bot.Connector.Authentication.UserTokenClient userTokenClient =
+                    turnContext.TurnState.Get<Microsoft.Bot.Connector.Authentication.UserTokenClient>();
+
+                await userTokenClient.GetTokenStatusAsync(
+                    "user-id",
+                    "msteams",
+                    "include",
+                    cancellationToken).ConfigureAwait(false);
+            };
+
+            // Act
+            await compatAdapter.ContinueConversationAsync(
+                "test-bot-id",
+                conversationReference,
+                callback,
+                CancellationToken.None);
+
+            // Assert
+            mockUserTokenClient.VerifyAll();
         }
 
         [Fact]
@@ -122,19 +168,14 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             Assert.Equal("customTurnStateValue", capturedCustomTurnState);
         }
 
-        private static TeamsBotFrameworkHttpAdapter CreateCompatAdapter()
+        private static TeamsBotFrameworkHttpAdapter CreateCompatAdapter(UserTokenClient? userTokenClient = null)
         {
             HttpClient httpClient = new();
             ConversationClient conversationClient = new(httpClient, NullLogger<ConversationClient>.Instance);
 
-            Mock<IConfiguration> mockConfig = new();
-            mockConfig.Setup(c => c["UserTokenApiEndpoint"]).Returns("https://token.botframework.com");
-
-            UserTokenClient userTokenClient = new(httpClient, mockConfig.Object, NullLogger<UserTokenClient>.Instance);
-
             BotApplication botApplication = new(
                 conversationClient,
-                userTokenClient,
+                userTokenClient ?? CreateMockUserTokenClient().Object,
                 NullLogger<BotApplication>.Instance);
 
             TeamsBotFrameworkHttpAdapter compatAdapter = new(
@@ -143,6 +184,17 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
                 NullLogger<TeamsBotFrameworkHttpAdapter>.Instance);
 
             return compatAdapter;
+        }
+
+        private static Mock<UserTokenClient> CreateMockUserTokenClient()
+        {
+            Mock<IConfiguration> mockConfig = new();
+            mockConfig.Setup(c => c["UserTokenApiEndpoint"]).Returns("https://token.botframework.com");
+
+            return new Mock<UserTokenClient>(
+                new HttpClient(),
+                mockConfig.Object,
+                NullLogger<UserTokenClient>.Instance);
         }
     }
 }

--- a/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatBotAdapterTests.cs
+++ b/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatBotAdapterTests.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             mockConversationClient.Verify(
                 c => c.SendActivityAsync(
                     It.Is<CoreActivity>(a => a.ServiceUrl != null && a.ServiceUrl.ToString().TrimEnd('/') == "https://turn-context-service-url.com"),
-                    It.IsAny<BotRequestContext?>(),
+                    It.Is<BotRequestContext?>(c => c != null && c.BotAppId == "bot-123"),
                     It.IsAny<Dictionary<string, string>?>(),
                     It.IsAny<CancellationToken>()),
                 Times.Once);

--- a/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatConversationsTests.cs
+++ b/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatConversationsTests.cs
@@ -206,6 +206,44 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
         }
 
         [Fact]
+        public async Task UpdateActivityWithHttpMessagesAsync_PassesRequestContext()
+        {
+            // Arrange
+            Mock<ConversationClient> mockConversationClient = CreateMockConversationClient();
+            BotRequestContext requestContext = new() { BotAppId = "bot-app-id" };
+            CompatConversations compatConversations = new(mockConversationClient.Object)
+            {
+                ServiceUrl = TestServiceUrl,
+                RequestContext = requestContext
+            };
+
+            Activity activity = new()
+            {
+                Type = ActivityTypes.Message,
+                Id = TestActivityId,
+                Text = "Updated message",
+                Conversation = new Microsoft.Bot.Schema.ConversationAccount { Id = TestConversationId }
+            };
+
+            mockConversationClient
+                .Setup(c => c.UpdateActivityAsync(
+                    TestConversationId,
+                    TestActivityId,
+                    It.IsAny<CoreActivity>(),
+                    It.IsAny<bool>(),
+                    It.Is<BotRequestContext?>(c => ReferenceEquals(c, requestContext)),
+                    It.IsAny<Dictionary<string, string>?>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new UpdateActivityResponse { Id = TestActivityId });
+
+            // Act
+            await compatConversations.UpdateActivityWithHttpMessagesAsync(TestConversationId, TestActivityId, activity);
+
+            // Assert
+            mockConversationClient.VerifyAll();
+        }
+
+        [Fact]
         public async Task UpdateActivityWithHttpMessagesAsync_DoesNotOverrideServiceUrl_WhenActivityServiceUrlIsSet()
         {
             // Arrange

--- a/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatUserTokenClientTests.cs
+++ b/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatUserTokenClientTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Http;
+using Moq;
+
+namespace Microsoft.Teams.Apps.BotBuilder.UnitTests;
+
+public class CompatUserTokenClientTests
+{
+    [Fact]
+    public async Task DelegatedMethods_PassRequestContextToCoreClient()
+    {
+        BotRequestContext requestContext = new() { BotAppId = "bot-app-id" };
+        Mock<UserTokenClient> coreUserTokenClient = CreateMockUserTokenClient();
+        CompatUserTokenClient compatUserTokenClient = new(coreUserTokenClient.Object) { RequestContext = requestContext };
+        string[] resourceUrls = ["https://graph.microsoft.com"];
+
+        coreUserTokenClient
+            .Setup(c => c.GetTokenStatusAsync(
+                "user-id",
+                "msteams",
+                "include",
+                It.Is<BotRequestContext?>(c => ReferenceEquals(c, requestContext)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new GetTokenStatusResult { ConnectionName = "connection", HasToken = true }]);
+        coreUserTokenClient
+            .Setup(c => c.GetTokenAsync(
+                "user-id",
+                "connection",
+                "msteams",
+                "magic-code",
+                It.Is<BotRequestContext?>(c => ReferenceEquals(c, requestContext)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetTokenResult { ConnectionName = "connection", Token = "token" });
+        coreUserTokenClient
+            .Setup(c => c.GetSignInResourceAsync(
+                "user-id",
+                "connection",
+                "msteams",
+                "https://redirect.example.com",
+                It.Is<BotRequestContext?>(c => ReferenceEquals(c, requestContext)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetSignInResourceResult { SignInLink = "https://signin.example.com" });
+        coreUserTokenClient
+            .Setup(c => c.ExchangeTokenAsync(
+                "user-id",
+                "connection",
+                "msteams",
+                "exchange-token",
+                It.Is<BotRequestContext?>(c => ReferenceEquals(c, requestContext)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetTokenResult { ConnectionName = "connection", Token = "exchanged-token" });
+        coreUserTokenClient
+            .Setup(c => c.SignOutUserAsync(
+                "user-id",
+                "connection",
+                "msteams",
+                It.Is<BotRequestContext?>(c => ReferenceEquals(c, requestContext)),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        coreUserTokenClient
+            .Setup(c => c.GetAadTokensAsync(
+                "user-id",
+                "connection",
+                "msteams",
+                resourceUrls,
+                It.Is<BotRequestContext?>(c => ReferenceEquals(c, requestContext)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, GetTokenResult>
+            {
+                ["https://graph.microsoft.com"] = new() { ConnectionName = "connection", Token = "aad-token" }
+            });
+
+        await compatUserTokenClient.GetTokenStatusAsync("user-id", "msteams", "include", CancellationToken.None);
+        await compatUserTokenClient.GetUserTokenAsync("user-id", "connection", "msteams", "magic-code", CancellationToken.None);
+        await compatUserTokenClient.GetSignInResourceAsync(
+            "connection",
+            new Activity
+            {
+                From = new ChannelAccount { Id = "user-id" },
+                ChannelId = "msteams"
+            },
+            "https://redirect.example.com",
+            CancellationToken.None);
+        await compatUserTokenClient.ExchangeTokenAsync(
+            "user-id",
+            "connection",
+            "msteams",
+            new TokenExchangeRequest { Token = "exchange-token" },
+            CancellationToken.None);
+        await compatUserTokenClient.SignOutUserAsync("user-id", "connection", "msteams", CancellationToken.None);
+        await compatUserTokenClient.GetAadTokensAsync("user-id", "connection", resourceUrls, "msteams", CancellationToken.None);
+
+        coreUserTokenClient.VerifyAll();
+    }
+
+    private static Mock<UserTokenClient> CreateMockUserTokenClient()
+    {
+        Mock<IConfiguration> configuration = new();
+        configuration.Setup(c => c["UserTokenApiEndpoint"]).Returns("https://token.botframework.com");
+        return new Mock<UserTokenClient>(
+            new HttpClient(),
+            configuration.Object,
+            NullLogger<UserTokenClient>.Instance);
+    }
+}

--- a/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/TeamsApiClientTests.cs
+++ b/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/TeamsApiClientTests.cs
@@ -14,15 +14,17 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests;
 public class TeamsApiClientTests
 {
     [Fact]
-    public async Task GetMembersAsync_PassesInboundRequestContext()
+    public async Task GetPagedMembersAsync_PassesInboundRequestContext()
     {
         Mock<ConversationClient> mockConversationClient = new(
             new HttpClient(),
             NullLogger<ConversationClient>.Instance);
         mockConversationClient
-            .Setup(c => c.GetConversationMembersAsync(
+            .Setup(c => c.GetConversationPagedMembersAsync(
                 "conversation-id",
                 It.Is<Uri>(u => u.ToString().TrimEnd('/') == "https://smba.trafficmanager.net/teams"),
+                null,
+                null,
                 It.Is<BotRequestContext?>(c =>
                     c != null
                     && c.BotAppId == "recipient-bot-id"
@@ -31,18 +33,22 @@ public class TeamsApiClientTests
                     && c.AgenticIdentity.AgenticUserId == "agentic-user-id"),
                 null,
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
-                new Microsoft.Teams.Core.Schema.ChannelAccount
+            .ReturnsAsync(new Microsoft.Teams.Core.PagedMembersResult
+            {
+                Members = new List<Microsoft.Teams.Core.Schema.ChannelAccount>
                 {
-                    Id = "member-id",
-                    Name = "Member"
+                    new Microsoft.Teams.Core.Schema.ChannelAccount
+                    {
+                        Id = "member-id",
+                        Name = "Member"
+                    }
                 }
-            ]);
+            });
 
         Activity activity = new()
         {
             Type = ActivityTypes.Message,
-            ChannelId = Channels.Msteams,
+            ChannelId = "msteams",
             ServiceUrl = "https://smba.trafficmanager.net/teams/",
             Conversation = new Microsoft.Bot.Schema.ConversationAccount { Id = "conversation-id" },
             Recipient = new Microsoft.Bot.Schema.ChannelAccount
@@ -63,10 +69,10 @@ public class TeamsApiClientTests
             [typeof(Microsoft.Bot.Connector.IConnectorClient).FullName!] = new CompatConnectorClient(new CompatConversations(mockConversationClient.Object))
         });
 
-        IEnumerable<Microsoft.Bot.Schema.Teams.TeamsChannelAccount> members =
-            await TeamsApiClient.GetMembersAsync(turnContext.Object, CancellationToken.None);
+        Microsoft.Bot.Schema.Teams.TeamsPagedMembersResult pagedMembers =
+            await TeamsApiClient.GetPagedMembersAsync(turnContext.Object, cancellationToken: CancellationToken.None);
 
-        Assert.Single(members);
+        Assert.Single(pagedMembers.Members);
         mockConversationClient.VerifyAll();
     }
 }

--- a/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/TeamsApiClientTests.cs
+++ b/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/TeamsApiClientTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Http;
+using Microsoft.Teams.Core.Schema;
+using Moq;
+
+namespace Microsoft.Teams.Apps.BotBuilder.UnitTests;
+
+public class TeamsApiClientTests
+{
+    [Fact]
+    public async Task GetMembersAsync_PassesInboundRequestContext()
+    {
+        Mock<ConversationClient> mockConversationClient = new(
+            new HttpClient(),
+            NullLogger<ConversationClient>.Instance);
+        mockConversationClient
+            .Setup(c => c.GetConversationMembersAsync(
+                "conversation-id",
+                It.Is<Uri>(u => u.ToString().TrimEnd('/') == "https://smba.trafficmanager.net/teams"),
+                It.Is<BotRequestContext?>(c =>
+                    c != null
+                    && c.BotAppId == "recipient-bot-id"
+                    && c.AgenticIdentity != null
+                    && c.AgenticIdentity.AgenticAppId == "agentic-app-id"
+                    && c.AgenticIdentity.AgenticUserId == "agentic-user-id"),
+                null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new Microsoft.Teams.Core.Schema.ChannelAccount
+                {
+                    Id = "member-id",
+                    Name = "Member"
+                }
+            ]);
+
+        Activity activity = new()
+        {
+            Type = ActivityTypes.Message,
+            ChannelId = Channels.Msteams,
+            ServiceUrl = "https://smba.trafficmanager.net/teams/",
+            Conversation = new Microsoft.Bot.Schema.ConversationAccount { Id = "conversation-id" },
+            Recipient = new Microsoft.Bot.Schema.ChannelAccount
+            {
+                Id = "28:recipient-account-id",
+                Properties =
+                {
+                    ["botId"] = "28:recipient-bot-id",
+                    ["agenticAppId"] = "agentic-app-id",
+                    ["agenticUserId"] = "agentic-user-id"
+                }
+            }
+        };
+        Mock<ITurnContext> turnContext = new();
+        turnContext.SetupGet(t => t.Activity).Returns(activity);
+        turnContext.SetupGet(t => t.TurnState).Returns(new TurnContextStateCollection
+        {
+            [typeof(Microsoft.Bot.Connector.IConnectorClient).FullName!] = new CompatConnectorClient(new CompatConversations(mockConversationClient.Object))
+        });
+
+        IEnumerable<Microsoft.Bot.Schema.Teams.TeamsChannelAccount> members =
+            await TeamsApiClient.GetMembersAsync(turnContext.Object, CancellationToken.None);
+
+        Assert.Single(members);
+        mockConversationClient.VerifyAll();
+    }
+}

--- a/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTelemetryTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTelemetryTests.cs
@@ -38,7 +38,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "tok", ConnectionName = GraphConnection });
 
         Context<MessageActivity> ctx = CreateMessageContext(harness);
@@ -64,7 +64,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GetTokenResult?)null);
 
         Context<MessageActivity> ctx = CreateMessageContext(harness);
@@ -87,7 +87,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "cached", ConnectionName = GraphConnection });
 
         Context<MessageActivity> ctx = CreateMessageContext(harness);
@@ -135,7 +135,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.SignOutUserAsync(TestUserId, GraphConnection, TestChannelId, It.IsAny<CancellationToken>()))
+            .Setup(c => c.SignOutUserAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         Context<MessageActivity> ctx = CreateMessageContext(harness);
@@ -157,7 +157,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenStatusAsync(TestUserId, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenStatusAsync(TestUserId, TestChannelId, null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { new GetTokenStatusResult { ConnectionName = GraphConnection, HasToken = true } });
 
         Context<MessageActivity> ctx = CreateMessageContext(harness);
@@ -184,7 +184,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "access", ConnectionName = GraphConnection });
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-success", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -208,7 +208,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "access", ConnectionName = GraphConnection });
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-dup", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -237,7 +237,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", null, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Bad request", null, System.Net.HttpStatusCode.BadRequest));
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-bad", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -261,7 +261,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", null, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Forbidden", null, System.Net.HttpStatusCode.Forbidden));
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-forbidden", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -310,7 +310,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", null, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GetTokenResult?)null);
 
         Context<InvokeActivity> ctx = CreateInvokeContext(harness);
@@ -333,7 +333,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", null, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Bad request", null, System.Net.HttpStatusCode.BadRequest));
 
         Context<InvokeActivity> ctx = CreateInvokeContext(harness);
@@ -357,7 +357,7 @@ public class OAuthFlowTelemetryTests
         TestHarness harness = CreateHarness();
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", null, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Forbidden", null, System.Net.HttpStatusCode.Forbidden));
 
         Context<InvokeActivity> ctx = CreateInvokeContext(harness);
@@ -474,13 +474,13 @@ public class OAuthFlowTelemetryTests
 
     private static void SetupSilentTokenReturnsNull(Mock<UserTokenClient> mock)
     {
-        mock.Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+        mock.Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GetTokenResult?)null);
     }
 
     private static void SetupGetSignInResource(Mock<UserTokenClient> mock)
     {
-        mock.Setup(c => c.GetSignInResourceAsync(It.IsAny<string>(), null, (Uri?)null, (Uri?)null, It.IsAny<CancellationToken>()))
+        mock.Setup(c => c.GetSignInResourceAsync(It.IsAny<string>(), null, (Uri?)null, (Uri?)null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetSignInResourceResult
             {
                 SignInLink = "https://login.microsoftonline.com/test",

--- a/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTests.cs
@@ -143,7 +143,7 @@ public class OAuthFlowTests
 
         // Arrange exchange
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "access-token", ConnectionName = GraphConnection });
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "exchange-1", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -173,7 +173,7 @@ public class OAuthFlowTests
 
         // Arrange exchange failure
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "bad-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "bad-token", null, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Unauthorized", null, System.Net.HttpStatusCode.Unauthorized));
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "exchange-2", ConnectionName = GraphConnection, Token = "bad-token" };
@@ -203,7 +203,7 @@ public class OAuthFlowTests
 
         // Arrange verify state
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "123456", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "123456", null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "access-token", ConnectionName = GraphConnection });
 
         SignInVerifyStateValue verifyValue = new() { State = "123456" };
@@ -243,7 +243,7 @@ public class OAuthFlowTests
         TestHarness harness = CreateHarness(GraphConnection);
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", null, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Not found", null, System.Net.HttpStatusCode.NotFound));
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-1", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -261,7 +261,7 @@ public class OAuthFlowTests
         TestHarness harness = CreateHarness(GraphConnection);
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", null, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Forbidden", null, System.Net.HttpStatusCode.Forbidden));
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-2", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -280,7 +280,7 @@ public class OAuthFlowTests
         TestHarness harness = CreateHarness(GraphConnection);
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "access-token", ConnectionName = GraphConnection });
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "dup-1", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -296,7 +296,7 @@ public class OAuthFlowTests
 
         // ExchangeTokenAsync only called once
         harness.MockUserTokenClient.Verify(
-            c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()),
+            c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", null, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -323,7 +323,7 @@ public class OAuthFlowTests
         harness.GraphFlow!.OnSignInFailure((_, _, _) => { failureFired = true; return Task.CompletedTask; });
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "badcode", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "badcode", null, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GetTokenResult?)null);
 
         SignInVerifyStateValue verifyValue = new() { State = "badcode" };
@@ -342,7 +342,7 @@ public class OAuthFlowTests
         TestHarness harness = CreateHarness(GraphConnection);
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", null, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Bad request", null, System.Net.HttpStatusCode.BadRequest));
 
         SignInVerifyStateValue verifyValue = new() { State = "code" };
@@ -359,7 +359,7 @@ public class OAuthFlowTests
         TestHarness harness = CreateHarness(GraphConnection);
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, "code", null, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Forbidden", null, System.Net.HttpStatusCode.Forbidden));
 
         SignInVerifyStateValue verifyValue = new() { State = "code" };
@@ -405,7 +405,7 @@ public class OAuthFlowTests
         });
 
         harness.MockUserTokenClient
-            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", It.IsAny<CancellationToken>()))
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", null, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Bad request", null, System.Net.HttpStatusCode.BadRequest));
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-fail", ConnectionName = GraphConnection, Token = "sso-token" };
@@ -425,7 +425,7 @@ public class OAuthFlowTests
         TestHarness harness = CreateHarness(GraphConnection);
 
         harness.MockUserTokenClient
-            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetTokenAsync(TestUserId, GraphConnection, TestChannelId, null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetTokenResult { Token = "cached-token", ConnectionName = GraphConnection });
 
         Context<MessageActivity> ctx = CreateMessageContext(harness, TestUserId);
@@ -537,13 +537,13 @@ public class OAuthFlowTests
 
     private static void SetupSilentTokenReturnsNull(Mock<UserTokenClient> mock, string connectionName)
     {
-        mock.Setup(c => c.GetTokenAsync(TestUserId, connectionName, TestChannelId, null, It.IsAny<CancellationToken>()))
+        mock.Setup(c => c.GetTokenAsync(TestUserId, connectionName, TestChannelId, null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GetTokenResult?)null);
     }
 
     private static void SetupGetSignInResource(Mock<UserTokenClient> mock)
     {
-        mock.Setup(c => c.GetSignInResourceAsync(It.IsAny<string>(), null, (Uri?)null, (Uri?)null, It.IsAny<CancellationToken>()))
+        mock.Setup(c => c.GetSignInResourceAsync(It.IsAny<string>(), null, (Uri?)null, (Uri?)null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetSignInResourceResult
             {
                 SignInLink = "https://login.microsoftonline.com/test",


### PR DESCRIPTION
## Summary
- Pass `BotRequestContext` through `CompatUserTokenClient` to all core user token calls.
- Set shared request context for reactive and proactive BotBuilder compat turns.
- Pass request context through remaining compat conversation/update and adapter send paths.
- Add unit coverage for user token, conversation, and adapter request-context plumbing.

## Validation
- `dotnet test core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/Microsoft.Teams.Apps.BotBuilder.UnitTests.csproj --no-restore`