### PR TITLE
docs(samples): note npm CFS proxy for TabApp Web build

### DIFF
--- a/core/samples/TabApp/README.md
+++ b/core/samples/TabApp/README.md
@@ -107,3 +107,5 @@ cd Web && npm install && npm run build
 # Run the bot
 dotnet run
 ```
+
+> **Microsoft-managed devices:** direct access to `registry.npmjs.org` is blocked, so `npm install` may fail. Your machine should already default to the Central Feed Services (CFS) proxy; if not, follow the setup instructions at [aka.ms/CFS](https://aka.ms/CFS). External contributors are unaffected.


### PR DESCRIPTION
## What

Adds a note to `core/samples/TabApp/README.md` under Build & Run.

## Why

The TabApp Web frontend (React/Vite) uses `npm install`, which is blocked on Microsoft-managed devices. The .NET SDK release build is unaffected (NuGet) — this is purely a dev-time sample note.

## Notes

- Links to [aka.ms/CFS](https://aka.ms/CFS); external contributors unaffected.
- No internal feed URL committed.
