### PR TITLE
Add explicit unauthenticated request bypass

### DIFF
--- a/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
+++ b/Libraries/Microsoft.Teams.Extensions/Microsoft.Teams.Extensions.Configuration/Microsoft.Teams.Apps.Extensions/TeamsSettings.cs
@@ -33,6 +33,12 @@ public class TeamsSettings
     /// <summary>Override the Microsoft Graph token scope.</summary>
     public string? GraphScope { get; set; }
 
+    /// <summary>
+    /// Allow the Teams messaging endpoint to accept unauthenticated requests.
+    /// Can be configured with the <c>Teams__DangerouslyAllowUnauthenticatedRequests</c> environment variable.
+    /// </summary>
+    public bool? DangerouslyAllowUnauthenticatedRequests { get; set; }
+
     public bool Empty
     {
         get { return ClientId == "" || ClientSecret == ""; }

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.cs
@@ -183,7 +183,9 @@ public partial class AspNetCorePlugin : ISenderPlugin, IAspNetCorePlugin
         try
         {
             var request = httpContext.Request;
-            var token = ExtractToken(request);
+            var options = httpContext.RequestServices?.GetService(typeof(AspNetCorePluginOptions)) as AspNetCorePluginOptions;
+            var dangerouslyAllowUnauthenticatedRequests = options?.DangerouslyAllowUnauthenticatedRequests == true;
+            var token = dangerouslyAllowUnauthenticatedRequests ? null : ExtractToken(request);
             var activity = await ParseActivity(request).ConfigureAwait(false);
 
             if (activity is null)
@@ -191,12 +193,14 @@ public partial class AspNetCorePlugin : ISenderPlugin, IAspNetCorePlugin
                 return Results.BadRequest("Missing activity");
             }
 
+            IToken activityToken = token is null ? new UnauthenticatedToken(activity.ServiceUrl) : token;
+
             // Require the token's serviceurl claim to match the activity's serviceUrl
             // (normalized, case-insensitive) when the activity specifies one. Mismatches
             // are logged server-side.
-            if (!string.IsNullOrEmpty(activity.ServiceUrl))
+            if (!dangerouslyAllowUnauthenticatedRequests && !string.IsNullOrEmpty(activity.ServiceUrl))
             {
-                var claimServiceUrl = token.Token.Payload.TryGetValue("serviceurl", out var serviceUrlClaim)
+                var claimServiceUrl = token!.Token.Payload.TryGetValue("serviceurl", out var serviceUrlClaim)
                     ? serviceUrlClaim as string
                     : null;
 
@@ -223,7 +227,7 @@ public partial class AspNetCorePlugin : ISenderPlugin, IAspNetCorePlugin
 
             var res = await Do(new ActivityEvent()
             {
-                Token = token,
+                Token = activityToken,
                 Activity = activity,
                 Extra = data,
                 Services = httpContext.RequestServices

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePlugin.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.Teams.Api.Activities;
 using Microsoft.Teams.Api.Auth;
 using Microsoft.Teams.Api.Clients;
@@ -185,7 +186,29 @@ public partial class AspNetCorePlugin : ISenderPlugin, IAspNetCorePlugin
             var request = httpContext.Request;
             var options = httpContext.RequestServices?.GetService(typeof(AspNetCorePluginOptions)) as AspNetCorePluginOptions;
             var dangerouslyAllowUnauthenticatedRequests = options?.DangerouslyAllowUnauthenticatedRequests == true;
-            var token = dangerouslyAllowUnauthenticatedRequests ? null : ExtractToken(request);
+            JsonWebToken? token = null;
+            if (!dangerouslyAllowUnauthenticatedRequests)
+            {
+                try
+                {
+                    token = ExtractToken(request);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    Logger.Warn("Rejecting request: missing Authorization bearer token.");
+                    return Results.Unauthorized();
+                }
+                catch (ArgumentException)
+                {
+                    Logger.Warn("Rejecting request: invalid Authorization bearer token.");
+                    return Results.Unauthorized();
+                }
+                catch (SecurityTokenException)
+                {
+                    Logger.Warn("Rejecting request: invalid Authorization bearer token.");
+                    return Results.Unauthorized();
+                }
+            }
             var activity = await ParseActivity(request).ConfigureAwait(false);
 
             if (activity is null)

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePluginOptions.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/AspNetCorePluginOptions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Teams.Plugins.AspNetCore;
+
+public class AspNetCorePluginOptions
+{
+    /// <summary>
+    /// Allow the Teams messaging endpoint to accept unauthenticated requests.
+    /// This should only be enabled for local development.
+    /// </summary>
+    public bool DangerouslyAllowUnauthenticatedRequests { get; set; }
+
+    [Obsolete("SkipAuth is deprecated. Use DangerouslyAllowUnauthenticatedRequests instead.")]
+    public bool SkipAuth
+    {
+        get => DangerouslyAllowUnauthenticatedRequests;
+        set => DangerouslyAllowUnauthenticatedRequests = value;
+    }
+}

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/HostApplicationBuilder.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/Extensions/HostApplicationBuilder.cs
@@ -15,24 +15,61 @@ namespace Microsoft.Teams.Plugins.AspNetCore.Extensions;
 
 public static class HostApplicationBuilderExtensions
 {
+    private const string SkipAuthObsoleteMessage = "skipAuth is deprecated. Use AspNetCorePluginOptions.DangerouslyAllowUnauthenticatedRequests or the Teams:DangerouslyAllowUnauthenticatedRequests configuration value instead.";
+
+    /// <summary>
+    /// adds core Teams services and the
+    /// AspNetCorePlugin
+    /// </summary>
+    public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder)
+    {
+        return builder.AddTeams(routing: true);
+    }
+
     /// <summary>
     /// adds core Teams services and the
     /// AspNetCorePlugin
     /// </summary>
     /// <param name="routing">set to false to disable the plugins default http controller</param>
-    /// <param name="skipAuth">set to true to disable token authentication</param>
+    public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, bool routing)
+    {
+        builder.AddTeamsCore();
+        return builder.AddTeamsAspNetCorePlugin(routing, options: null);
+    }
+
+    /// <summary>
+    /// adds core Teams services and the
+    /// AspNetCorePlugin
+    /// </summary>
+    /// <param name="options">the AspNetCore plugin options</param>
+    /// <param name="routing">set to false to disable the plugins default http controller</param>
+    public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, AspNetCorePluginOptions options, bool routing = true)
+    {
+        builder.AddTeamsCore();
+        return builder.AddTeamsAspNetCorePlugin(routing, options);
+    }
+
+    /// <summary>
+    /// adds core Teams services and the
+    /// AspNetCorePlugin
+    /// </summary>
+    /// <param name="routing">set to false to disable the plugins default http controller</param>
+    /// <param name="skipAuth">deprecated; use <see cref="AspNetCorePluginOptions.DangerouslyAllowUnauthenticatedRequests"/> instead</param>
+    [Obsolete(SkipAuthObsoleteMessage)]
     public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, bool routing = true, bool skipAuth = false)
     {
         builder.AddTeamsCore();
-        builder.AddTeamsPlugin<AspNetCorePlugin>();
-        builder.AddTeamsTokenAuthentication(skipAuth);
+        return builder.AddTeamsAspNetCorePlugin(routing, new AspNetCorePluginOptions { DangerouslyAllowUnauthenticatedRequests = skipAuth });
+    }
 
-        if (routing)
-        {
-            builder.Services.AddControllers().AddApplicationPart(Assembly.GetExecutingAssembly());
-        }
-
-        return builder;
+    /// <summary>
+    /// adds core Teams services and the
+    /// AspNetCorePlugin
+    /// </summary>
+    /// <param name="app">your app instance</param>
+    public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, App app)
+    {
+        return builder.AddTeams(app, routing: true);
     }
 
     /// <summary>
@@ -41,19 +78,47 @@ public static class HostApplicationBuilderExtensions
     /// </summary>
     /// <param name="app">your app instance</param>
     /// <param name="routing">set to false to disable the plugins default http controller</param>
-    /// <param name="skipAuth">set to true to disable token authentication</param>
+    public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, App app, bool routing)
+    {
+        builder.AddTeamsCore(app);
+        return builder.AddTeamsAspNetCorePlugin(routing, options: null);
+    }
+
+    /// <summary>
+    /// adds core Teams services and the
+    /// AspNetCorePlugin
+    /// </summary>
+    /// <param name="app">your app instance</param>
+    /// <param name="options">the AspNetCore plugin options</param>
+    /// <param name="routing">set to false to disable the plugins default http controller</param>
+    public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, App app, AspNetCorePluginOptions options, bool routing = true)
+    {
+        builder.AddTeamsCore(app);
+        return builder.AddTeamsAspNetCorePlugin(routing, options);
+    }
+
+    /// <summary>
+    /// adds core Teams services and the
+    /// AspNetCorePlugin
+    /// </summary>
+    /// <param name="app">your app instance</param>
+    /// <param name="routing">set to false to disable the plugins default http controller</param>
+    /// <param name="skipAuth">deprecated; use <see cref="AspNetCorePluginOptions.DangerouslyAllowUnauthenticatedRequests"/> instead</param>
+    [Obsolete(SkipAuthObsoleteMessage)]
     public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, App app, bool routing = true, bool skipAuth = false)
     {
         builder.AddTeamsCore(app);
-        builder.AddTeamsPlugin<AspNetCorePlugin>();
-        builder.AddTeamsTokenAuthentication(skipAuth);
+        return builder.AddTeamsAspNetCorePlugin(routing, new AspNetCorePluginOptions { DangerouslyAllowUnauthenticatedRequests = skipAuth });
+    }
 
-        if (routing)
-        {
-            builder.Services.AddControllers().AddApplicationPart(Assembly.GetExecutingAssembly());
-        }
-
-        return builder;
+    /// <summary>
+    /// adds core Teams services and the
+    /// AspNetCorePlugin
+    /// </summary>
+    /// <param name="options">your app options</param>
+    public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, AppOptions options)
+    {
+        return builder.AddTeams(options, routing: true);
     }
 
     /// <summary>
@@ -62,19 +127,47 @@ public static class HostApplicationBuilderExtensions
     /// </summary>
     /// <param name="options">your app options</param>
     /// <param name="routing">set to false to disable the plugins default http controller</param>
-    /// <param name="skipAuth">set to true to disable token authentication</param>
+    public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, AppOptions options, bool routing)
+    {
+        builder.AddTeamsCore(options);
+        return builder.AddTeamsAspNetCorePlugin(routing, options: null);
+    }
+
+    /// <summary>
+    /// adds core Teams services and the
+    /// AspNetCorePlugin
+    /// </summary>
+    /// <param name="appOptions">your app options</param>
+    /// <param name="aspNetCoreOptions">the AspNetCore plugin options</param>
+    /// <param name="routing">set to false to disable the plugins default http controller</param>
+    public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, AppOptions appOptions, AspNetCorePluginOptions aspNetCoreOptions, bool routing = true)
+    {
+        builder.AddTeamsCore(appOptions);
+        return builder.AddTeamsAspNetCorePlugin(routing, aspNetCoreOptions);
+    }
+
+    /// <summary>
+    /// adds core Teams services and the
+    /// AspNetCorePlugin
+    /// </summary>
+    /// <param name="options">your app options</param>
+    /// <param name="routing">set to false to disable the plugins default http controller</param>
+    /// <param name="skipAuth">deprecated; use <see cref="AspNetCorePluginOptions.DangerouslyAllowUnauthenticatedRequests"/> instead</param>
+    [Obsolete(SkipAuthObsoleteMessage)]
     public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, AppOptions options, bool routing = true, bool skipAuth = false)
     {
         builder.AddTeamsCore(options);
-        builder.AddTeamsPlugin<AspNetCorePlugin>();
-        builder.AddTeamsTokenAuthentication(skipAuth);
+        return builder.AddTeamsAspNetCorePlugin(routing, new AspNetCorePluginOptions { DangerouslyAllowUnauthenticatedRequests = skipAuth });
+    }
 
-        if (routing)
-        {
-            builder.Services.AddControllers().AddApplicationPart(Assembly.GetExecutingAssembly());
-        }
-
-        return builder;
+    /// <summary>
+    /// adds core Teams services and the
+    /// AspNetCorePlugin
+    /// </summary>
+    /// <param name="appBuilder">your app builder</param>
+    public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, AppBuilder appBuilder)
+    {
+        return builder.AddTeams(appBuilder, routing: true);
     }
 
     /// <summary>
@@ -83,19 +176,37 @@ public static class HostApplicationBuilderExtensions
     /// </summary>
     /// <param name="appBuilder">your app builder</param>
     /// <param name="routing">set to false to disable the plugins default http controller</param>
-    /// <param name="skipAuth">set to true to disable token authentication</param>
+    public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, AppBuilder appBuilder, bool routing)
+    {
+        builder.AddTeamsCore(appBuilder);
+        return builder.AddTeamsAspNetCorePlugin(routing, options: null);
+    }
+
+    /// <summary>
+    /// adds core Teams services and the
+    /// AspNetCorePlugin
+    /// </summary>
+    /// <param name="appBuilder">your app builder</param>
+    /// <param name="options">the AspNetCore plugin options</param>
+    /// <param name="routing">set to false to disable the plugins default http controller</param>
+    public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, AppBuilder appBuilder, AspNetCorePluginOptions options, bool routing = true)
+    {
+        builder.AddTeamsCore(appBuilder);
+        return builder.AddTeamsAspNetCorePlugin(routing, options);
+    }
+
+    /// <summary>
+    /// adds core Teams services and the
+    /// AspNetCorePlugin
+    /// </summary>
+    /// <param name="appBuilder">your app builder</param>
+    /// <param name="routing">set to false to disable the plugins default http controller</param>
+    /// <param name="skipAuth">deprecated; use <see cref="AspNetCorePluginOptions.DangerouslyAllowUnauthenticatedRequests"/> instead</param>
+    [Obsolete(SkipAuthObsoleteMessage)]
     public static IHostApplicationBuilder AddTeams(this IHostApplicationBuilder builder, AppBuilder appBuilder, bool routing = true, bool skipAuth = false)
     {
         builder.AddTeamsCore(appBuilder);
-        builder.AddTeamsPlugin<AspNetCorePlugin>();
-        builder.AddTeamsTokenAuthentication(skipAuth);
-
-        if (routing)
-        {
-            builder.Services.AddControllers().AddApplicationPart(Assembly.GetExecutingAssembly());
-        }
-
-        return builder;
+        return builder.AddTeamsAspNetCorePlugin(routing, new AspNetCorePluginOptions { DangerouslyAllowUnauthenticatedRequests = skipAuth });
     }
 
     public static class TeamsTokenAuthConstants
@@ -112,36 +223,68 @@ public static class HostApplicationBuilderExtensions
         public const string AuthorizationPolicy = "EntraTokenJWTPolicy";
     }
 
+    private static IHostApplicationBuilder AddTeamsAspNetCorePlugin(this IHostApplicationBuilder builder, bool routing, AspNetCorePluginOptions? options)
+    {
+        builder.AddTeamsPlugin<AspNetCorePlugin>();
+        builder.AddTeamsTokenAuthentication(options);
+
+        if (routing)
+        {
+            builder.Services.AddControllers().AddApplicationPart(Assembly.GetExecutingAssembly());
+        }
+
+        return builder;
+    }
+
     /// <summary>
     /// add TeamsJWTScheme for validating incoming SMBA tokens and EntraTokenJWTScheme for validating incoming Entra tokens
     /// provides Authorization policy TeamsJWTPolicy required by [Authorize(Policy="TeamsJWTPolicy")] in MessageController
     /// provides Authorization policy EntraTokenJWTPolicy required when Tab invokes remote functions
     /// </summary>
     /// <returns></returns>
-    public static IHostApplicationBuilder AddTeamsTokenAuthentication(this IHostApplicationBuilder builder, bool skipAuth = false)
+    public static IHostApplicationBuilder AddTeamsTokenAuthentication(this IHostApplicationBuilder builder)
+    {
+        return builder.AddTeamsTokenAuthentication(options: null);
+    }
+
+    /// <summary>
+    /// add TeamsJWTScheme for validating incoming SMBA tokens and EntraTokenJWTScheme for validating incoming Entra tokens
+    /// provides Authorization policy TeamsJWTPolicy required by [Authorize(Policy="TeamsJWTPolicy")] in MessageController
+    /// provides Authorization policy EntraTokenJWTPolicy required when Tab invokes remote functions
+    /// </summary>
+    /// <param name="options">the AspNetCore plugin options</param>
+    public static IHostApplicationBuilder AddTeamsTokenAuthentication(this IHostApplicationBuilder builder, AspNetCorePluginOptions? options)
     {
         var settings = builder.Configuration.GetTeams();
         var cloud = settings.ResolveCloud();
+        var dangerouslyAllowUnauthenticatedRequests = options?.DangerouslyAllowUnauthenticatedRequests
+            ?? settings.DangerouslyAllowUnauthenticatedRequests
+            ?? false;
+        builder.Services.AddSingleton(new AspNetCorePluginOptions
+        {
+            DangerouslyAllowUnauthenticatedRequests = dangerouslyAllowUnauthenticatedRequests
+        });
 
         var teamsValidationSettings = new TeamsValidationSettings(cloud);
         if (!string.IsNullOrEmpty(settings.ClientId))
         {
             teamsValidationSettings.AddDefaultAudiences(settings.ClientId);
         }
-        else if (skipAuth)
+
+        if (dangerouslyAllowUnauthenticatedRequests)
         {
-            // No Teams:ClientId configured and skipAuth is set, so the authorization
+            // DangerouslyAllowUnauthenticatedRequests is set, so the authorization
             // policy bypasses authentication and the bot will accept anonymous traffic.
             // The warning routes through whatever logging pipeline the consumer set up.
             LogFromServices(builder.Services, l => l.LogWarning(
-                "No Teams:ClientId configured and skipAuth is enabled. Bot will accept unauthenticated requests on the messaging endpoint."));
+                "DangerouslyAllowUnauthenticatedRequests is enabled. Bot will accept unauthenticated requests on the messaging endpoint."));
         }
-        else
+        else if (string.IsNullOrEmpty(settings.ClientId))
         {
-            // No Teams:ClientId configured and skipAuth is not set, so the authorization
+            // No Teams:ClientId configured and unauthenticated requests are not allowed, so the authorization
             // policy rejects every request to the messaging endpoint. Warn the consumer
             // their bot will not receive traffic until credentials are configured (or
-            // skipAuth: true is passed to AddTeams(...) for local development).
+            // DangerouslyAllowUnauthenticatedRequests is set for local development).
             LogFromServices(builder.Services, l => l.LogWarning(
                 "No Teams:ClientId configured. Bot will reject all requests on the messaging endpoint until credentials are configured."));
         }
@@ -162,7 +305,7 @@ public static class HostApplicationBuilderExtensions
         {
             options.AddPolicy(TeamsTokenAuthConstants.AuthorizationPolicy, policy =>
             {
-                if (skipAuth)
+                if (dangerouslyAllowUnauthenticatedRequests)
                 {
                     // bypass authentication
                     policy.RequireAssertion(_ => true);
@@ -170,7 +313,7 @@ public static class HostApplicationBuilderExtensions
                 else if (string.IsNullOrEmpty(settings.ClientId))
                 {
                     // No credentials configured: reject all requests. Pass
-                    // skipAuth: true to AddTeams(...) to opt into the bypass
+                    // DangerouslyAllowUnauthenticatedRequests to AddTeams(...) to opt into the bypass
                     // for local development without credentials.
                     policy.RequireAssertion(_ => false);
                 }
@@ -190,6 +333,21 @@ public static class HostApplicationBuilderExtensions
         });
 
         return builder;
+    }
+
+    /// <summary>
+    /// add TeamsJWTScheme for validating incoming SMBA tokens and EntraTokenJWTScheme for validating incoming Entra tokens
+    /// provides Authorization policy TeamsJWTPolicy required by [Authorize(Policy="TeamsJWTPolicy")] in MessageController
+    /// provides Authorization policy EntraTokenJWTPolicy required when Tab invokes remote functions
+    /// </summary>
+    /// <param name="skipAuth">deprecated; use <see cref="AspNetCorePluginOptions.DangerouslyAllowUnauthenticatedRequests"/> instead</param>
+    [Obsolete(SkipAuthObsoleteMessage)]
+    public static IHostApplicationBuilder AddTeamsTokenAuthentication(this IHostApplicationBuilder builder, bool skipAuth)
+    {
+        return builder.AddTeamsTokenAuthentication(new AspNetCorePluginOptions
+        {
+            DangerouslyAllowUnauthenticatedRequests = skipAuth
+        });
     }
 
     /// <summary>

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/UnauthenticatedToken.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/UnauthenticatedToken.cs
@@ -10,9 +10,7 @@ internal sealed class UnauthenticatedToken(string? serviceUrl) : IToken
     public string? AppId => null;
     public string? AppDisplayName => null;
     public string? TenantId => null;
-    public string ServiceUrl { get; } = string.IsNullOrEmpty(serviceUrl)
-        ? "https://smba.trafficmanager.net/teams/"
-        : serviceUrl.EndsWith('/') ? serviceUrl : $"{serviceUrl}/";
+    public string ServiceUrl { get; } = serviceUrl ?? string.Empty;
     public CallerType From => CallerType.Azure;
     public string FromId => "urn:botframework:azure";
     public DateTime? Expiration => null;

--- a/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/UnauthenticatedToken.cs
+++ b/Libraries/Microsoft.Teams.Plugins/Microsoft.Teams.Plugins.AspNetCore/UnauthenticatedToken.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Teams.Api.Auth;
+
+namespace Microsoft.Teams.Plugins.AspNetCore;
+
+internal sealed class UnauthenticatedToken(string? serviceUrl) : IToken
+{
+    public string? AppId => null;
+    public string? AppDisplayName => null;
+    public string? TenantId => null;
+    public string ServiceUrl { get; } = string.IsNullOrEmpty(serviceUrl)
+        ? "https://smba.trafficmanager.net/teams/"
+        : serviceUrl.EndsWith('/') ? serviceUrl : $"{serviceUrl}/";
+    public CallerType From => CallerType.Azure;
+    public string FromId => "urn:botframework:azure";
+    public DateTime? Expiration => null;
+    public bool IsExpired => false;
+    public IEnumerable<string> Scopes => [];
+    public override string ToString() => string.Empty;
+}

--- a/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginTests.cs
+++ b/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Teams.Api;
 using Microsoft.Teams.Api.Activities;
 using Microsoft.Teams.Api.Auth;
@@ -44,6 +45,16 @@ public class AspNetCorePluginTests
         var bytes = Encoding.UTF8.GetBytes(json);
         ctx.Request.Body = new MemoryStream(bytes);
         ctx.Request.ContentLength = bytes.Length;
+        return ctx;
+    }
+
+    private static DefaultHttpContext CreateUnauthenticatedRequestsAllowedHttpContext(IActivity activity)
+    {
+        var ctx = CreateHttpContext(activity);
+        ctx.Request.Headers.Remove("Authorization");
+        ctx.RequestServices = new ServiceCollection()
+            .AddSingleton(new AspNetCorePluginOptions { DangerouslyAllowUnauthenticatedRequests = true })
+            .BuildServiceProvider();
         return ctx;
     }
 
@@ -153,6 +164,30 @@ public class AspNetCorePluginTests
         Assert.Equal(500, problem.StatusCode);
         Assert.Contains("boom", problem.Value!.ToString());
         logger.Verify(l => l.Error(It.IsAny<object[]>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task Test_Do_Http_DangerouslyAllowUnauthenticatedRequests_NoAuthorizationHeader_Processes()
+    {
+        var activity = CreateMessageActivity("https://smba.trafficmanager.net/teams/");
+        var coreResponse = new Response(HttpStatusCode.Accepted, new { ok = true });
+        var eventsCalled = new List<string>();
+
+        EventFunction events = (plugin, name, payload, ct) =>
+        {
+            eventsCalled.Add(name);
+            if (name == "activity") return Task.FromResult<object?>(coreResponse);
+            return Task.FromResult<object?>(null);
+        };
+
+        var plugin = CreatePlugin(new Mock<ILogger>(), events);
+        var ctx = CreateUnauthenticatedRequestsAllowedHttpContext(activity);
+
+        var result = await plugin.Do(ctx);
+
+        Assert.Contains("activity", eventsCalled);
+        var jsonResult = Assert.IsType<Microsoft.AspNetCore.Http.HttpResults.JsonHttpResult<object?>>(result);
+        Assert.Equal((int)coreResponse.Status, jsonResult.StatusCode);
     }
 
     [Fact]

--- a/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginTests.cs
+++ b/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginTests.cs
@@ -190,6 +190,37 @@ public class AspNetCorePluginTests
         Assert.Equal((int)coreResponse.Status, jsonResult.StatusCode);
     }
 
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("https://smba.trafficmanager.net/teams", "https://smba.trafficmanager.net/teams")]
+    public async Task Test_Do_Http_DangerouslyAllowUnauthenticatedRequests_UsesActivityServiceUrlAsTokenServiceUrl(string? activityServiceUrl, string expectedTokenServiceUrl)
+    {
+        var activity = CreateMessageActivity(activityServiceUrl);
+        var coreResponse = new Response(HttpStatusCode.Accepted, new { ok = true });
+        string? tokenServiceUrl = null;
+
+        EventFunction events = (plugin, name, payload, ct) =>
+        {
+            if (name == "activity")
+            {
+                var activityEvent = Assert.IsType<ActivityEvent>(payload);
+                tokenServiceUrl = activityEvent.Token.ServiceUrl;
+                return Task.FromResult<object?>(coreResponse);
+            }
+
+            return Task.FromResult<object?>(null);
+        };
+
+        var plugin = CreatePlugin(new Mock<ILogger>(), events);
+        var ctx = CreateUnauthenticatedRequestsAllowedHttpContext(activity);
+
+        var result = await plugin.Do(ctx);
+
+        var jsonResult = Assert.IsType<Microsoft.AspNetCore.Http.HttpResults.JsonHttpResult<object?>>(result);
+        Assert.Equal((int)coreResponse.Status, jsonResult.StatusCode);
+        Assert.Equal(expectedTokenServiceUrl, tokenServiceUrl);
+    }
+
     [Fact]
     public async Task Test_Do_Http_MissingAuthorizationHeader_ReturnsUnauthorized()
     {

--- a/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginTests.cs
+++ b/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/AspNetCorePluginTests.cs
@@ -191,6 +191,52 @@ public class AspNetCorePluginTests
     }
 
     [Fact]
+    public async Task Test_Do_Http_MissingAuthorizationHeader_ReturnsUnauthorized()
+    {
+        var activity = CreateMessageActivity("https://smba.trafficmanager.net/teams/");
+        var eventsCalled = new List<string>();
+        EventFunction events = (plugin, name, payload, ct) =>
+        {
+            eventsCalled.Add(name);
+            return Task.FromResult<object?>(new Response(HttpStatusCode.OK, new { ok = true }));
+        };
+        var logger = new Mock<ILogger>();
+        var plugin = CreatePlugin(logger, events);
+        var ctx = CreateHttpContext(activity);
+        ctx.Request.Headers.Remove("Authorization");
+
+        var result = await plugin.Do(ctx);
+
+        var unauthorized = Assert.IsType<Microsoft.AspNetCore.Http.HttpResults.UnauthorizedHttpResult>(result);
+        Assert.Equal(401, unauthorized.StatusCode);
+        Assert.DoesNotContain("activity", eventsCalled);
+        logger.Verify(l => l.Warn(It.IsAny<object[]>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Test_Do_Http_InvalidAuthorizationHeader_ReturnsUnauthorized()
+    {
+        var activity = CreateMessageActivity("https://smba.trafficmanager.net/teams/");
+        var eventsCalled = new List<string>();
+        EventFunction events = (plugin, name, payload, ct) =>
+        {
+            eventsCalled.Add(name);
+            return Task.FromResult<object?>(new Response(HttpStatusCode.OK, new { ok = true }));
+        };
+        var logger = new Mock<ILogger>();
+        var plugin = CreatePlugin(logger, events);
+        var ctx = CreateHttpContext(activity);
+        ctx.Request.Headers.Authorization = "Bearer not-a-jwt";
+
+        var result = await plugin.Do(ctx);
+
+        var unauthorized = Assert.IsType<Microsoft.AspNetCore.Http.HttpResults.UnauthorizedHttpResult>(result);
+        Assert.Equal(401, unauthorized.StatusCode);
+        Assert.DoesNotContain("activity", eventsCalled);
+        logger.Verify(l => l.Warn(It.IsAny<object[]>()), Times.Once);
+    }
+
+    [Fact]
     public void Test_ExtractToken_ReturnsToken()
     {
         var plugin = CreatePlugin();

--- a/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/Extensions/HostApplicationBuilderTests.cs
+++ b/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/Extensions/HostApplicationBuilderTests.cs
@@ -41,7 +41,7 @@ public class HostApplicationBuilderTests
 
 
     [Fact]
-    public async Task AddTeamsTokenAuthentication_ShouldSkipJwtAuthentication_WhenClientIdIsMissing()
+    public async Task AddTeamsTokenAuthentication_ShouldRejectRequests_WhenClientIdIsMissing()
     {
         var builder = WebApplication.CreateBuilder();
         var mockSettings = new Dictionary<string, string?>
@@ -49,19 +49,20 @@ public class HostApplicationBuilderTests
             ["Teams:ClientId"] = null,
         };
         builder.Configuration.AddInMemoryCollection(mockSettings);
-        builder.AddTeams(skipAuth: false);
+        builder.AddTeams();
         var services = builder.Build().Services;
         var authOptions = services.GetRequiredService<IAuthorizationPolicyProvider>();
+        var pluginOptions = services.GetRequiredService<AspNetCorePluginOptions>();
 
         var policy = await authOptions.GetPolicyAsync(TeamsTokenAuthConstants.AuthorizationPolicy);
 
-        // Should allow all requests
         Assert.NotNull(policy);
         Assert.True(policy.Requirements.OfType<AssertionRequirement>().Any());
+        Assert.False(pluginOptions.DangerouslyAllowUnauthenticatedRequests);
     }
 
     [Fact]
-    public async Task AddTeamsTokenAuthentication_ShouldSkipJwtAuthentication_WhenWithSkipIsTrue()
+    public async Task AddTeamsTokenAuthentication_ShouldAllowUnauthenticatedRequests_WhenDangerouslyAllowed()
     {
         var builder = WebApplication.CreateBuilder();
         var mockSettings = new Dictionary<string, string?>
@@ -69,15 +70,62 @@ public class HostApplicationBuilderTests
             ["Teams:ClientId"] = "test-client-id",
         };
         builder.Configuration.AddInMemoryCollection(mockSettings);
-        builder.AddTeams(skipAuth: true);
+        builder.AddTeams(new AspNetCorePluginOptions { DangerouslyAllowUnauthenticatedRequests = true });
         var services = builder.Build().Services;
         var authOptions = services.GetRequiredService<IAuthorizationPolicyProvider>();
+        var pluginOptions = services.GetRequiredService<AspNetCorePluginOptions>();
 
         var policy = await authOptions.GetPolicyAsync(TeamsTokenAuthConstants.AuthorizationPolicy);
 
         // Should allow all requests
         Assert.NotNull(policy);
         Assert.True(policy.Requirements.OfType<AssertionRequirement>().Any());
+        Assert.True(pluginOptions.DangerouslyAllowUnauthenticatedRequests);
+    }
+
+    [Fact]
+    public async Task AddTeamsTokenAuthentication_ShouldAllowUnauthenticatedRequests_WhenConfigured()
+    {
+        var builder = WebApplication.CreateBuilder();
+        var mockSettings = new Dictionary<string, string?>
+        {
+            ["Teams:ClientId"] = "test-client-id",
+            ["Teams:DangerouslyAllowUnauthenticatedRequests"] = "true",
+        };
+        builder.Configuration.AddInMemoryCollection(mockSettings);
+        builder.AddTeams();
+        var services = builder.Build().Services;
+        var authOptions = services.GetRequiredService<IAuthorizationPolicyProvider>();
+        var pluginOptions = services.GetRequiredService<AspNetCorePluginOptions>();
+
+        var policy = await authOptions.GetPolicyAsync(TeamsTokenAuthConstants.AuthorizationPolicy);
+
+        Assert.NotNull(policy);
+        Assert.True(policy.Requirements.OfType<AssertionRequirement>().Any());
+        Assert.True(pluginOptions.DangerouslyAllowUnauthenticatedRequests);
+    }
+
+    [Fact]
+    public async Task AddTeamsTokenAuthentication_ShouldAllowUnauthenticatedRequests_WhenObsoleteSkipAuthIsTrue()
+    {
+        var builder = WebApplication.CreateBuilder();
+        var mockSettings = new Dictionary<string, string?>
+        {
+            ["Teams:ClientId"] = "test-client-id",
+        };
+        builder.Configuration.AddInMemoryCollection(mockSettings);
+#pragma warning disable CS0618 // Verifies backward compatibility for the deprecated skipAuth parameter.
+        builder.AddTeams(skipAuth: true);
+#pragma warning restore CS0618
+        var services = builder.Build().Services;
+        var authOptions = services.GetRequiredService<IAuthorizationPolicyProvider>();
+        var pluginOptions = services.GetRequiredService<AspNetCorePluginOptions>();
+
+        var policy = await authOptions.GetPolicyAsync(TeamsTokenAuthConstants.AuthorizationPolicy);
+
+        Assert.NotNull(policy);
+        Assert.True(policy.Requirements.OfType<AssertionRequirement>().Any());
+        Assert.True(pluginOptions.DangerouslyAllowUnauthenticatedRequests);
     }
 
     [Fact]

--- a/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/Extensions/HostApplicationBuilderTests.cs
+++ b/Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/Extensions/HostApplicationBuilderTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Infrastructure;
@@ -52,12 +54,15 @@ public class HostApplicationBuilderTests
         builder.AddTeams();
         var services = builder.Build().Services;
         var authOptions = services.GetRequiredService<IAuthorizationPolicyProvider>();
+        var authorizationService = services.GetRequiredService<IAuthorizationService>();
         var pluginOptions = services.GetRequiredService<AspNetCorePluginOptions>();
 
         var policy = await authOptions.GetPolicyAsync(TeamsTokenAuthConstants.AuthorizationPolicy);
+        var result = await authorizationService.AuthorizeAsync(new ClaimsPrincipal(), null, policy!);
 
         Assert.NotNull(policy);
         Assert.True(policy.Requirements.OfType<AssertionRequirement>().Any());
+        Assert.False(result.Succeeded);
         Assert.False(pluginOptions.DangerouslyAllowUnauthenticatedRequests);
     }
 
@@ -73,13 +78,16 @@ public class HostApplicationBuilderTests
         builder.AddTeams(new AspNetCorePluginOptions { DangerouslyAllowUnauthenticatedRequests = true });
         var services = builder.Build().Services;
         var authOptions = services.GetRequiredService<IAuthorizationPolicyProvider>();
+        var authorizationService = services.GetRequiredService<IAuthorizationService>();
         var pluginOptions = services.GetRequiredService<AspNetCorePluginOptions>();
 
         var policy = await authOptions.GetPolicyAsync(TeamsTokenAuthConstants.AuthorizationPolicy);
+        var result = await authorizationService.AuthorizeAsync(new ClaimsPrincipal(), null, policy!);
 
         // Should allow all requests
         Assert.NotNull(policy);
         Assert.True(policy.Requirements.OfType<AssertionRequirement>().Any());
+        Assert.True(result.Succeeded);
         Assert.True(pluginOptions.DangerouslyAllowUnauthenticatedRequests);
     }
 
@@ -96,12 +104,15 @@ public class HostApplicationBuilderTests
         builder.AddTeams();
         var services = builder.Build().Services;
         var authOptions = services.GetRequiredService<IAuthorizationPolicyProvider>();
+        var authorizationService = services.GetRequiredService<IAuthorizationService>();
         var pluginOptions = services.GetRequiredService<AspNetCorePluginOptions>();
 
         var policy = await authOptions.GetPolicyAsync(TeamsTokenAuthConstants.AuthorizationPolicy);
+        var result = await authorizationService.AuthorizeAsync(new ClaimsPrincipal(), null, policy!);
 
         Assert.NotNull(policy);
         Assert.True(policy.Requirements.OfType<AssertionRequirement>().Any());
+        Assert.True(result.Succeeded);
         Assert.True(pluginOptions.DangerouslyAllowUnauthenticatedRequests);
     }
 
@@ -119,12 +130,15 @@ public class HostApplicationBuilderTests
 #pragma warning restore CS0618
         var services = builder.Build().Services;
         var authOptions = services.GetRequiredService<IAuthorizationPolicyProvider>();
+        var authorizationService = services.GetRequiredService<IAuthorizationService>();
         var pluginOptions = services.GetRequiredService<AspNetCorePluginOptions>();
 
         var policy = await authOptions.GetPolicyAsync(TeamsTokenAuthConstants.AuthorizationPolicy);
+        var result = await authorizationService.AuthorizeAsync(new ClaimsPrincipal(), null, policy!);
 
         Assert.NotNull(policy);
         Assert.True(policy.Requirements.OfType<AssertionRequirement>().Any());
+        Assert.True(result.Succeeded);
         Assert.True(pluginOptions.DangerouslyAllowUnauthenticatedRequests);
     }
 

--- a/core/src/Microsoft.Teams.Core/Hosting/AuthenticationNotConfiguredHandler.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/AuthenticationNotConfiguredHandler.cs
@@ -14,6 +14,12 @@ internal sealed class AuthenticationNotConfiguredHandler(
     ILoggerFactory logger,
     UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
 {
+    private static readonly Action<ILogger, Exception?> _logAuthenticationNotConfigured =
+        LoggerMessage.Define(
+            LogLevel.Warning,
+            new EventId(1, "AuthenticationNotConfigured"),
+            "Authentication is not configured. Configure ClientId or enable DangerouslyAllowUnauthenticatedRequests for local development.");
+
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
         return Task.FromResult(AuthenticateResult.Fail("Authentication not configured"));
@@ -21,10 +27,11 @@ internal sealed class AuthenticationNotConfiguredHandler(
 
     protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
     {
+        _logAuthenticationNotConfigured(Logger, null);
+
         await Results.Problem(
             statusCode: StatusCodes.Status401Unauthorized,
-            title: "Authentication not configured",
-            detail: "Configure ClientId or enable DangerouslyAllowUnauthenticatedRequests for local development."
+            title: "Authentication not configured"
         ).ExecuteAsync(Context).ConfigureAwait(false);
     }
 }

--- a/core/src/Microsoft.Teams.Core/Hosting/AuthenticationNotConfiguredHandler.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/AuthenticationNotConfiguredHandler.cs
@@ -21,8 +21,10 @@ internal sealed class AuthenticationNotConfiguredHandler(
 
     protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
     {
-        Response.StatusCode = StatusCodes.Status401Unauthorized;
-        Response.ContentType = "application/json";
-        await Response.WriteAsync("{\"error\":\"Authentication not configured\"}").ConfigureAwait(false);
+        await Results.Problem(
+            statusCode: StatusCodes.Status401Unauthorized,
+            title: "Authentication not configured",
+            detail: "Configure ClientId or enable DangerouslyAllowUnauthenticatedRequests for local development."
+        ).ExecuteAsync(Context).ConfigureAwait(false);
     }
 }

--- a/core/src/Microsoft.Teams.Core/Hosting/AuthenticationNotConfiguredHandler.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/AuthenticationNotConfiguredHandler.cs
@@ -4,6 +4,7 @@
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Teams.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -14,12 +15,6 @@ internal sealed class AuthenticationNotConfiguredHandler(
     ILoggerFactory logger,
     UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
 {
-    private static readonly Action<ILogger, Exception?> _logAuthenticationNotConfigured =
-        LoggerMessage.Define(
-            LogLevel.Warning,
-            new EventId(1, "AuthenticationNotConfigured"),
-            "Authentication is not configured. Configure ClientId or enable DangerouslyAllowUnauthenticatedRequests for local development.");
-
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
         return Task.FromResult(AuthenticateResult.Fail("Authentication not configured"));
@@ -27,7 +22,7 @@ internal sealed class AuthenticationNotConfiguredHandler(
 
     protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
     {
-        _logAuthenticationNotConfigured(Logger, null);
+        Logger.AuthenticationNotConfigured(Scheme.Name);
 
         await Results.Problem(
             statusCode: StatusCodes.Status401Unauthorized,

--- a/core/src/Microsoft.Teams.Core/Hosting/AuthenticationNotConfiguredHandler.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/AuthenticationNotConfiguredHandler.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Teams.Core.Hosting;
+
+internal sealed class AuthenticationNotConfiguredHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        return Task.FromResult(AuthenticateResult.Fail("Authentication not configured"));
+    }
+
+    protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
+    {
+        Response.StatusCode = StatusCodes.Status401Unauthorized;
+        Response.ContentType = "application/json";
+        await Response.WriteAsync("{\"error\":\"Authentication not configured\"}").ConfigureAwait(false);
+    }
+}

--- a/core/src/Microsoft.Teams.Core/Hosting/BotConfig.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/BotConfig.cs
@@ -17,6 +17,10 @@ public sealed class BotConfig
 
     internal const string BotFrameworkSectionName = "BotFramework";
 
+    private const string TeamsSectionName = "Teams";
+
+    private const string DangerouslyAllowUnauthenticatedRequestsKey = "DangerouslyAllowUnauthenticatedRequests";
+
     internal const string DefaultOpenIdMetadataUrl = "https://login.botframework.com/v1/.well-known/openid-configuration";
 
     internal const string DefaultEntraInstance = "https://login.microsoftonline.com/";
@@ -65,6 +69,12 @@ public sealed class BotConfig
     /// </summary>
     public string BotTokenIssuer { get; set; } = DefaultBotTokenIssuer;
 
+    /// <summary>
+    /// Gets or sets whether inbound bot requests should bypass authentication.
+    /// This should only be enabled for local development.
+    /// </summary>
+    public bool DangerouslyAllowUnauthenticatedRequests { get; set; }
+
     internal IConfigurationSection? MsalConfigurationSection { get; set; }
 
     /// <summary>
@@ -96,6 +106,10 @@ public sealed class BotConfig
 
         IConfigurationSection section = configuration.GetSection(sectionName);
         IConfigurationSection botFrameworkSection = configuration.GetSection(BotFrameworkSectionName);
+        bool dangerouslyAllowUnauthenticatedRequests =
+            ResolveOptionalBoolean(section, DangerouslyAllowUnauthenticatedRequestsKey)
+            ?? ResolveOptionalBoolean(configuration.GetSection(TeamsSectionName), DangerouslyAllowUnauthenticatedRequestsKey)
+            ?? false;
         BotConfig config = new()
         {
             TenantId = section["TenantId"] ?? string.Empty,
@@ -103,6 +117,7 @@ public sealed class BotConfig
             EntraInstance = ResolveAbsoluteUri(section, "Instance", DefaultEntraInstance),
             OpenIdMetadataUrl = ResolveAbsoluteUri(botFrameworkSection, "OpenIdMetadataUrl", DefaultOpenIdMetadataUrl),
             BotTokenIssuer = ResolveAbsoluteUri(botFrameworkSection, "BotTokenIssuer", DefaultBotTokenIssuer),
+            DangerouslyAllowUnauthenticatedRequests = dangerouslyAllowUnauthenticatedRequests,
             MsalConfigurationSection = section,
             SectionName = sectionName
         };
@@ -116,6 +131,25 @@ public sealed class BotConfig
         }, typeof(BotConfig));
 
         return config;
+    }
+
+    private static bool? ResolveOptionalBoolean(IConfigurationSection section, string key)
+    {
+        ArgumentNullException.ThrowIfNull(section);
+
+        string? value = section[key];
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (bool.TryParse(value, out bool result))
+        {
+            return result;
+        }
+
+        throw new InvalidOperationException(
+            $"Configuration value '{section.Path}:{key}' is not a valid boolean: '{value}'.");
     }
 
     private static string ResolveAbsoluteUri(IConfigurationSection section, string key, string defaultValue)

--- a/core/src/Microsoft.Teams.Core/Hosting/BotConfig.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/BotConfig.cs
@@ -17,8 +17,6 @@ public sealed class BotConfig
 
     internal const string BotFrameworkSectionName = "BotFramework";
 
-    private const string TeamsSectionName = "Teams";
-
     private const string DangerouslyAllowUnauthenticatedRequestsKey = "DangerouslyAllowUnauthenticatedRequests";
 
     internal const string DefaultOpenIdMetadataUrl = "https://login.botframework.com/v1/.well-known/openid-configuration";
@@ -93,6 +91,11 @@ public sealed class BotConfig
     /// <returns>A BotConfig populated from the section, or an empty BotConfig if no ClientId is configured.</returns>
     public static BotConfig Resolve(IServiceCollection services, string sectionName = DefaultSectionName)
     {
+        return Resolve(services, sectionName, log: true);
+    }
+
+    internal static BotConfig Resolve(IServiceCollection services, string sectionName, bool log)
+    {
         ArgumentNullException.ThrowIfNull(services);
 
         IConfiguration? configuration = AddBotApplicationExtensions.ResolveFromServicesPreHost<IConfiguration>(services);
@@ -108,7 +111,6 @@ public sealed class BotConfig
         IConfigurationSection botFrameworkSection = configuration.GetSection(BotFrameworkSectionName);
         bool dangerouslyAllowUnauthenticatedRequests =
             ResolveOptionalBoolean(section, DangerouslyAllowUnauthenticatedRequestsKey)
-            ?? ResolveOptionalBoolean(configuration.GetSection(TeamsSectionName), DangerouslyAllowUnauthenticatedRequestsKey)
             ?? false;
         BotConfig config = new()
         {
@@ -122,13 +124,18 @@ public sealed class BotConfig
             SectionName = sectionName
         };
 
-        AddBotApplicationExtensions.LogFromServices(services, l =>
+        if (log)
         {
-            if (!string.IsNullOrEmpty(config.ClientId))
-                _logUsingSectionConfig(l, sectionName, null);
-            else
-                _logNoConfigFound(l, null);
-        }, typeof(BotConfig));
+            AddBotApplicationExtensions.LogFromServices(services, l =>
+            {
+                if (config.DangerouslyAllowUnauthenticatedRequests)
+                    l.BypassAuthenticationConfigured(sectionName);
+                else if (!string.IsNullOrEmpty(config.ClientId))
+                    _logUsingSectionConfig(l, sectionName, null);
+                else
+                    l.AuthenticationNotConfigured(sectionName);
+            }, typeof(BotConfig));
+        }
 
         return config;
     }
@@ -171,7 +178,4 @@ public sealed class BotConfig
 
     private static readonly Action<ILogger, string, Exception?> _logUsingSectionConfig =
         LoggerMessage.Define<string>(LogLevel.Debug, new(3), "Resolved bot configuration from '{SectionName}' configuration section");
-    private static readonly Action<ILogger, Exception?> _logNoConfigFound =
-        LoggerMessage.Define(LogLevel.Warning, new(4), "No bot configuration found in configuration.");
-
 }

--- a/core/src/Microsoft.Teams.Core/Hosting/JwtExtensions.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/JwtExtensions.cs
@@ -79,7 +79,12 @@ namespace Microsoft.Teams.Core.Hosting
         {
             ArgumentNullException.ThrowIfNull(builder);
 
-            if (string.IsNullOrWhiteSpace(clientId))
+            BotConfig? botConfig = ResolveBotConfig(builder.Services, schemeName);
+            if (botConfig?.DangerouslyAllowUnauthenticatedRequests == true)
+            {
+                builder.AddBypassAuthentication(schemeName, logger);
+            }
+            else if (string.IsNullOrWhiteSpace(clientId))
             {
                 builder.AddAuthenticationNotConfigured(schemeName);
             }
@@ -206,7 +211,7 @@ namespace Microsoft.Teams.Core.Hosting
 
         /// <summary>
         /// Overload that accepts an already-resolved <see cref="BotConfig"/> to avoid a redundant
-        /// <see cref="BotConfig.Resolve"/> call during internal registration paths.
+        /// BotConfig resolution call during internal registration paths.
         /// </summary>
         private static AuthenticationBuilder AddTeamsJwtBearer(this AuthenticationBuilder builder, BotConfig botConfig, ILogger? logger = null)
         {
@@ -228,7 +233,7 @@ namespace Microsoft.Teams.Core.Hosting
             }
             else if (string.IsNullOrWhiteSpace(botConfig.ClientId))
             {
-                builder.AddAuthenticationNotConfigured(botConfig.SectionName);
+                builder.AddAuthenticationNotConfiguredScheme(botConfig.SectionName);
             }
             else
             {
@@ -238,7 +243,20 @@ namespace Microsoft.Teams.Core.Hosting
             return builder;
         }
 
+        private static BotConfig? ResolveBotConfig(IServiceCollection services, string sectionName)
+        {
+            return services.Any(d => d.ServiceType == typeof(IConfiguration))
+                ? BotConfig.Resolve(services, sectionName, log: false)
+                : null;
+        }
+
         private static AuthenticationBuilder AddAuthenticationNotConfigured(this AuthenticationBuilder builder, string schemeName)
+        {
+            AddBotApplicationExtensions.LogFromServices(builder.Services, l => l.AuthenticationNotConfigured(schemeName));
+            return builder.AddAuthenticationNotConfiguredScheme(schemeName);
+        }
+
+        private static AuthenticationBuilder AddAuthenticationNotConfiguredScheme(this AuthenticationBuilder builder, string schemeName)
         {
             builder.AddScheme<AuthenticationSchemeOptions, AuthenticationNotConfiguredHandler>(schemeName, _ => { });
             return builder;
@@ -252,9 +270,9 @@ namespace Microsoft.Teams.Core.Hosting
             string botOidcUrl = BotConfig.DefaultOpenIdMetadataUrl;
             string entraInstance = BotConfig.DefaultEntraInstance;
             string botTokenIssuer = BotConfig.DefaultBotTokenIssuer;
-            if (builder.Services.Any(d => d.ServiceType == typeof(IConfiguration)))
+            BotConfig? botConfig = ResolveBotConfig(builder.Services, schemeName);
+            if (botConfig is not null)
             {
-                BotConfig botConfig = BotConfig.Resolve(builder.Services, schemeName);
                 botOidcUrl = botConfig.OpenIdMetadataUrl;
                 entraInstance = botConfig.EntraInstance;
                 botTokenIssuer = botConfig.BotTokenIssuer;

--- a/core/src/Microsoft.Teams.Core/Hosting/JwtExtensions.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/JwtExtensions.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Teams.Core.Hosting
             // BotConfig.Resolve call (and duplicate startup log) that would occur through the
             // public string-based AddBotAuthentication → AddTeamsJwtBearer chain.
             AuthenticationBuilder authBuilder = services.AddAuthentication();
-            if (string.IsNullOrWhiteSpace(botConfig.ClientId))
+            if (botConfig.DangerouslyAllowUnauthenticatedRequests || string.IsNullOrWhiteSpace(botConfig.ClientId))
             {
                 authBuilder.AddBypassAuthentication(botConfig.SectionName, logger);
             }

--- a/core/src/Microsoft.Teams.Core/Hosting/JwtExtensions.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/JwtExtensions.cs
@@ -34,7 +34,9 @@ namespace Microsoft.Teams.Core.Hosting
         public static AuthenticationBuilder AddBotAuthentication(this IServiceCollection services, string aadSectionName = BotConfig.DefaultSectionName, ILogger? logger = null)
         {
             BotConfig botConfig = BotConfig.Resolve(services, aadSectionName);
-            return services.AddBotAuthentication(botConfig.ClientId, botConfig.TenantId, aadSectionName, logger);
+            AuthenticationBuilder builder = services.AddAuthentication();
+            builder.AddBotAuthentication(botConfig, logger);
+            return builder;
         }
 
         /// <summary>
@@ -79,7 +81,7 @@ namespace Microsoft.Teams.Core.Hosting
 
             if (string.IsNullOrWhiteSpace(clientId))
             {
-                builder.AddBypassAuthentication(schemeName, logger);
+                builder.AddAuthenticationNotConfigured(schemeName);
             }
             else
             {
@@ -118,14 +120,7 @@ namespace Microsoft.Teams.Core.Hosting
             // BotConfig.Resolve call (and duplicate startup log) that would occur through the
             // public string-based AddBotAuthentication → AddTeamsJwtBearer chain.
             AuthenticationBuilder authBuilder = services.AddAuthentication();
-            if (botConfig.DangerouslyAllowUnauthenticatedRequests || string.IsNullOrWhiteSpace(botConfig.ClientId))
-            {
-                authBuilder.AddBypassAuthentication(botConfig.SectionName, logger);
-            }
-            else
-            {
-                authBuilder.AddTeamsJwtBearer(botConfig, logger);
-            }
+            authBuilder.AddBotAuthentication(botConfig, logger);
 
             return services
                 .AddAuthorizationBuilder()
@@ -223,6 +218,30 @@ namespace Microsoft.Teams.Core.Hosting
                 botConfig.EntraInstance,
                 botConfig.BotTokenIssuer,
                 logger);
+        }
+
+        private static AuthenticationBuilder AddBotAuthentication(this AuthenticationBuilder builder, BotConfig botConfig, ILogger? logger = null)
+        {
+            if (botConfig.DangerouslyAllowUnauthenticatedRequests)
+            {
+                builder.AddBypassAuthentication(botConfig.SectionName, logger);
+            }
+            else if (string.IsNullOrWhiteSpace(botConfig.ClientId))
+            {
+                builder.AddAuthenticationNotConfigured(botConfig.SectionName);
+            }
+            else
+            {
+                builder.AddTeamsJwtBearer(botConfig, logger);
+            }
+
+            return builder;
+        }
+
+        private static AuthenticationBuilder AddAuthenticationNotConfigured(this AuthenticationBuilder builder, string schemeName)
+        {
+            builder.AddScheme<AuthenticationSchemeOptions, AuthenticationNotConfiguredHandler>(schemeName, _ => { });
+            return builder;
         }
 
         private static AuthenticationBuilder AddTeamsJwtBearer(this AuthenticationBuilder builder, string schemeName, string audience, string tenantId, ILogger? logger = null)

--- a/core/src/Microsoft.Teams.Core/Log.cs
+++ b/core/src/Microsoft.Teams.Core/Log.cs
@@ -105,11 +105,14 @@ internal static partial class Log
     [LoggerMessage(EventId = 54, Level = LogLevel.Error, Message = "JWT authentication failed for scheme {Scheme}: {ExceptionMessage} | token iss={TokenIssuer} aud={TokenAudience} exp={TokenExpiration} sub={TokenSubject} | expected aud={ConfiguredAudience}")]
     public static partial void JwtAuthenticationFailed(this ILogger logger, Exception ex, string scheme, string exceptionMessage, string tokenIssuer, string tokenAudience, string tokenExpiration, string tokenSubject, string configuredAudience);
 
-    [LoggerMessage(EventId = 55, Level = LogLevel.Warning, Message = "ClientId not provided for scheme '{SchemeName}'. Configuring bypass authentication (no token validation). This is INSECURE and should only be used for development.")]
+    [LoggerMessage(EventId = 55, Level = LogLevel.Warning, Message = "DangerouslyAllowUnauthenticatedRequests is enabled for scheme '{SchemeName}'. Configuring bypass authentication with no token validation. This is INSECURE and should only be used for development.")]
     public static partial void BypassAuthenticationConfigured(this ILogger logger, string schemeName);
 
     [LoggerMessage(EventId = 56, Level = LogLevel.Warning, Message = "Using bypass authentication scheme succeeded for scheme: {Scheme}. This is INSECURE and should only be used for development.")]
     public static partial void BypassAuthenticationSucceeded(this ILogger logger, string scheme);
+
+    [LoggerMessage(EventId = 57, Level = LogLevel.Warning, Message = "Authentication is not configured for scheme '{SchemeName}'. Configure ClientId or enable DangerouslyAllowUnauthenticatedRequests for local development.")]
+    public static partial void AuthenticationNotConfigured(this ILogger logger, string schemeName);
 
     // ── Hosting (UMI inference) ─────────────────────────────────────────
 

--- a/core/test/Microsoft.Teams.Core.UnitTests/Hosting/BotConfigTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Hosting/BotConfigTests.cs
@@ -145,26 +145,11 @@ public class BotConfigTests
     }
 
     [Fact]
-    public void Resolve_DangerouslyAllowUnauthenticatedRequests_FallsBackToTeamsSection()
+    public void Resolve_DangerouslyAllowUnauthenticatedRequests_IgnoresTeamsSection()
     {
         ServiceCollection services = BuildServices(new Dictionary<string, string?>
         {
             ["AzureAd:ClientId"] = "client-id",
-            ["Teams:DangerouslyAllowUnauthenticatedRequests"] = "true",
-        });
-
-        BotConfig config = BotConfig.Resolve(services);
-
-        Assert.True(config.DangerouslyAllowUnauthenticatedRequests);
-    }
-
-    [Fact]
-    public void Resolve_DangerouslyAllowUnauthenticatedRequests_ConfiguredSectionOverridesTeamsSection()
-    {
-        ServiceCollection services = BuildServices(new Dictionary<string, string?>
-        {
-            ["AzureAd:ClientId"] = "client-id",
-            ["AzureAd:DangerouslyAllowUnauthenticatedRequests"] = "false",
             ["Teams:DangerouslyAllowUnauthenticatedRequests"] = "true",
         });
 

--- a/core/test/Microsoft.Teams.Core.UnitTests/Hosting/BotConfigTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Hosting/BotConfigTests.cs
@@ -131,6 +131,49 @@ public class BotConfigTests
     }
 
     [Fact]
+    public void Resolve_DangerouslyAllowUnauthenticatedRequests_HonorsConfiguredSection()
+    {
+        ServiceCollection services = BuildServices(new Dictionary<string, string?>
+        {
+            ["AzureAd:ClientId"] = "client-id",
+            ["AzureAd:DangerouslyAllowUnauthenticatedRequests"] = "true",
+        });
+
+        BotConfig config = BotConfig.Resolve(services);
+
+        Assert.True(config.DangerouslyAllowUnauthenticatedRequests);
+    }
+
+    [Fact]
+    public void Resolve_DangerouslyAllowUnauthenticatedRequests_FallsBackToTeamsSection()
+    {
+        ServiceCollection services = BuildServices(new Dictionary<string, string?>
+        {
+            ["AzureAd:ClientId"] = "client-id",
+            ["Teams:DangerouslyAllowUnauthenticatedRequests"] = "true",
+        });
+
+        BotConfig config = BotConfig.Resolve(services);
+
+        Assert.True(config.DangerouslyAllowUnauthenticatedRequests);
+    }
+
+    [Fact]
+    public void Resolve_DangerouslyAllowUnauthenticatedRequests_ConfiguredSectionOverridesTeamsSection()
+    {
+        ServiceCollection services = BuildServices(new Dictionary<string, string?>
+        {
+            ["AzureAd:ClientId"] = "client-id",
+            ["AzureAd:DangerouslyAllowUnauthenticatedRequests"] = "false",
+            ["Teams:DangerouslyAllowUnauthenticatedRequests"] = "true",
+        });
+
+        BotConfig config = BotConfig.Resolve(services);
+
+        Assert.False(config.DangerouslyAllowUnauthenticatedRequests);
+    }
+
+    [Fact]
     public void Resolve_ThrowsInvalidOperationException_WhenOpenIdMetadataUrlIsNotAbsoluteUri()
     {
         ServiceCollection services = BuildServices(new Dictionary<string, string?>
@@ -167,6 +210,19 @@ public class BotConfigTests
 
         InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => BotConfig.Resolve(services));
         Assert.Contains("AzureAd:Instance", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Resolve_ThrowsInvalidOperationException_WhenDangerouslyAllowUnauthenticatedRequestsIsNotBoolean()
+    {
+        ServiceCollection services = BuildServices(new Dictionary<string, string?>
+        {
+            ["AzureAd:ClientId"] = "client-id",
+            ["AzureAd:DangerouslyAllowUnauthenticatedRequests"] = "not-a-bool",
+        });
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => BotConfig.Resolve(services));
+        Assert.Contains("AzureAd:DangerouslyAllowUnauthenticatedRequests", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/core/test/Microsoft.Teams.Core.UnitTests/Hosting/JwtExtensionsTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Hosting/JwtExtensionsTests.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Teams.Core.Hosting;
@@ -189,5 +192,34 @@ public class JwtExtensionsTests
         Exception? caught = Record.Exception(() => services.AddBotAuthentication(ClientId, Tenant));
 
         Assert.Null(caught);
+    }
+
+    [Fact]
+    public async Task AddBotAuthorization_DangerouslyAllowUnauthenticatedRequests_AuthenticatesWithoutAuthorizationHeader()
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AzureAd:ClientId"] = ClientId,
+                ["AzureAd:TenantId"] = Tenant,
+                ["AzureAd:DangerouslyAllowUnauthenticatedRequests"] = "true",
+            })
+            .Build();
+
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddLogging();
+        services.AddBotAuthorization();
+
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+        DefaultHttpContext httpContext = new()
+        {
+            RequestServices = serviceProvider
+        };
+
+        AuthenticateResult result = await httpContext.AuthenticateAsync("AzureAd");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("BypassAuth", result.Principal?.Identity?.AuthenticationType);
     }
 }

--- a/core/test/Microsoft.Teams.Core.UnitTests/Hosting/JwtExtensionsTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Hosting/JwtExtensionsTests.cs
@@ -253,7 +253,13 @@ public class JwtExtensionsTests
         string body = await new StreamReader(responseBody).ReadToEndAsync();
         Assert.False(result.Succeeded);
         Assert.Equal(StatusCodes.Status401Unauthorized, httpContext.Response.StatusCode);
-        Assert.Equal("application/json", httpContext.Response.ContentType);
-        Assert.Equal("{\"error\":\"Authentication not configured\"}", body);
+        Assert.Equal("application/problem+json", httpContext.Response.ContentType);
+
+        using JsonDocument problem = JsonDocument.Parse(body);
+        Assert.Equal("Authentication not configured", problem.RootElement.GetProperty("title").GetString());
+        Assert.Equal(StatusCodes.Status401Unauthorized, problem.RootElement.GetProperty("status").GetInt32());
+        Assert.Equal(
+            "Configure ClientId or enable DangerouslyAllowUnauthenticatedRequests for local development.",
+            problem.RootElement.GetProperty("detail").GetString());
     }
 }

--- a/core/test/Microsoft.Teams.Core.UnitTests/Hosting/JwtExtensionsTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Hosting/JwtExtensionsTests.cs
@@ -196,6 +196,35 @@ public class JwtExtensionsTests
     }
 
     [Fact]
+    public async Task AddBotAuthentication_ManualOverload_DangerouslyAllowUnauthenticatedRequests_AuthenticatesWithoutAuthorizationHeader()
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AzureAd:ClientId"] = ClientId,
+                ["AzureAd:TenantId"] = Tenant,
+                ["AzureAd:DangerouslyAllowUnauthenticatedRequests"] = "true",
+            })
+            .Build();
+
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddLogging();
+        services.AddBotAuthentication(ClientId, Tenant);
+
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+        DefaultHttpContext httpContext = new()
+        {
+            RequestServices = serviceProvider
+        };
+
+        AuthenticateResult result = await httpContext.AuthenticateAsync("AzureAd");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("BypassAuth", result.Principal?.Identity?.AuthenticationType);
+    }
+
+    [Fact]
     public async Task AddBotAuthorization_DangerouslyAllowUnauthenticatedRequests_AuthenticatesWithoutAuthorizationHeader()
     {
         IConfigurationRoot configuration = new ConfigurationBuilder()
@@ -239,6 +268,9 @@ public class JwtExtensionsTests
         services.AddSingleton<IConfiguration>(configuration);
         services.AddLogging(builder => builder.AddProvider(loggerProvider));
         services.AddBotAuthorization();
+        Assert.Contains(
+            "Authentication is not configured for scheme 'AzureAd'. Configure ClientId or enable DangerouslyAllowUnauthenticatedRequests for local development.",
+            loggerProvider.Messages);
 
         using ServiceProvider serviceProvider = services.BuildServiceProvider();
         await using MemoryStream responseBody = new();
@@ -262,7 +294,7 @@ public class JwtExtensionsTests
         Assert.Equal(StatusCodes.Status401Unauthorized, problem.RootElement.GetProperty("status").GetInt32());
         Assert.False(problem.RootElement.TryGetProperty("detail", out _));
         Assert.Contains(
-            "Authentication is not configured. Configure ClientId or enable DangerouslyAllowUnauthenticatedRequests for local development.",
+            "Authentication is not configured for scheme 'AzureAd'. Configure ClientId or enable DangerouslyAllowUnauthenticatedRequests for local development.",
             loggerProvider.Messages);
     }
 

--- a/core/test/Microsoft.Teams.Core.UnitTests/Hosting/JwtExtensionsTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Hosting/JwtExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.JsonWebTokens;
@@ -234,8 +235,9 @@ public class JwtExtensionsTests
             .Build();
 
         ServiceCollection services = new();
+        ListLoggerProvider loggerProvider = new();
         services.AddSingleton<IConfiguration>(configuration);
-        services.AddLogging();
+        services.AddLogging(builder => builder.AddProvider(loggerProvider));
         services.AddBotAuthorization();
 
         using ServiceProvider serviceProvider = services.BuildServiceProvider();
@@ -258,8 +260,50 @@ public class JwtExtensionsTests
         using JsonDocument problem = JsonDocument.Parse(body);
         Assert.Equal("Authentication not configured", problem.RootElement.GetProperty("title").GetString());
         Assert.Equal(StatusCodes.Status401Unauthorized, problem.RootElement.GetProperty("status").GetInt32());
-        Assert.Equal(
-            "Configure ClientId or enable DangerouslyAllowUnauthenticatedRequests for local development.",
-            problem.RootElement.GetProperty("detail").GetString());
+        Assert.False(problem.RootElement.TryGetProperty("detail", out _));
+        Assert.Contains(
+            "Authentication is not configured. Configure ClientId or enable DangerouslyAllowUnauthenticatedRequests for local development.",
+            loggerProvider.Messages);
+    }
+
+    private sealed class ListLoggerProvider : ILoggerProvider
+    {
+        public List<string> Messages { get; } = [];
+
+        public ILogger CreateLogger(string categoryName) => new ListLogger(Messages);
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class ListLogger(List<string> messages) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                messages.Add(formatter(state, exception));
+            }
+        }
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/core/test/Microsoft.Teams.Core.UnitTests/Hosting/JwtExtensionsTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Hosting/JwtExtensionsTests.cs
@@ -222,4 +222,38 @@ public class JwtExtensionsTests
         Assert.True(result.Succeeded);
         Assert.Equal("BypassAuth", result.Principal?.Identity?.AuthenticationType);
     }
+
+    [Fact]
+    public async Task AddBotAuthorization_NoClientId_ChallengesWithAuthenticationNotConfigured()
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AzureAd:TenantId"] = Tenant,
+            })
+            .Build();
+
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddLogging();
+        services.AddBotAuthorization();
+
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+        await using MemoryStream responseBody = new();
+        DefaultHttpContext httpContext = new()
+        {
+            RequestServices = serviceProvider
+        };
+        httpContext.Response.Body = responseBody;
+
+        AuthenticateResult result = await httpContext.AuthenticateAsync("AzureAd");
+        await httpContext.ChallengeAsync("AzureAd");
+
+        responseBody.Position = 0;
+        string body = await new StreamReader(responseBody).ReadToEndAsync();
+        Assert.False(result.Succeeded);
+        Assert.Equal(StatusCodes.Status401Unauthorized, httpContext.Response.StatusCode);
+        Assert.Equal("application/json", httpContext.Response.ContentType);
+        Assert.Equal("{\"error\":\"Authentication not configured\"}", body);
+    }
 }


### PR DESCRIPTION
## Summary
- Deprecate `skipAuth` in favor of `DangerouslyAllowUnauthenticatedRequests` while preserving compatibility.
- Allow unauthenticated `/api/messages` requests without parsing a bearer token when the dangerous bypass is enabled in the AspNetCore plugin path. This currently prevents 2.0 from being used for agents playground.
- Support `DangerouslyAllowUnauthenticatedRequests` via `Teams` config/env and the core `TeamsBotApplication` auth path, including `AzureAd` section support.

## Behavior
- When `DangerouslyAllowUnauthenticatedRequests` is enabled, unauthenticated requests are accepted without requiring or parsing the `Authorization` header.
- When `ClientId` is missing and the dangerous bypass is not enabled, requests are rejected with `401` ProblemDetails containing only the generic `Authentication not configured` title/status.
- The remediation guidance to configure `ClientId` or enable `DangerouslyAllowUnauthenticatedRequests` is logged server-side and is not returned in the HTTP response body.

## Validation
- `dotnet test Tests/Microsoft.Teams.Plugins.AspNetCore.Tests/Microsoft.Teams.Plugins.AspNetCore.Tests.csproj --verbosity minimal`
- `dotnet test core/test/Microsoft.Teams.Core.UnitTests/Microsoft.Teams.Core.UnitTests.csproj --verbosity minimal`
- `dotnet build Microsoft.Teams.sln --verbosity minimal`