### PR TITLE
Accept botid audience for agentic inbound tokens

### DIFF
--- a/core/src/Microsoft.Teams.Core/Hosting/JwtExtensions.cs
+++ b/core/src/Microsoft.Teams.Core/Hosting/JwtExtensions.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Teams.Core.Hosting
                     RequireSignedTokens = true,
                     ValidateIssuer = true,
                     ValidateAudience = true,
-                    ValidAudiences = [audience, $"api://{audience}"],
+                    ValidAudiences = [audience, $"api://{audience}", $"api://botid-{audience}"],
                     IssuerValidator = (issuer, token, _) => ValidateTeamsIssuer(issuer, token, tenantId, entraInstance, botTokenIssuer),
                     IssuerSigningKeyResolver = (_, securityToken, _, _) =>
                     {

--- a/core/test/Microsoft.Teams.Core.UnitTests/Hosting/JwtExtensionsTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Hosting/JwtExtensionsTests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Teams.Core.Hosting;
@@ -189,5 +191,22 @@ public class JwtExtensionsTests
         Exception? caught = Record.Exception(() => services.AddBotAuthentication(ClientId, Tenant));
 
         Assert.Null(caught);
+    }
+
+    [Fact]
+    public void AddBotAuthentication_ConfiguresExpectedInboundAudiences()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddBotAuthentication(ClientId, Tenant);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        JwtBearerOptions options = provider
+            .GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+            .Get(BotConfig.DefaultSectionName);
+
+        Assert.Equal(
+            [ClientId, $"api://{ClientId}", $"api://botid-{ClientId}"],
+            options.TokenValidationParameters.ValidAudiences);
     }
 }


### PR DESCRIPTION
## Summary
- Add `api://botid-{clientId}` to Core JWT valid audiences for inbound Teams tokens.
- Cover the configured inbound audience list in `JwtExtensions` unit tests so app ID, `api://{clientId}`, and `api://botid-{clientId}` are all expected.

## Validation
- `dotnet build core/src/Microsoft.Teams.Core/Microsoft.Teams.Core.csproj --no-restore --verbosity minimal`
- `dotnet test core/test/Microsoft.Teams.Core.UnitTests/Microsoft.Teams.Core.UnitTests.csproj --no-restore --verbosity minimal`