### PR TITLE
Flatten api clients

### DIFF
--- a/core/samples/TargetedMessages/Program.cs
+++ b/core/samples/TargetedMessages/Program.cs
@@ -56,7 +56,7 @@ teamsApp.OnMessage("(?i)^test update$", async (context, cancellationToken) =>
         try
         {
             MessageActivityInput updated = MessageActivityInput.CreateBuilder().WithText($"✏️ Updated at {DateTime.UtcNow:HH:mm:ss}").Build();
-            await context.Api.Conversations.Activities.UpdateTargetedAsync(conversationId, messageId, updated, cancellationToken: cancellationToken);
+            await context.Api.Conversations.UpdateTargetedActivityAsync(conversationId, messageId, updated, cancellationToken: cancellationToken);
         }
         catch (Exception ex)
         {
@@ -85,7 +85,7 @@ teamsApp.OnMessage("(?i)^test delete$", async (context, cancellationToken) =>
         await Task.Delay(3000);
         try
         {
-            await context.Api.Conversations.Activities.DeleteTargetedAsync(conversationId, messageId, cancellationToken: cancellationToken);
+            await context.Api.Conversations.DeleteTargetedActivityAsync(conversationId, messageId, cancellationToken: cancellationToken);
         }
         catch (Exception ex)
         {

--- a/core/samples/TargetedMessages/README.md
+++ b/core/samples/TargetedMessages/README.md
@@ -24,8 +24,8 @@ Slash commands arrive at the bot as regular `MessageActivity` events with `Activ
 |---------|----------|
 | `test send` | Send a targeted message via `Context.SendActivityAsync` with `WithRecipient(account, isTargeted: true)` |
 | `test reply` | Reply with a targeted message via `Context.Reply` |
-| `test update` | Send a targeted message, then update it after 3 seconds via `Api.Conversations.Activities.UpdateTargetedAsync` |
-| `test delete` | Send a targeted message, then delete it after 3 seconds via `Api.Conversations.Activities.DeleteTargetedAsync` |
+| `test update` | Send a targeted message, then update it after 3 seconds via `Api.Conversations.UpdateTargetedActivityAsync` |
+| `test delete` | Send a targeted message, then delete it after 3 seconds via `Api.Conversations.DeleteTargetedActivityAsync` |
 | `test inbound` | Read `Context.Activity.Recipient?.IsTargeted` and report whether the inbound message was targeted at the bot |
 | `help` | List available commands |
 

--- a/core/samples/TeamsBot/Program.cs
+++ b/core/samples/TeamsBot/Program.cs
@@ -173,7 +173,7 @@ teamsApp.OnMessage("(?i)targeted", async (context, cancellationToken) =>
         .WithText("This targeted message was updated!")
         .Build();
 
-    await context.Api.Conversations.Activities.UpdateTargetedAsync(
+    await context.Api.Conversations.UpdateTargetedActivityAsync(
         context.Activity.Conversation.Id!,
         sendResponse!.Id!,
         updated,
@@ -182,7 +182,7 @@ teamsApp.OnMessage("(?i)targeted", async (context, cancellationToken) =>
     await Task.Delay(2000, cancellationToken);
 
     // Delete the targeted message
-    await context.Api.Conversations.Activities.DeleteTargetedAsync(
+    await context.Api.Conversations.DeleteTargetedActivityAsync(
         context.Activity.Conversation.Id!,
         sendResponse.Id!,
         cancellationToken: cancellationToken);
@@ -205,7 +205,7 @@ teamsApp.OnMessage("(?i)^react$", async (context, cancellationToken) =>
     await Task.Delay(2000, cancellationToken);
 
     // Add a waving hand reaction
-    await context.Api.Conversations.Reactions.AddAsync(
+    await context.Api.Conversations.AddReactionAsync(
         context.Activity.Conversation.Id,
         response!.Id!,
         "1f44b_wavinghand-tone4",
@@ -214,7 +214,7 @@ teamsApp.OnMessage("(?i)^react$", async (context, cancellationToken) =>
     await Task.Delay(2000, cancellationToken);
 
     // Add a beaming face reaction
-    await context.Api.Conversations.Reactions.AddAsync(
+    await context.Api.Conversations.AddReactionAsync(
         context?.Activity?.Conversation?.Id!,
         response.Id!,
         "1f601_beamingfacewithsmilingeyes",
@@ -223,7 +223,7 @@ teamsApp.OnMessage("(?i)^react$", async (context, cancellationToken) =>
     await Task.Delay(2000, cancellationToken);
     ArgumentNullException.ThrowIfNull(context);
     // Remove the beaming face reaction
-    await context.Api.Conversations.Reactions.DeleteAsync(
+    await context.Api.Conversations.DeleteReactionAsync(
         context?.Activity?.Conversation?.Id!,
         response.Id!,
         "1f601_beamingfacewithsmilingeyes",

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ActivityClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ActivityClient.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Teams.Apps.Api.Clients;
 /// Client for creating, updating, and deleting activities in a conversation.
 /// Delegates to the core <see cref="CoreConversationClient"/>.
 /// </summary>
+[Obsolete("Use the activity methods on ConversationApiClient directly instead.")]
 public class ActivityClient
 {
     private const string ObsoleteInboundMessage =

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs
@@ -8,7 +8,6 @@ using Microsoft.Teams.Core;
 using Microsoft.Teams.Core.Http;
 using Microsoft.Teams.Core.Schema;
 
-using CoreActivityInput = Microsoft.Teams.Core.Schema.CoreActivityInput;
 using CoreConversationClient = Microsoft.Teams.Core.ConversationClient;
 
 namespace Microsoft.Teams.Apps.Api.Clients;
@@ -65,19 +64,13 @@ public class ConversationApiClient
 
     #region Activity Methods
 
-    private Task<SendActivityResponse?> SendCoreAsync(string conversationId, CoreActivityInput activity, bool isTargeted, Dictionary<string, string>? additionalHeaders, CancellationToken cancellationToken)
-        => _client.SendActivityAsync(conversationId, activity, _serviceUrl, isTargeted: isTargeted, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
-
-    private Task<UpdateActivityResponse> UpdateCoreAsync(string conversationId, string id, CoreActivityInput activity, bool isTargeted, Dictionary<string, string>? additionalHeaders, CancellationToken cancellationToken)
-        => _client.UpdateActivityAsync(conversationId, id, activity, _serviceUrl, isTargeted, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
-
     /// <summary>
     /// Create a new activity in a conversation.
     /// </summary>
     public Task<SendActivityResponse?> CreateActivityAsync(string conversationId, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        return SendCoreAsync(conversationId, activity, isTargeted: false, additionalHeaders, cancellationToken);
+        return _client.SendActivityAsync(conversationId, activity, _serviceUrl, isTargeted: false, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -86,7 +79,7 @@ public class ConversationApiClient
     public Task<UpdateActivityResponse> UpdateActivityAsync(string conversationId, string id, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        return UpdateCoreAsync(conversationId, id, activity, isTargeted: false, additionalHeaders, cancellationToken);
+        return _client.UpdateActivityAsync(conversationId, id, activity, _serviceUrl, isTargeted: false, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -96,7 +89,7 @@ public class ConversationApiClient
     {
         ArgumentNullException.ThrowIfNull(activity);
         activity.ReplyToId = id;
-        return SendCoreAsync(conversationId, activity, isTargeted: false, additionalHeaders, cancellationToken);
+        return _client.SendActivityAsync(conversationId, activity, _serviceUrl, isTargeted: false, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -115,7 +108,7 @@ public class ConversationApiClient
     public Task<SendActivityResponse?> CreateTargetedActivityAsync(string conversationId, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        return SendCoreAsync(conversationId, activity, isTargeted: true, additionalHeaders, cancellationToken);
+        return _client.SendActivityAsync(conversationId, activity, _serviceUrl, isTargeted: true, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -125,7 +118,7 @@ public class ConversationApiClient
     public Task<UpdateActivityResponse> UpdateTargetedActivityAsync(string conversationId, string id, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        return UpdateCoreAsync(conversationId, id, activity, isTargeted: true, additionalHeaders, cancellationToken);
+        return _client.UpdateActivityAsync(conversationId, id, activity, _serviceUrl, isTargeted: true, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs
@@ -1,20 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Core;
 using Microsoft.Teams.Core.Http;
 using Microsoft.Teams.Core.Schema;
 
+using CoreActivityInput = Microsoft.Teams.Core.Schema.CoreActivityInput;
 using CoreConversationClient = Microsoft.Teams.Core.ConversationClient;
 
 namespace Microsoft.Teams.Apps.Api.Clients;
 
 /// <summary>
-/// Client for managing conversations, exposing sub-clients for activities, members, and reactions.
+/// Client for managing conversations, including activities, members, and reactions.
 /// Delegates to the core <see cref="CoreConversationClient"/>.
 /// </summary>
 public class ConversationApiClient
 {
+    private const string ObsoleteInboundMessage =
+        "Sending an inbound TeamsActivity (read-model) is obsolete. Use the overload that accepts a TeamsActivityInput built via MessageActivityInput.CreateBuilder().";
+
     private readonly CoreConversationClient _client;
     private readonly Uri _serviceUrl;
     private readonly AgenticIdentity? _agenticIdentity;
@@ -22,16 +29,19 @@ public class ConversationApiClient
     /// <summary>
     /// Client for activity operations.
     /// </summary>
+    [Obsolete("Use the activity methods on ConversationApiClient directly instead.")]
     public ActivityClient Activities { get; }
 
     /// <summary>
     /// Client for member operations.
     /// </summary>
+    [Obsolete("Use the member methods on ConversationApiClient directly instead.")]
     public MemberClient Members { get; }
 
     /// <summary>
     /// Client for reaction operations.
     /// </summary>
+    [Obsolete("Use ConversationApiClient.AddReactionAsync and ConversationApiClient.DeleteReactionAsync instead.")]
     public ReactionClient Reactions { get; }
 
     internal ConversationApiClient(Uri serviceUrl, CoreConversationClient client, AgenticIdentity? agenticIdentity = null)
@@ -39,10 +49,14 @@ public class ConversationApiClient
         _serviceUrl = serviceUrl;
         _client = client;
         _agenticIdentity = agenticIdentity;
+#pragma warning disable CS0618 // Suppress obsolete warnings for backward-compatible initialization
         Activities = new ActivityClient(serviceUrl, client, agenticIdentity);
         Members = new MemberClient(serviceUrl, client, agenticIdentity);
         Reactions = new ReactionClient(serviceUrl, client, agenticIdentity);
+#pragma warning restore CS0618
     }
+
+    private BotRequestContext? AgenticContext => BotRequestContext.FromAgenticIdentity(_agenticIdentity);
 
     /// <summary>
     /// Create a new conversation.
@@ -52,5 +66,238 @@ public class ConversationApiClient
         return _client.CreateConversationAsync(request, _serviceUrl, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
-    private BotRequestContext? AgenticContext => BotRequestContext.FromAgenticIdentity(_agenticIdentity);
+    #region Activity Methods
+
+    private Task<SendActivityResponse?> SendCoreAsync(string conversationId, CoreActivityInput activity, bool isTargeted, Dictionary<string, string>? additionalHeaders, CancellationToken cancellationToken)
+        => _client.SendActivityAsync(conversationId, activity, _serviceUrl, isTargeted: isTargeted, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+
+    private Task<UpdateActivityResponse> UpdateCoreAsync(string conversationId, string id, CoreActivityInput activity, bool isTargeted, Dictionary<string, string>? additionalHeaders, CancellationToken cancellationToken)
+        => _client.UpdateActivityAsync(conversationId, id, activity, _serviceUrl, isTargeted, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+
+    /// <summary>
+    /// Create a new activity in a conversation.
+    /// </summary>
+    public Task<SendActivityResponse?> CreateActivityAsync(string conversationId, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        return SendCoreAsync(conversationId, activity, isTargeted: false, additionalHeaders, cancellationToken);
+    }
+
+    /// <summary>
+    /// Create a new activity in a conversation.
+    /// </summary>
+    [Obsolete(ObsoleteInboundMessage)]
+    public Task<SendActivityResponse?> CreateActivityAsync(string conversationId, TeamsActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        return SendCoreAsync(conversationId, CoreActivityInput.FromActivity(activity), isTargeted: false, additionalHeaders, cancellationToken);
+    }
+
+    /// <summary>
+    /// Update an existing activity in a conversation.
+    /// </summary>
+    public Task<UpdateActivityResponse> UpdateActivityAsync(string conversationId, string id, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        return UpdateCoreAsync(conversationId, id, activity, isTargeted: false, additionalHeaders, cancellationToken);
+    }
+
+    /// <summary>
+    /// Update an existing activity in a conversation.
+    /// </summary>
+    [Obsolete(ObsoleteInboundMessage)]
+    public Task<UpdateActivityResponse> UpdateActivityAsync(string conversationId, string id, TeamsActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        return UpdateCoreAsync(conversationId, id, CoreActivityInput.FromActivity(activity), isTargeted: false, additionalHeaders, cancellationToken);
+    }
+
+    /// <summary>
+    /// Reply to an existing activity in a conversation.
+    /// </summary>
+    public Task<SendActivityResponse?> ReplyToActivityAsync(string conversationId, string id, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        activity.ReplyToId = id;
+        return SendCoreAsync(conversationId, activity, isTargeted: false, additionalHeaders, cancellationToken);
+    }
+
+    /// <summary>
+    /// Reply to an existing activity in a conversation.
+    /// </summary>
+    [Obsolete(ObsoleteInboundMessage)]
+    public Task<SendActivityResponse?> ReplyToActivityAsync(string conversationId, string id, TeamsActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        CoreActivityInput input = CoreActivityInput.FromActivity(activity);
+        input.ReplyToId = id;
+        return SendCoreAsync(conversationId, input, isTargeted: false, additionalHeaders, cancellationToken);
+    }
+
+    /// <summary>
+    /// Delete an activity from a conversation.
+    /// </summary>
+    public Task DeleteActivityAsync(string conversationId, string id, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        return _client.DeleteActivityAsync(conversationId, id, _serviceUrl, isTargeted: false, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Create a new targeted activity in a conversation.
+    /// Targeted activities are only visible to the specified recipient.
+    /// </summary>
+    [Experimental("ExperimentalTeamsTargeted")]
+    public Task<SendActivityResponse?> CreateTargetedActivityAsync(string conversationId, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        return SendCoreAsync(conversationId, activity, isTargeted: true, additionalHeaders, cancellationToken);
+    }
+
+    /// <summary>
+    /// Update an existing targeted activity in a conversation.
+    /// </summary>
+    [Experimental("ExperimentalTeamsTargeted")]
+    public Task<UpdateActivityResponse> UpdateTargetedActivityAsync(string conversationId, string id, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        return UpdateCoreAsync(conversationId, id, activity, isTargeted: true, additionalHeaders, cancellationToken);
+    }
+
+    /// <summary>
+    /// Delete a targeted activity from a conversation.
+    /// </summary>
+    [Experimental("ExperimentalTeamsTargeted")]
+    public Task DeleteTargetedActivityAsync(string conversationId, string id, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        return _client.DeleteActivityAsync(conversationId, id, _serviceUrl, isTargeted: true, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+    }
+
+    #endregion
+
+    #region Member Methods
+
+    /// <summary>
+    /// Get all members of a conversation.
+    /// </summary>
+    [Obsolete("Use GetMembersPagedAsync instead.")]
+    public async Task<IList<TeamsChannelAccount?>> GetMembersAsync(string conversationId, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        IList<ChannelAccount> members = await _client.GetConversationMembersAsync(conversationId, _serviceUrl, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return [.. members.Select(m => TeamsChannelAccount.FromChannelAccount(m))];
+    }
+
+    /// <summary>
+    /// Get members of a conversation with pagination support.
+    /// </summary>
+    public async Task<PagedTeamsMembersResult> GetMembersPagedAsync(
+        string conversationId,
+        int pageSize = 50,
+        string? continuationToken = null,
+        Dictionary<string, string>? additionalHeaders = null,
+        CancellationToken cancellationToken = default)
+    {
+        PagedMembersResult? paged = await _client.GetConversationPagedMembersAsync(
+            conversationId,
+            _serviceUrl,
+            pageSize,
+            continuationToken,
+            requestContext: AgenticContext,
+            customHeaders: additionalHeaders,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        PagedTeamsMembersResult result = new();
+        if (paged is not null)
+        {
+            result.ContinuationToken = paged.ContinuationToken;
+            if (paged.Members is not null)
+            {
+                result.Members = [.. paged.Members.Select(m => TeamsChannelAccount.FromChannelAccount(m))];
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Get all members of a conversation, automatically following pagination.
+    /// </summary>
+    /// <remarks>
+    /// Streams members across all pages by following the continuation token internally,
+    /// for convenient <c>await foreach</c> iteration. Use <see cref="GetMembersPagedAsync"/> when you
+    /// need explicit control over paging (for example, to persist the continuation token across
+    /// requests and resume later).
+    /// </remarks>
+    public async IAsyncEnumerable<TeamsChannelAccount> GetAllMembersAsync(
+        string conversationId,
+        int pageSize = 50,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        string? continuationToken = null;
+        do
+        {
+            PagedTeamsMembersResult page = await GetMembersPagedAsync(
+                conversationId,
+                pageSize,
+                continuationToken,
+                additionalHeaders: null,
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (TeamsChannelAccount? member in page.Members)
+            {
+                if (member is not null)
+                {
+                    yield return member;
+                }
+            }
+
+            continuationToken = page.ContinuationToken;
+        } while (!string.IsNullOrEmpty(continuationToken));
+    }
+
+    /// <summary>
+    /// Get a specific member of a conversation by ID.
+    /// </summary>
+    public Task<T> GetMemberByIdAsync<T>(string conversationId, string memberId, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default) where T : ChannelAccount
+    {
+        return _client.GetConversationMemberAsync<T>(conversationId, memberId, _serviceUrl, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Get a specific member of a conversation by ID.
+    /// </summary>
+    public async Task<TeamsChannelAccount?> GetMemberByIdAsync(string conversationId, string memberId, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        ChannelAccount member = await GetMemberByIdAsync<ChannelAccount>(conversationId, memberId, additionalHeaders, cancellationToken).ConfigureAwait(false);
+        return TeamsChannelAccount.FromChannelAccount(member);
+    }
+
+    #endregion
+
+    #region Reaction Methods
+
+    /// <summary>
+    /// Adds a reaction on an activity in a conversation.
+    /// </summary>
+    /// <param name="conversationId">The conversation id.</param>
+    /// <param name="activityId">The id of the activity to react to.</param>
+    /// <param name="reactionType">The reaction type (for example: "like", "heart", "laugh", etc.).</param>
+    /// <param name="additionalHeaders">Optional custom headers to include in the request.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    public Task AddReactionAsync(string conversationId, string activityId, string reactionType, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        return _client.AddReactionAsync(conversationId, activityId, reactionType, _serviceUrl, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Removes a reaction from an activity in a conversation.
+    /// </summary>
+    /// <param name="conversationId">The conversation id.</param>
+    /// <param name="activityId">The id of the activity the reaction is on.</param>
+    /// <param name="reactionType">The reaction type to remove (for example: "like", "heart", "laugh", etc.).</param>
+    /// <param name="additionalHeaders">Optional custom headers to include in the request.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    public Task DeleteReactionAsync(string conversationId, string activityId, string reactionType, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        return _client.DeleteReactionAsync(conversationId, activityId, reactionType, _serviceUrl, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+    }
+
+    #endregion
 }

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs
@@ -19,9 +19,6 @@ namespace Microsoft.Teams.Apps.Api.Clients;
 /// </summary>
 public class ConversationApiClient
 {
-    private const string ObsoleteInboundMessage =
-        "Sending an inbound TeamsActivity (read-model) is obsolete. Use the overload that accepts a TeamsActivityInput built via MessageActivityInput.CreateBuilder().";
-
     private readonly CoreConversationClient _client;
     private readonly Uri _serviceUrl;
     private readonly AgenticIdentity? _agenticIdentity;
@@ -84,32 +81,12 @@ public class ConversationApiClient
     }
 
     /// <summary>
-    /// Create a new activity in a conversation.
-    /// </summary>
-    [Obsolete(ObsoleteInboundMessage)]
-    public Task<SendActivityResponse?> CreateActivityAsync(string conversationId, TeamsActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(activity);
-        return SendCoreAsync(conversationId, CoreActivityInput.FromActivity(activity), isTargeted: false, additionalHeaders, cancellationToken);
-    }
-
-    /// <summary>
     /// Update an existing activity in a conversation.
     /// </summary>
     public Task<UpdateActivityResponse> UpdateActivityAsync(string conversationId, string id, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
         return UpdateCoreAsync(conversationId, id, activity, isTargeted: false, additionalHeaders, cancellationToken);
-    }
-
-    /// <summary>
-    /// Update an existing activity in a conversation.
-    /// </summary>
-    [Obsolete(ObsoleteInboundMessage)]
-    public Task<UpdateActivityResponse> UpdateActivityAsync(string conversationId, string id, TeamsActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(activity);
-        return UpdateCoreAsync(conversationId, id, CoreActivityInput.FromActivity(activity), isTargeted: false, additionalHeaders, cancellationToken);
     }
 
     /// <summary>
@@ -120,18 +97,6 @@ public class ConversationApiClient
         ArgumentNullException.ThrowIfNull(activity);
         activity.ReplyToId = id;
         return SendCoreAsync(conversationId, activity, isTargeted: false, additionalHeaders, cancellationToken);
-    }
-
-    /// <summary>
-    /// Reply to an existing activity in a conversation.
-    /// </summary>
-    [Obsolete(ObsoleteInboundMessage)]
-    public Task<SendActivityResponse?> ReplyToActivityAsync(string conversationId, string id, TeamsActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(activity);
-        CoreActivityInput input = CoreActivityInput.FromActivity(activity);
-        input.ReplyToId = id;
-        return SendCoreAsync(conversationId, input, isTargeted: false, additionalHeaders, cancellationToken);
     }
 
     /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/MemberClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/MemberClient.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Teams.Apps.Api.Clients;
 /// Client for managing conversation members.
 /// Delegates to the core <see cref="CoreConversationClient"/>.
 /// </summary>
+[Obsolete("Use the member methods on ConversationApiClient directly instead.")]
 public class MemberClient
 {
     private readonly CoreConversationClient _client;

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ReactionClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ReactionClient.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Teams.Apps.Api.Clients;
 /// Client for managing reactions on activities in a conversation.
 /// Delegates to the core <see cref="CoreConversationClient"/>.
 /// </summary>
+[Obsolete("Use ConversationApiClient.AddReactionAsync and ConversationApiClient.DeleteReactionAsync instead.")]
 public class ReactionClient
 {
     private readonly CoreConversationClient _client;

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -141,7 +141,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     ?? throw new InvalidOperationException("Activity.Conversation.Id is required to send an activity.");
 
         TeamsActivityInput typing = new(TeamsActivityTypes.Typing);
-        return Api.Conversations.Activities.CreateAsync(conversationId, typing, cancellationToken: cancellationToken);
+        return Api.Conversations.CreateActivityAsync(conversationId, typing, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -278,11 +278,11 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
 
         if (!isTargeted)
         {
-            return Api.Conversations.Activities.CreateAsync(conversationId, activity, cancellationToken: cancellationToken);
+            return Api.Conversations.CreateActivityAsync(conversationId, activity, cancellationToken: cancellationToken);
         }
 
 #pragma warning disable ExperimentalTeamsTargeted
-        return Api.Conversations.Activities.CreateTargetedAsync(conversationId, activity, cancellationToken: cancellationToken);
+        return Api.Conversations.CreateTargetedActivityAsync(conversationId, activity, cancellationToken: cancellationToken);
 #pragma warning restore ExperimentalTeamsTargeted
     }
 

--- a/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
@@ -69,8 +69,7 @@ public class TeamsBotApplication : BotApplication
     /// <remarks>
     /// This property provides a structured API for accessing Teams operations through a hierarchy:
     /// <list type="bullet">
-    /// <item><c>Api.Conversations.Activities</c> - Activity operations (send, update, delete)</item>
-    /// <item><c>Api.Conversations.Members</c> - Member operations (get, delete)</item>
+    /// <item><c>Api.Conversations</c> - Conversation operations, including activities, members, and reactions</item>
     /// <item><c>Api.UserToken</c> - User token operations (OAuth SSO, sign-in resources)</item>
     /// <item><c>Api.Teams</c> - Team operations (get details, channels)</item>
     /// <item><c>Api.Meetings</c> - Meeting operations (get info, participant, notifications)</item>

--- a/core/test/IntegrationTests/ApiClientTests.cs
+++ b/core/test/IntegrationTests/ApiClientTests.cs
@@ -49,7 +49,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     {
         MessageActivityInput activity = CreateMessageActivity($"[ApiClient.Activities.Create] at `{DateTime.UtcNow:s}`");
 
-        SendActivityResponse? res = await _api.Conversations.Activities.CreateAsync(_f.ConversationId, activity);
+        SendActivityResponse? res = await _api.Conversations.CreateActivityAsync(_f.ConversationId, activity);
 
         Assert.NotNull(res);
         Assert.NotNull(res.Id);
@@ -62,12 +62,12 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     {
         MessageActivityInput original = CreateMessageActivity($"[ApiClient.Activities.Update] Original at `{DateTime.UtcNow:s}`");
 
-        SendActivityResponse? sent = await _api.Conversations.Activities.CreateAsync(_f.ConversationId, original);
+        SendActivityResponse? sent = await _api.Conversations.CreateActivityAsync(_f.ConversationId, original);
         Assert.NotNull(sent?.Id);
 
         MessageActivityInput updated = CreateMessageActivity($"[ApiClient.Activities.Update] Updated at `{DateTime.UtcNow:s}`");
 
-        UpdateActivityResponse? res = await _api.Conversations.Activities.UpdateAsync(
+        UpdateActivityResponse? res = await _api.Conversations.UpdateActivityAsync(
             _f.ConversationId, sent.Id, updated);
 
         Assert.NotNull(res?.Id);
@@ -80,12 +80,12 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     {
         MessageActivityInput original = CreateMessageActivity($"[ApiClient.Activities.Reply] Parent at `{DateTime.UtcNow:s}`");
 
-        SendActivityResponse? sent = await _api.Conversations.Activities.CreateAsync(_f.ConversationId, original);
+        SendActivityResponse? sent = await _api.Conversations.CreateActivityAsync(_f.ConversationId, original);
         Assert.NotNull(sent?.Id);
 
         MessageActivityInput reply = CreateMessageActivity($"[ApiClient.Activities.Reply] Reply at `{DateTime.UtcNow:s}`");
 
-        SendActivityResponse? res = await _api.Conversations.Activities.ReplyAsync(
+        SendActivityResponse? res = await _api.Conversations.ReplyToActivityAsync(
             _f.ConversationId, sent.Id, reply);
 
         Assert.NotNull(res);
@@ -98,12 +98,12 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     {
         MessageActivityInput activity = CreateMessageActivity($"[ApiClient.Activities.Delete] at `{DateTime.UtcNow:s}`");
 
-        SendActivityResponse? sent = await _api.Conversations.Activities.CreateAsync(_f.ConversationId, activity);
+        SendActivityResponse? sent = await _api.Conversations.CreateActivityAsync(_f.ConversationId, activity);
         Assert.NotNull(sent?.Id);
 
         await Task.Delay(2000);
 
-        await _api.Conversations.Activities.DeleteAsync(_f.ConversationId, sent.Id);
+        await _api.Conversations.DeleteActivityAsync(_f.ConversationId, sent.Id);
         _output.WriteLine($"Deleted activity: {sent.Id}");
     }
 
@@ -121,7 +121,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
             $"[ApiClient.Activities.CreateTargeted] at `{DateTime.UtcNow:s}`",
             new ChannelAccount { Id = _f.MemberMri1 });
 
-        SendActivityResponse? res = await _api.Conversations.Activities.CreateTargetedAsync(_f.ConversationId, activity);
+        SendActivityResponse? res = await _api.Conversations.CreateTargetedActivityAsync(_f.ConversationId, activity);
 
         Assert.NotNull(res);
         Assert.NotNull(res.Id);
@@ -137,12 +137,12 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
             $"[ApiClient.Activities.UpdateTargeted] Original at `{DateTime.UtcNow:s}`",
             new ChannelAccount { Id = _f.MemberMri1 });
 
-        SendActivityResponse? sent = await _api.Conversations.Activities.CreateTargetedAsync(_f.ConversationId, original);
+        SendActivityResponse? sent = await _api.Conversations.CreateTargetedActivityAsync(_f.ConversationId, original);
         Assert.NotNull(sent?.Id);
 
         MessageActivityInput updated = CreateMessageActivity($"[ApiClient.Activities.UpdateTargeted] Updated at `{DateTime.UtcNow:s}`");
 
-        UpdateActivityResponse? res = await _api.Conversations.Activities.UpdateTargetedAsync(
+        UpdateActivityResponse? res = await _api.Conversations.UpdateTargetedActivityAsync(
             _f.ConversationId, sent.Id, updated);
 
         Assert.NotNull(res?.Id);
@@ -158,12 +158,12 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
             $"[ApiClient.Activities.DeleteTargeted] at `{DateTime.UtcNow:s}`",
             new ChannelAccount { Id = _f.MemberMri1 });
 
-        SendActivityResponse? sent = await _api.Conversations.Activities.CreateTargetedAsync(_f.ConversationId, activity);
+        SendActivityResponse? sent = await _api.Conversations.CreateTargetedActivityAsync(_f.ConversationId, activity);
         Assert.NotNull(sent?.Id);
 
         await Task.Delay(2000);
 
-        await _api.Conversations.Activities.DeleteTargetedAsync(_f.ConversationId, sent.Id);
+        await _api.Conversations.DeleteTargetedActivityAsync(_f.ConversationId, sent.Id);
         _output.WriteLine($"Deleted targeted activity: {sent.Id}");
     }
 
@@ -175,7 +175,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     [Trait("Category", "Members")]
     public async Task Members_GetAsync()
     {
-        IList<TeamsChannelAccount?> members = await _api.Conversations.Members.GetAsync(_f.ConversationId);
+        IList<TeamsChannelAccount?> members = await _api.Conversations.GetMembersAsync(_f.ConversationId);
 
         Assert.NotNull(members);
         Assert.NotEmpty(members);
@@ -192,7 +192,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     {
         Skip.If(_f.AgenticIdentity is not null, "Paged members returns 500 with agentic identity — service limitation");
 
-        PagedTeamsMembersResult paged = await _api.Conversations.Members.GetPagedAsync(_f.ConversationId);
+        PagedTeamsMembersResult paged = await _api.Conversations.GetMembersPagedAsync(_f.ConversationId);
 
         Assert.NotNull(paged);
         Assert.NotEmpty(paged.Members);
@@ -210,7 +210,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     {
         string memberId = _f.MemberMri1!;
 
-        TeamsChannelAccount? member = await _api.Conversations.Members.GetByIdAsync(
+        TeamsChannelAccount? member = await _api.Conversations.GetMemberByIdAsync(
             _f.ConversationId, memberId);
 
         Assert.NotNull(member);
@@ -224,7 +224,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     {
         string memberId = _f.MemberMri1!;
 
-        TeamsChannelAccount member = await _api.Conversations.Members.GetByIdAsync<TeamsChannelAccount>(
+        TeamsChannelAccount member = await _api.Conversations.GetMemberByIdAsync<TeamsChannelAccount>(
             _f.ConversationId, memberId);
 
         Assert.NotNull(member);
@@ -245,15 +245,15 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
 
         MessageActivityInput activity = CreateMessageActivity($"[ApiClient.Reactions] Test at `{DateTime.UtcNow:s}`");
 
-        SendActivityResponse? sent = await _api.Conversations.Activities.CreateAsync(_f.ConversationId, activity);
+        SendActivityResponse? sent = await _api.Conversations.CreateActivityAsync(_f.ConversationId, activity);
         Assert.NotNull(sent?.Id);
 
-        await _api.Conversations.Reactions.AddAsync(_f.ConversationId, sent.Id, "like");
+        await _api.Conversations.AddReactionAsync(_f.ConversationId, sent.Id, "like");
         _output.WriteLine("Added 'like' reaction");
 
         await Task.Delay(1000);
 
-        await _api.Conversations.Reactions.DeleteAsync(_f.ConversationId, sent.Id, "like");
+        await _api.Conversations.DeleteReactionAsync(_f.ConversationId, sent.Id, "like");
         _output.WriteLine("Removed 'like' reaction");
     }
 
@@ -464,7 +464,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
         Assert.Equal(_f.ServiceUrl, scoped.ServiceUrl);
 
         // Verify the scoped client can make a real call
-        IList<TeamsChannelAccount?> members = await scoped.Conversations.Members.GetAsync(_f.ConversationId);
+        IList<TeamsChannelAccount?> members = await scoped.Conversations.GetMembersAsync(_f.ConversationId);
         Assert.NotNull(members);
         Assert.NotEmpty(members);
         _output.WriteLine($"ForServiceUrl scoped client retrieved {members.Count} members");

--- a/core/test/IntegrationTests/CompatTeamsInfoTests.cs
+++ b/core/test/IntegrationTests/CompatTeamsInfoTests.cs
@@ -307,7 +307,7 @@ public class TeamsApiClientTests : IClassFixture<IntegrationTestFixture>
         // The meetings participant API requires AAD object ID, not MRI/pairwise bot framework ID.
         // Get the AAD object ID from a human member (bots don't have one).
         ApiClient api = _f.ScopedApiClient;
-        IList<Microsoft.Teams.Apps.Schema.TeamsChannelAccount?> members = await api.Conversations.Members.GetAsync(_f.ConversationId);
+        IList<Microsoft.Teams.Apps.Schema.TeamsChannelAccount?> members = await api.Conversations.GetMembersAsync(_f.ConversationId);
         Assert.NotEmpty(members);
 
         string? aadObjectId = null;

--- a/core/test/IntegrationTests/CreateConversationTests.cs
+++ b/core/test/IntegrationTests/CreateConversationTests.cs
@@ -265,7 +265,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
             .WithText($"[ApiClient] 1:1 via Activities.Create at `{DateTime.UtcNow:s}`")
             .Build();
 
-        SendActivityResponse? sent = await _api.Conversations.Activities.CreateAsync(response.Id, activity);
+        SendActivityResponse? sent = await _api.Conversations.CreateActivityAsync(response.Id, activity);
         Assert.NotNull(sent?.Id);
         _output.WriteLine($"[ApiClient] Created 1:1 {response.Id}, sent activity {sent.Id}");
     }
@@ -356,7 +356,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
             .WithText($"[ApiClient] Thread reply at `{DateTime.UtcNow:s}`")
             .Build();
 
-        SendActivityResponse? replyResponse = await _api.Conversations.Activities.ReplyAsync(
+        SendActivityResponse? replyResponse = await _api.Conversations.ReplyToActivityAsync(
             response.Id, response.ActivityId, reply);
 
         Assert.NotNull(replyResponse);

--- a/core/test/IntegrationTests/IntegrationTestFixture.cs
+++ b/core/test/IntegrationTests/IntegrationTestFixture.cs
@@ -122,7 +122,7 @@ public class IntegrationTestFixture : IAsyncLifetime, IDisposable, ITestOutputHe
     public async Task InitializeAsync()
     {
         ApiClient scoped = ScopedApiClient;
-        IList<TeamsChannelAccount?> raw = await scoped.Conversations.Members.GetAsync(ConversationId);
+        IList<TeamsChannelAccount?> raw = await scoped.Conversations.GetMembersAsync(ConversationId);
 
         string botMri = $"28:{BotAppId}";
         CachedMembers = raw

--- a/core/test/TeamsApisDemo/Program.cs
+++ b/core/test/TeamsApisDemo/Program.cs
@@ -26,18 +26,18 @@ Console.WriteLine($"Running Teams Bot Application for appId '{teamsBotApplicatio
 
 
 var smba = new Uri("https://smba.trafficmanager.net/amer");
-var membersClient = teamsBotApplication.Api.ForServiceUrl(smba).Conversations.Members;
+var conversations = teamsBotApplication.Api.ForServiceUrl(smba).Conversations;
 
 int pages = 1;
 string cid = "19%3ALydFnezGKSkhYoiLNP6kZ8AuXQr36EDAkvG9CNJSPKc1%40thread.tacv2";
-var paged = await membersClient.GetPagedAsync(cid, 52);
+var paged = await conversations.GetMembersPagedAsync(cid, 52);
 
 List<TeamsChannelAccount?> members = [..paged.Members];
 
 while (!string.IsNullOrEmpty(paged.ContinuationToken))
 {
     Console.WriteLine("Getting next page of members...");
-    paged = await membersClient.GetPagedAsync(cid, 52, paged.ContinuationToken);
+    paged = await conversations.GetMembersPagedAsync(cid, 52, paged.ContinuationToken);
     members.AddRange(paged.Members);
     pages++;
 }


### PR DESCRIPTION
This pull request modernizes the `ConversationApiClient` by moving activity, member, and reaction operations directly onto the main client, deprecating the old sub-client classes and methods. It updates documentation and sample code to reflect these changes, and introduces new methods for member pagination and targeted activities. The changes improve usability and streamline the API surface, while retaining backward compatibility via obsolete sub-clients.

**Client API modernization:**

* Added activity, member, and reaction methods (e.g., `CreateActivityAsync`, `GetMembersPagedAsync`, `AddReactionAsync`) directly to `ConversationApiClient`, deprecating the `Activities`, `Members`, and `Reactions` sub-clients and marking them as `[Obsolete]` for backward compatibility. [[1]](diffhunk://#diff-adb096c0752cabe7980d4c5edbe837cd4d1fff52a3a13312e0505bb47d973d9eR60-R273)], [[2]](diffhunk://#diff-adb096c0752cabe7980d4c5edbe837cd4d1fff52a3a13312e0505bb47d973d9eR27-R50)], [[3]](diffhunk://#diff-076da0b36aadd7ef4165dab640d742f9c142c308b8dd7a06214d2106badcee84R17)], [[4]](diffhunk://#diff-eb59ce601e0b3aee3cb7311932c17d55dde761bc444ae1c5d21e5c628fa211edR18)])
* Introduced new member-related methods on `ConversationApiClient`, including `GetMembersPagedAsync`, `GetAllMembersAsync` (for streaming members with pagination), and overloads for getting a member by ID. ([[core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.csR60-R273](diffhunk://#diff-adb096c0752cabe7980d4c5edbe837cd4d1fff52a3a13312e0505bb47d973d9eR60-R273)])

**Targeted activities improvements:**

* Added `CreateTargetedActivityAsync`, `UpdateTargetedActivityAsync`, and `DeleteTargetedActivityAsync` methods to `ConversationApiClient`, and deprecated the corresponding methods on the old sub-clients. ([[core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.csR60-R273](diffhunk://#diff-adb096c0752cabe7980d4c5edbe837cd4d1fff52a3a13312e0505bb47d973d9eR60-R273)])

**Reaction API improvements:**

* Added `AddReactionAsync` and `DeleteReactionAsync` methods directly to `ConversationApiClient`, deprecating the old `ReactionClient`. ([[core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.csR60-R273](diffhunk://#diff-adb096c0752cabe7980d4c5edbe837cd4d1fff52a3a13312e0505bb47d973d9eR60-R273)])

**Documentation and sample updates:**

* Updated `ApiClient-Design.md` to document the new API surface, clarify the deprecation of sub-clients, and provide updated usage examples. [[1]](diffhunk://#diff-2dca39336524593d728d4b51f75818a8490d4500d94b3a5da250eb23cfd90187L12-R27)], [[2]](diffhunk://#diff-2dca39336524593d728d4b51f75818a8490d4500d94b3a5da250eb23cfd90187L39-R41)], [[3]](diffhunk://#diff-2dca39336524593d728d4b51f75818a8490d4500d94b3a5da250eb23cfd90187L57-R62)])
* Refactored all samples (`TeamsBot`, `TargetedMessages`) to use the new direct methods on `ConversationApiClient` instead of the sub-client pattern. [[1]](diffhunk://#diff-2943fbf089e8220accc519554b7412f47e6d4965a5b99a56f6676996c0531903L61-R61)], [[2]](diffhunk://#diff-2943fbf089e8220accc519554b7412f47e6d4965a5b99a56f6676996c0531903L91-R91)], [[3]](diffhunk://#diff-691809f7a90c5bda6ee5e4335c2c393864a32101545fb0b35c24bc659623361bL185-R185)], [[4]](diffhunk://#diff-691809f7a90c5bda6ee5e4335c2c393864a32101545fb0b35c24bc659623361bL194-R194)], [[5]](diffhunk://#diff-691809f7a90c5bda6ee5e4335c2c393864a32101545fb0b35c24bc659623361bL220-R220)], [[6]](diffhunk://#diff-691809f7a90c5bda6ee5e4335c2c393864a32101545fb0b35c24bc659623361bL230-R230)], [[7]](diffhunk://#diff-691809f7a90c5bda6ee5e4335c2c393864a32101545fb0b35c24bc659623361bL240-R240)])

These changes make the API more intuitive and future-proof, while ensuring existing codebases continue to work with deprecation warnings.