### PR TITLE
Require explicit serviceUrl for Core activity APIs

### DIFF
--- a/core/samples/A2ABot/A2A/A2AServer.cs
+++ b/core/samples/A2ABot/A2A/A2AServer.cs
@@ -73,7 +73,7 @@ internal sealed class A2AServer(
             .WithServiceUrl(serviceUrl)
             .WithConversation(new TeamsConversation { Id = newConvId })
             .Build();
-        SendActivityResponse? sent = await conversations.SendActivityAsync(proactive, cancellationToken: ct);
+        SendActivityResponse? sent = await conversations.SendActivityAsync(proactive, serviceUrl, cancellationToken: ct);
         logger.LogInformation("[{Bot}/A2A] proactive greeting sent (conv={ConvId}, activityId={ActivityId})",
             config.Name, newConvId, sent?.Id ?? "<none>");
 

--- a/core/samples/AFBot/Program.cs
+++ b/core/samples/AFBot/Program.cs
@@ -40,12 +40,11 @@ botApp.OnActivity = async (activity, cancellationToken) =>
 
     CoreActivity typing = CoreActivity.CreateBuilder()
         .WithType(ActivityType.Typing)
-        .WithServiceUrl(activity.ServiceUrl!)
         .WithChannelId(activity.ChannelId!)
         .WithConversation(activity.Conversation!)
         .WithFrom(activity.Recipient)
         .Build();
-    await botApp.SendActivityAsync(typing, cancellationToken: cancellationToken);
+    await botApp.SendActivityAsync(typing, activity.ServiceUrl!, cancellationToken: cancellationToken);
 
     AgentRunResponse agentResponse = await agent.RunAsync(activity.Properties["text"]?.ToString() ?? "OMW", cancellationToken: timer.Token);
 
@@ -53,14 +52,13 @@ botApp.OnActivity = async (activity, cancellationToken) =>
     Console.WriteLine($"AI:: GOT {agentResponse.Messages.Count} msgs");
     CoreActivity replyActivity = CoreActivity.CreateBuilder()
         .WithType(ActivityType.Message)
-        .WithServiceUrl(activity.ServiceUrl!)
         .WithChannelId(activity.ChannelId!)
         .WithConversation(activity.Conversation!)
         .WithFrom(activity.Recipient)
         .WithProperty("text", m1!.Text)
         .Build();
 
-    SendActivityResponse? res = await botApp.SendActivityAsync(replyActivity, cancellationToken: cancellationToken);
+    SendActivityResponse? res = await botApp.SendActivityAsync(replyActivity, activity.ServiceUrl!, cancellationToken: cancellationToken);
 
     Console.WriteLine("SENT >>> => " + res?.Id);
 };

--- a/core/samples/CompatBot/EchoBot.cs
+++ b/core/samples/CompatBot/EchoBot.cs
@@ -84,11 +84,12 @@ internal class EchoBot(BotApplication teamsBotApp, ConversationState conversatio
             .WithProperty("text", "Hello TM !")
             .WithRecipient(incomingFrom)
             .WithFrom(incomingRecipient)
-            //.WithServiceUrl(activity.ServiceUrl!)
-            .WithServiceUrl("https://pilot1.botapi.skype.com/amer/9a9b49fd-1dc5-4217-88b3-ecf855e91b0e/")
             .Build();
 
-        await teamsBotApp.ConversationClient.SendActivityAsync(tm, cancellationToken: cancellationToken);
+        await teamsBotApp.ConversationClient.SendActivityAsync(
+            tm,
+            new Uri("https://pilot1.botapi.skype.com/amer/9a9b49fd-1dc5-4217-88b3-ecf855e91b0e/"),
+            cancellationToken: cancellationToken);
 
         ResourceResponse res = await turnContext.SendActivityAsync(
             MessageFactory.Text("I'm going to add and remove reactions to this message."), cancellationToken);

--- a/core/samples/CoreBot/Program.cs
+++ b/core/samples/CoreBot/Program.cs
@@ -19,13 +19,12 @@ botApp.OnActivity = async (activity, cancellationToken) =>
     CoreActivity replyActivity = CoreActivity.CreateBuilder()
         .WithType(ActivityType.Message)
         .WithChannelId(activity.ChannelId)
-        .WithServiceUrl(activity.ServiceUrl)
         .WithConversation(activity.Conversation)
         .WithFrom(activity.Recipient)
         .WithProperty("text", replyText)
         .Build();
 
-    await botApp.SendActivityAsync(replyActivity, cancellationToken: cancellationToken);
+    await botApp.SendActivityAsync(replyActivity, activity.ServiceUrl!, cancellationToken: cancellationToken);
 };
 
 webApp.Run();

--- a/core/samples/McpServer/McpTools.cs
+++ b/core/samples/McpServer/McpTools.cs
@@ -29,7 +29,7 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
             .WithConversation(new Conversation(conversationId))
             .WithText(message)
             .Build();
-        await app.SendActivityAsync(notifyActivity, cancellationToken);
+        await app.SendActivityAsync(notifyActivity, state.ServiceUrl, cancellationToken);
         return new NotifyResult(Notified: true, UserId: userId);
     }
 
@@ -53,7 +53,7 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
             .Build();
         try
         {
-            await app.SendActivityAsync(askActivity, cancellationToken);
+            await app.SendActivityAsync(askActivity, state.ServiceUrl, cancellationToken);
         }
         catch
         {
@@ -139,7 +139,7 @@ public sealed class McpTools(TeamsBotApplication app, State state, IConfiguratio
         state.Approvals[approvalId] = ApprovalStatus.Pending;
         try
         {
-            await app.SendActivityAsync(activity, cancellationToken);
+            await app.SendActivityAsync(activity, state.ServiceUrl, cancellationToken);
         }
         catch
         {

--- a/core/samples/Proactive/Worker.cs
+++ b/core/samples/Proactive/Worker.cs
@@ -19,12 +19,11 @@ public class Worker(ConversationClient conversationClient, ILogger<Worker> logge
             if (logger.IsEnabled(LogLevel.Information))
             {
                 CoreActivity proactiveMessage = CoreActivity.CreateBuilder()
-                    .WithServiceUrl(new Uri(ServiceUrl))
                     .WithConversation(new(ConversationId))
                     .Build();
                 proactiveMessage.From = new ChannelAccount { Id = FromId };
                 proactiveMessage.Properties["text"] = $"Proactive hello at {DateTimeOffset.Now}";
-                SendActivityResponse? aid = await conversationClient.SendActivityAsync(proactiveMessage, cancellationToken: stoppingToken);
+                SendActivityResponse? aid = await conversationClient.SendActivityAsync(proactiveMessage, new Uri(ServiceUrl), cancellationToken: stoppingToken);
                 logger.LogInformation("Activity {Aid} sent", aid?.Id ?? "unknown");
             }
             await Task.Delay(1000, stoppingToken);

--- a/core/samples/TabApp/Program.cs
+++ b/core/samples/TabApp/Program.cs
@@ -84,7 +84,7 @@ app.MapPost("/functions/post-to-chat", async (
         .WithServiceUrl(serviceUrl)
         .WithConversation(new TeamsConversation { Id = conversationId! })
         .Build();
-    await conversations.SendActivityAsync(activity, cancellationToken: ct);
+    await conversations.SendActivityAsync(activity, serviceUrl, cancellationToken: ct);
 
     return Results.Json(new PostToChatResult(Ok: true));
 }).RequireAuthorization();

--- a/core/samples/TeamsBot/WelcomeMessageMiddleware.cs
+++ b/core/samples/TeamsBot/WelcomeMessageMiddleware.cs
@@ -45,7 +45,7 @@ internal class WelcomeMessageMiddleware : ITurnMiddleware
                 .WithConversationReference(TeamsActivity.FromActivity(activity))
                 .Build();
 
-            await botApplication.SendActivityAsync(welcomeActivity, cancellationToken: cancellationToken);
+            await botApplication.SendActivityAsync(welcomeActivity, activity.ServiceUrl!, cancellationToken);
 
             _hasSentWelcomeMessage = true;
         }

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/CompatConversations.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/CompatConversations.cs
@@ -232,20 +232,15 @@ namespace Microsoft.Teams.Apps.BotBuilder
 
         public async Task<HttpOperationResponse<ResourceResponse>> ReplyToActivityWithHttpMessagesAsync(string conversationId, string activityId, Activity activity, Dictionary<string, List<string>>? customHeaders = null, CancellationToken cancellationToken = default)
         {
+            ArgumentException.ThrowIfNullOrWhiteSpace(ServiceUrl);
             Dictionary<string, string>? convertedHeaders = ConvertHeaders(customHeaders);
 
             CoreActivity coreActivity = activity.FromBotFrameworkActivity();
 
-            // Default to the ServiceUrl from the adapter if it's not set on the activity, as ConversationClient requires it for sending activities
-            if (!string.IsNullOrWhiteSpace(ServiceUrl) && coreActivity.ServiceUrl == null)
-            {
-                coreActivity.ServiceUrl = new Uri(ServiceUrl);
-            }
-
             coreActivity.ReplyToId = activityId;
             coreActivity.Conversation = new Microsoft.Teams.Core.Schema.Conversation(conversationId);
 
-            SendActivityResponse? response = await _client.SendActivityAsync(coreActivity, requestContext: RequestContext, customHeaders: convertedHeaders, cancellationToken: cancellationToken).ConfigureAwait(false);
+            SendActivityResponse? response = await _client.SendActivityAsync(coreActivity, new Uri(ServiceUrl), requestContext: RequestContext, customHeaders: convertedHeaders, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             ResourceResponse resourceResponse = new()
             {
@@ -303,19 +298,14 @@ namespace Microsoft.Teams.Apps.BotBuilder
         /// </returns>
         public async Task<HttpOperationResponse<ResourceResponse>> SendToConversationWithHttpMessagesAsync(string conversationId, Activity activity, Dictionary<string, List<string>>? customHeaders = null, CancellationToken cancellationToken = default)
         {
+            ArgumentException.ThrowIfNullOrWhiteSpace(ServiceUrl);
             Dictionary<string, string>? convertedHeaders = ConvertHeaders(customHeaders);
 
             CoreActivity coreActivity = activity.FromBotFrameworkActivity();
 
-            // Default to the ServiceUrl from the adapter if it's not set on the activity, as ConversationClient requires it for sending activities
-            if (!string.IsNullOrWhiteSpace(ServiceUrl) && coreActivity.ServiceUrl == null)
-            {
-                coreActivity.ServiceUrl = new Uri(ServiceUrl);
-            }
-
             coreActivity.Conversation = new Microsoft.Teams.Core.Schema.Conversation(conversationId);
 
-            SendActivityResponse? response = await _client.SendActivityAsync(coreActivity, requestContext: RequestContext, customHeaders: convertedHeaders, cancellationToken: cancellationToken).ConfigureAwait(false);
+            SendActivityResponse? response = await _client.SendActivityAsync(coreActivity, new Uri(ServiceUrl), requestContext: RequestContext, customHeaders: convertedHeaders, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             ResourceResponse resourceResponse = new()
             {
@@ -343,20 +333,16 @@ namespace Microsoft.Teams.Apps.BotBuilder
         /// </returns>
         public async Task<HttpOperationResponse<ResourceResponse>> UpdateActivityWithHttpMessagesAsync(string conversationId, string activityId, Activity activity, Dictionary<string, List<string>>? customHeaders = null, CancellationToken cancellationToken = default)
         {
+            ArgumentException.ThrowIfNullOrWhiteSpace(ServiceUrl);
             Dictionary<string, string>? convertedHeaders = ConvertHeaders(customHeaders);
 
             CoreActivity coreActivity = activity.FromBotFrameworkActivity();
-
-            // Default to the ServiceUrl from the adapter if it's not set on the activity, as ConversationClient requires it for updating activities
-            if (!string.IsNullOrWhiteSpace(ServiceUrl) && coreActivity.ServiceUrl == null)
-            {
-                coreActivity.ServiceUrl = new Uri(ServiceUrl);
-            }
 
             UpdateActivityResponse response = await _client.UpdateActivityAsync(
                 conversationId,
                 activityId,
                 coreActivity,
+                new Uri(ServiceUrl),
                 requestContext: RequestContext,
                 customHeaders: convertedHeaders,
                 cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/CompatConversations.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/CompatConversations.cs
@@ -232,7 +232,6 @@ namespace Microsoft.Teams.Apps.BotBuilder
 
         public async Task<HttpOperationResponse<ResourceResponse>> ReplyToActivityWithHttpMessagesAsync(string conversationId, string activityId, Activity activity, Dictionary<string, List<string>>? customHeaders = null, CancellationToken cancellationToken = default)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(ServiceUrl);
             Dictionary<string, string>? convertedHeaders = ConvertHeaders(customHeaders);
 
             CoreActivity coreActivity = activity.FromBotFrameworkActivity();
@@ -240,7 +239,7 @@ namespace Microsoft.Teams.Apps.BotBuilder
             coreActivity.ReplyToId = activityId;
             coreActivity.Conversation = new Microsoft.Teams.Core.Schema.Conversation(conversationId);
 
-            SendActivityResponse? response = await _client.SendActivityAsync(coreActivity, new Uri(ServiceUrl), requestContext: RequestContext, customHeaders: convertedHeaders, cancellationToken: cancellationToken).ConfigureAwait(false);
+            SendActivityResponse? response = await _client.SendActivityAsync(coreActivity, ResolveActivityServiceUrl(activity, "reply to activities"), requestContext: RequestContext, customHeaders: convertedHeaders, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             ResourceResponse resourceResponse = new()
             {
@@ -298,14 +297,13 @@ namespace Microsoft.Teams.Apps.BotBuilder
         /// </returns>
         public async Task<HttpOperationResponse<ResourceResponse>> SendToConversationWithHttpMessagesAsync(string conversationId, Activity activity, Dictionary<string, List<string>>? customHeaders = null, CancellationToken cancellationToken = default)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(ServiceUrl);
             Dictionary<string, string>? convertedHeaders = ConvertHeaders(customHeaders);
 
             CoreActivity coreActivity = activity.FromBotFrameworkActivity();
 
             coreActivity.Conversation = new Microsoft.Teams.Core.Schema.Conversation(conversationId);
 
-            SendActivityResponse? response = await _client.SendActivityAsync(coreActivity, new Uri(ServiceUrl), requestContext: RequestContext, customHeaders: convertedHeaders, cancellationToken: cancellationToken).ConfigureAwait(false);
+            SendActivityResponse? response = await _client.SendActivityAsync(coreActivity, ResolveActivityServiceUrl(activity, "send activities"), requestContext: RequestContext, customHeaders: convertedHeaders, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             ResourceResponse resourceResponse = new()
             {
@@ -333,7 +331,6 @@ namespace Microsoft.Teams.Apps.BotBuilder
         /// </returns>
         public async Task<HttpOperationResponse<ResourceResponse>> UpdateActivityWithHttpMessagesAsync(string conversationId, string activityId, Activity activity, Dictionary<string, List<string>>? customHeaders = null, CancellationToken cancellationToken = default)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(ServiceUrl);
             Dictionary<string, string>? convertedHeaders = ConvertHeaders(customHeaders);
 
             CoreActivity coreActivity = activity.FromBotFrameworkActivity();
@@ -342,7 +339,7 @@ namespace Microsoft.Teams.Apps.BotBuilder
                 conversationId,
                 activityId,
                 coreActivity,
-                new Uri(ServiceUrl),
+                ResolveActivityServiceUrl(activity, "update activities"),
                 requestContext: RequestContext,
                 customHeaders: convertedHeaders,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -406,6 +403,20 @@ namespace Microsoft.Teams.Apps.BotBuilder
             }
 
             return convertedHeaders;
+        }
+
+        private Uri ResolveActivityServiceUrl(Activity activity, string operation)
+        {
+            string? serviceUrl = !string.IsNullOrWhiteSpace(activity.ServiceUrl)
+                ? activity.ServiceUrl
+                : ServiceUrl;
+
+            if (string.IsNullOrWhiteSpace(serviceUrl))
+            {
+                throw new InvalidOperationException($"ServiceUrl is required to {operation}.");
+            }
+
+            return new Uri(serviceUrl);
         }
 
         public async Task<HttpOperationResponse<Microsoft.Bot.Schema.ChannelAccount>> GetConversationMemberWithHttpMessagesAsync(string userId, string conversationId, Dictionary<string, List<string>> customHeaders = null!, CancellationToken cancellationToken = default)

--- a/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsBotAdapter.cs
+++ b/core/src/Microsoft.Teams.Apps.BotBuilder/TeamsBotAdapter.cs
@@ -105,17 +105,21 @@ public class TeamsBotAdapter(
 
             CoreActivity coreActivity = activity.FromBotFrameworkActivity();
 
-            // Ensure ServiceUrl is set from turn context if not already present
-            if (coreActivity.ServiceUrl == null && !string.IsNullOrWhiteSpace(inboundActivity.ServiceUrl))
+            string? serviceUrlString = !string.IsNullOrWhiteSpace(activity.ServiceUrl)
+                ? activity.ServiceUrl
+                : inboundActivity.ServiceUrl;
+            if (string.IsNullOrWhiteSpace(serviceUrlString))
             {
-                coreActivity.ServiceUrl = new Uri(inboundActivity.ServiceUrl);
+                throw new InvalidOperationException("ServiceUrl is required to send activities.");
             }
+            Uri serviceUrl = new(serviceUrlString);
 
             coreActivity.Conversation ??= new Microsoft.Teams.Core.Schema.Conversation(
                 inboundActivity.Conversation?.Id
                 ?? throw new InvalidOperationException("Conversation ID is required to send activities."));
             SendActivityResponse? resp = await botApplication.ConversationClient.SendActivityAsync(
                 coreActivity,
+                serviceUrl,
                 requestContext,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -143,16 +147,20 @@ public class TeamsBotAdapter(
 
         CoreActivity coreActivity = activity.FromBotFrameworkActivity();
 
-        // Ensure ServiceUrl is set from turn context if not already present
-        if (coreActivity.ServiceUrl == null && !string.IsNullOrWhiteSpace(turnContext.Activity.ServiceUrl))
+        string? serviceUrlString = !string.IsNullOrWhiteSpace(activity.ServiceUrl)
+            ? activity.ServiceUrl
+            : turnContext.Activity.ServiceUrl;
+        if (string.IsNullOrWhiteSpace(serviceUrlString))
         {
-            coreActivity.ServiceUrl = new Uri(turnContext.Activity.ServiceUrl);
+            throw new InvalidOperationException("ServiceUrl is required to update activities.");
         }
+        Uri serviceUrl = new(serviceUrlString);
 
         UpdateActivityResponse res = await botApplication.ConversationClient.UpdateActivityAsync(
             activity.Conversation.Id,
             activity.Id,
             coreActivity,
+            serviceUrl,
             requestContext: BotRequestContext.FromInboundActivity(turnContext.Activity?.FromBotFrameworkActivity()),
             cancellationToken: cancellationToken).ConfigureAwait(false);
         return new ResourceResponse() { Id = res.Id };

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ActivityClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ActivityClient.cs
@@ -32,9 +32,8 @@ public class ActivityClient
     public Task<SendActivityResponse?> CreateAsync(string conversationId, CoreActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        activity.ServiceUrl ??= _serviceUrl;
         activity.Conversation ??= new Conversation(conversationId);
-        return _client.SendActivityAsync(activity, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.SendActivityAsync(activity, _serviceUrl, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -43,8 +42,7 @@ public class ActivityClient
     public Task<UpdateActivityResponse> UpdateAsync(string conversationId, string id, CoreActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        activity.ServiceUrl ??= _serviceUrl;
-        return _client.UpdateActivityAsync(conversationId, id, activity, requestContext: BotRequestContext.FromActivity(activity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.UpdateActivityAsync(conversationId, id, activity, _serviceUrl, requestContext: BotRequestContext.FromActivity(activity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -54,9 +52,8 @@ public class ActivityClient
     {
         ArgumentNullException.ThrowIfNull(activity);
         activity.ReplyToId = id;
-        activity.ServiceUrl ??= _serviceUrl;
         activity.Conversation ??= new Conversation(conversationId);
-        return _client.SendActivityAsync(activity, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.SendActivityAsync(activity, _serviceUrl, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -75,14 +72,13 @@ public class ActivityClient
     public Task<SendActivityResponse?> CreateTargetedAsync(string conversationId, CoreActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        activity.ServiceUrl ??= _serviceUrl;
         activity.Conversation ??= new Conversation(conversationId);
         // Ensure recipient is marked as targeted
         if (activity.Recipient is not null)
         {
             activity.Recipient.IsTargeted = true;
         }
-        return _client.SendActivityAsync(activity, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.SendActivityAsync(activity, _serviceUrl, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -92,8 +88,7 @@ public class ActivityClient
     public Task<UpdateActivityResponse> UpdateTargetedAsync(string conversationId, string id, CoreActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        activity.ServiceUrl ??= _serviceUrl;
-        return _client.UpdateTargetedActivityAsync(conversationId, id, activity, requestContext: BotRequestContext.FromActivity(activity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.UpdateTargetedActivityAsync(conversationId, id, activity, _serviceUrl, requestContext: BotRequestContext.FromActivity(activity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs
+++ b/core/src/Microsoft.Teams.Apps/Api/Clients/ConversationApiClient.cs
@@ -66,9 +66,8 @@ public class ConversationApiClient
     public Task<SendActivityResponse?> CreateActivityAsync(string conversationId, CoreActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        activity.ServiceUrl ??= _serviceUrl;
         activity.Conversation ??= new Conversation(conversationId);
-        return _client.SendActivityAsync(activity, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.SendActivityAsync(activity, _serviceUrl, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -77,8 +76,7 @@ public class ConversationApiClient
     public Task<UpdateActivityResponse> UpdateActivityAsync(string conversationId, string id, CoreActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        activity.ServiceUrl ??= _serviceUrl;
-        return _client.UpdateActivityAsync(conversationId, id, activity, requestContext: BotRequestContext.FromActivity(activity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.UpdateActivityAsync(conversationId, id, activity, _serviceUrl, requestContext: BotRequestContext.FromActivity(activity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -88,9 +86,8 @@ public class ConversationApiClient
     {
         ArgumentNullException.ThrowIfNull(activity);
         activity.ReplyToId = id;
-        activity.ServiceUrl ??= _serviceUrl;
         activity.Conversation ??= new Conversation(conversationId);
-        return _client.SendActivityAsync(activity, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.SendActivityAsync(activity, _serviceUrl, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -109,13 +106,12 @@ public class ConversationApiClient
     public Task<SendActivityResponse?> CreateTargetedActivityAsync(string conversationId, CoreActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        activity.ServiceUrl ??= _serviceUrl;
         activity.Conversation ??= new Conversation(conversationId);
         if (activity.Recipient is not null)
         {
             activity.Recipient.IsTargeted = true;
         }
-        return _client.SendActivityAsync(activity, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.SendActivityAsync(activity, _serviceUrl, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -125,8 +121,7 @@ public class ConversationApiClient
     public Task<UpdateActivityResponse> UpdateTargetedActivityAsync(string conversationId, string id, CoreActivity activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        activity.ServiceUrl ??= _serviceUrl;
-        return _client.UpdateTargetedActivityAsync(conversationId, id, activity, requestContext: BotRequestContext.FromActivity(activity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.UpdateTargetedActivityAsync(conversationId, id, activity, _serviceUrl, requestContext: BotRequestContext.FromActivity(activity), customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -29,6 +29,9 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// </summary>
     public TActivity Activity { get; } = activity;
 
+    private Uri ServiceUrl => Activity.ServiceUrl
+        ?? throw new InvalidOperationException("Activity.ServiceUrl is required.");
+
     /// <summary>
     /// Gets the application (client) ID configured for this bot.
     /// </summary>
@@ -48,8 +51,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <summary>
     /// Gets the <see cref="ApiClient"/> scoped to the current activity's service URL.
     /// </summary>
-    public ApiClient Api => _api ??= TeamsBotApplication.Api.ForServiceUrl(
-        Activity.ServiceUrl ?? throw new InvalidOperationException("Activity.ServiceUrl is required to use the Api client."));
+    public ApiClient Api => _api ??= TeamsBotApplication.Api.ForServiceUrl(ServiceUrl);
 
     // ==================== Turn State ====================
 
@@ -260,7 +262,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
         TeamsActivity reply = new TeamsActivityBuilder(activity)
             .WithConversationReference(Activity)
             .Build();
-        return TeamsBotApplication.SendActivityAsync(reply, cancellationToken: cancellationToken);
+        return TeamsBotApplication.SendActivityAsync(reply, ServiceUrl, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -274,7 +276,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
             .WithType(TeamsActivityTypes.Typing)
             .WithConversationReference(Activity)
             .Build();
-        return TeamsBotApplication.SendActivityAsync(reply, cancellationToken: cancellationToken);
+        return TeamsBotApplication.SendActivityAsync(reply, ServiceUrl, cancellationToken: cancellationToken);
     }
 
     // ==================== OAuth Sign-In ====================

--- a/core/src/Microsoft.Teams.Apps/Schema/TeamsActivityBuilder.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/TeamsActivityBuilder.cs
@@ -28,6 +28,28 @@ public class TeamsActivityBuilder : CoreActivityBuilder<TeamsActivity, TeamsActi
     }
 
     /// <summary>
+    /// Sets the service URL.
+    /// </summary>
+    /// <param name="serviceUrl">The service URL.</param>
+    /// <returns>The builder instance for chaining.</returns>
+    public TeamsActivityBuilder WithServiceUrl(Uri? serviceUrl)
+    {
+        _activity.ServiceUrl = serviceUrl;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the service URL from a string.
+    /// </summary>
+    /// <param name="serviceUrlString">The service URL as a string.</param>
+    /// <returns>The builder instance for chaining.</returns>
+    public TeamsActivityBuilder WithServiceUrl(string serviceUrlString)
+    {
+        _activity.ServiceUrl = new Uri(serviceUrlString);
+        return this;
+    }
+
+    /// <summary>
     /// Apply Conversation Reference from the specified activity.
     /// </summary>
     /// <param name="activity">The source activity to copy conversation reference from.</param>

--- a/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
@@ -222,7 +222,7 @@ public class TeamsBotApplication : BotApplication
 
         TeamsActivity activity = builder.Build();
 
-        return SendActivityAsync(activity, cancellationToken: cancellationToken);
+        return SendActivityAsync(activity, resolvedUrl, cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/core/src/Microsoft.Teams.Apps/TeamsStreamingWriter.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsStreamingWriter.cs
@@ -54,6 +54,7 @@ public sealed class TeamsStreamingWriter
     private readonly ConversationClient _client;
     private readonly TeamsActivity _reference;
     private readonly string _conversationId;
+    private readonly Uri _serviceUrl;
     private readonly ILogger _logger;
     // Assigned from the server's 201 response after the first send; null until then.
     private string? _streamId;
@@ -80,6 +81,7 @@ public sealed class TeamsStreamingWriter
         _client = client;
         _reference = reference;
         _conversationId = reference.Conversation?.Id ?? throw new ArgumentException("Activity must have a Conversation with an Id.", nameof(reference));
+        _serviceUrl = reference.ServiceUrl ?? throw new ArgumentException("Activity must have a ServiceUrl.", nameof(reference));
         _logger = logger ?? NullLogger.Instance;
     }
 
@@ -218,7 +220,7 @@ public sealed class TeamsStreamingWriter
 
         try
         {
-            await _client.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await _client.SendActivityAsync(activity, _serviceUrl, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
         catch (HttpRequestException ex)
         {
@@ -255,7 +257,7 @@ public sealed class TeamsStreamingWriter
     {
         try
         {
-            return await _client.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await _client.SendActivityAsync(activity, _serviceUrl, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
         catch (HttpRequestException ex)
         {
@@ -348,12 +350,12 @@ public sealed class TeamsStreamingWriter
         if (_streamId != null)
         {
             _logger.LogDebug("Updating original streamed message in place after timeout (streamId '{StreamId}').", _streamId);
-            await _client.UpdateActivityAsync(_conversationId, _streamId, activity, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await _client.UpdateActivityAsync(_conversationId, _streamId, activity, _serviceUrl, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
         else
         {
             // No streamed message exists yet; send the buffered content as a normal message.
-            await _client.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await _client.SendActivityAsync(activity, _serviceUrl, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/core/src/Microsoft.Teams.Core/BotApplication.cs
+++ b/core/src/Microsoft.Teams.Core/BotApplication.cs
@@ -35,10 +35,10 @@ namespace Microsoft.Teams.Core;
 ///         CoreActivity.CreateBuilder()
 ///             .WithType(ActivityType.Message)
 ///             .WithConversation(activity.Conversation)
-///             .WithServiceUrl(activity.ServiceUrl)
-///             .WithProperty("text", "Hello!")
-///             .Build(),
-///         ct);
+///                     .WithProperty("text", "Hello!")
+///                     .Build(),
+///                 activity.ServiceUrl!,
+///                 ct);
 /// };
 ///
 /// app.Run();
@@ -64,9 +64,9 @@ namespace Microsoft.Teams.Core;
 ///                 CoreActivity.CreateBuilder()
 ///                     .WithType(ActivityType.Message)
 ///                     .WithConversation(activity.Conversation)
-///                     .WithServiceUrl(activity.ServiceUrl)
 ///                     .WithProperty("text", $"You said: {activity.Properties["text"]}")
 ///                     .Build(),
+///                 activity.ServiceUrl!,
 ///                 ct);
 ///         }
 ///     }
@@ -153,9 +153,9 @@ public class BotApplication
     ///             CoreActivity.CreateBuilder()
     ///                 .WithType(ActivityType.Message)
     ///                 .WithConversation(activity.Conversation)
-    ///                 .WithServiceUrl(activity.ServiceUrl)
     ///                 .WithProperty("text", "Received your message!")
     ///                 .Build(),
+    ///             activity.ServiceUrl!,
     ///             ct);
     ///     }
     /// };
@@ -287,31 +287,32 @@ public class BotApplication
     /// </summary>
     /// <remarks>
     /// This is a convenience wrapper around <see cref="ConversationClient.SendActivityAsync"/>. The activity
-    /// must have its <see cref="CoreActivity.Conversation"/> and <see cref="CoreActivity.ServiceUrl"/> properties set.
+    /// must have its <see cref="CoreActivity.Conversation"/> property set.
     /// <example>
     /// <code>
     /// var reply = CoreActivity.CreateBuilder()
     ///     .WithType(ActivityType.Message)
     ///     .WithConversation(incomingActivity.Conversation)
-    ///     .WithServiceUrl(incomingActivity.ServiceUrl)
     ///     .WithProperty("text", "Hello from the bot!")
     ///     .Build();
     ///
-    /// SendActivityResponse? response = await bot.SendActivityAsync(reply, cancellationToken);
+    /// SendActivityResponse? response = await bot.SendActivityAsync(reply, incomingActivity.ServiceUrl!, cancellationToken);
     /// string? sentId = response?.Id;
     /// </code>
     /// </example>
     /// </remarks>
-    /// <param name="activity">The activity to send. Cannot be null. Must have <see cref="CoreActivity.Conversation"/> and <see cref="CoreActivity.ServiceUrl"/> set.</param>
+    /// <param name="activity">The activity to send. Cannot be null. Must have <see cref="CoreActivity.Conversation"/> set.</param>
+    /// <param name="serviceUrl">The service URL for the conversation. Cannot be null.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the send operation.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="SendActivityResponse"/> with the ID of the sent activity, or null.</returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="activity"/> is null or the conversation client has not been initialized.</exception>
-    public async Task<SendActivityResponse?> SendActivityAsync(CoreActivity activity, CancellationToken cancellationToken = default)
+    public async Task<SendActivityResponse?> SendActivityAsync(CoreActivity activity, Uri serviceUrl, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
+        ArgumentNullException.ThrowIfNull(serviceUrl);
         ArgumentNullException.ThrowIfNull(_conversationClient, "ConversationClient not initialized");
 
-        return await _conversationClient.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await _conversationClient.SendActivityAsync(activity, serviceUrl, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/core/src/Microsoft.Teams.Core/ConversationClient.cs
+++ b/core/src/Microsoft.Teams.Core/ConversationClient.cs
@@ -39,20 +39,21 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
     /// <summary>
     /// Sends the specified activity to the conversation endpoint asynchronously.
     /// </summary>
-    /// <param name="activity">The activity to send. Cannot be null. Must contain a valid ServiceUrl and Conversation with an Id.
+    /// <param name="activity">The activity to send. Cannot be null. Must contain a Conversation with an Id.
     /// The recipient's IsTargeted property determines if this is a targeted activity.</param>
+    /// <param name="serviceUrl">The service URL for the conversation. Cannot be null.</param>
     /// <param name="requestContext">Optional per-request properties (see <see cref="Http.BotRequestContext"/>) used as a fallback; values derived from the activity take precedence.</param>
     /// <param name="customHeaders">Optional custom headers to include in the request.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the send operation.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the response with the ID of the sent activity.</returns>
     /// <exception cref="Exception">Thrown if the activity could not be sent successfully. The exception message includes the HTTP status code and
     /// response content.</exception>
-    public virtual async Task<SendActivityResponse?> SendActivityAsync(CoreActivity activity, BotRequestContext? requestContext = null, CustomHeaders? customHeaders = null, CancellationToken cancellationToken = default)
+    public virtual async Task<SendActivityResponse?> SendActivityAsync(CoreActivity activity, Uri serviceUrl, BotRequestContext? requestContext = null, CustomHeaders? customHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
+        ArgumentNullException.ThrowIfNull(serviceUrl);
         string? conversationId = activity.Conversation?.Id;
         ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
-        ArgumentNullException.ThrowIfNull(activity.ServiceUrl);
 
 #pragma warning disable ExperimentalTeamsTargeted
         bool isTargeted = activity.Recipient?.IsTargeted == true;
@@ -60,13 +61,13 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
 
         BotRequestContext? properties = BotRequestContext.Merge(requestContext, BotRequestContext.FromActivity(activity));
 
-        string url = $"{activity.ServiceUrl.ToString().TrimEnd('/')}/v3/conversations/{Uri.EscapeDataString(conversationId)}/activities/";
+        string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/conversations/{Uri.EscapeDataString(conversationId)}/activities/";
 
         if (activity.ChannelId == "agents")
         {
             logger.TruncatingConversationId();
             string convId = "acf"; //conversationId.Length > 100 ? conversationId[..100] : conversationId;
-            url = $"{activity.ServiceUrl.ToString().TrimEnd('/')}/v3/conversations/{Uri.EscapeDataString(convId)}/activities/";
+            url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/conversations/{Uri.EscapeDataString(convId)}/activities/";
         }
 
         if (isTargeted)
@@ -81,7 +82,7 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
         if (span is not null)
         {
             span.SetTag(Telemetry.Tags.Operation, Telemetry.Operations.SendActivity);
-            span.SetTag(Telemetry.Tags.ServiceUrl, activity.ServiceUrl.ToString());
+            span.SetTag(Telemetry.Tags.ServiceUrl, serviceUrl.ToString());
             span.SetTag(Telemetry.Tags.ConversationId, conversationId);
             span.SetTag(Telemetry.Tags.ActivityType, activity.Type);
         }
@@ -111,20 +112,21 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
     /// <param name="conversationId">The ID of the conversation. Cannot be null or whitespace.</param>
     /// <param name="activityId">The ID of the activity to update. Cannot be null or whitespace.</param>
     /// <param name="activity">The updated activity data. Cannot be null.</param>
+    /// <param name="serviceUrl">The service URL for the conversation. Cannot be null.</param>
     /// <param name="isTargeted">Whether this is a targeted activity visible only to a specific recipient.</param>
     /// <param name="requestContext">Optional per-request properties (see <see cref="Http.BotRequestContext"/>) to stamp onto the request's options.</param>
     /// <param name="customHeaders">Optional custom headers to include in the request.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the update operation.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the response with the ID of the updated activity.</returns>
     /// <exception cref="HttpRequestException">Thrown if the activity could not be updated successfully.</exception>
-    public virtual async Task<UpdateActivityResponse> UpdateActivityAsync(string conversationId, string activityId, CoreActivity activity, bool isTargeted = false, BotRequestContext? requestContext = null, CustomHeaders? customHeaders = null, CancellationToken cancellationToken = default)
+    public virtual async Task<UpdateActivityResponse> UpdateActivityAsync(string conversationId, string activityId, CoreActivity activity, Uri serviceUrl, bool isTargeted = false, BotRequestContext? requestContext = null, CustomHeaders? customHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
         ArgumentException.ThrowIfNullOrWhiteSpace(activityId);
         ArgumentNullException.ThrowIfNull(activity);
-        ArgumentNullException.ThrowIfNull(activity.ServiceUrl);
+        ArgumentNullException.ThrowIfNull(serviceUrl);
 
-        string url = $"{activity.ServiceUrl.ToString().TrimEnd('/')}/v3/conversations/{Uri.EscapeDataString(conversationId)}/activities/{Uri.EscapeDataString(activityId)}";
+        string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/conversations/{Uri.EscapeDataString(conversationId)}/activities/{Uri.EscapeDataString(activityId)}";
 
         if (isTargeted)
         {
@@ -140,7 +142,7 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
         if (span is not null)
         {
             span.SetTag(Telemetry.Tags.Operation, Telemetry.Operations.UpdateActivity);
-            span.SetTag(Telemetry.Tags.ServiceUrl, activity.ServiceUrl.ToString());
+            span.SetTag(Telemetry.Tags.ServiceUrl, serviceUrl.ToString());
             span.SetTag(Telemetry.Tags.ConversationId, conversationId);
             span.SetTag(Telemetry.Tags.ActivityId, activityId);
             span.SetTag(Telemetry.Tags.ActivityType, activity.Type);
@@ -171,20 +173,21 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
     /// </summary>
     /// <param name="conversationId">The ID of the conversation. Cannot be null or whitespace.</param>
     /// <param name="activityId">The ID of the activity to update. Cannot be null or whitespace.</param>
-    /// <param name="activity">The updated activity data. Cannot be null. Must contain a valid ServiceUrl.</param>
+    /// <param name="activity">The updated activity data. Cannot be null.</param>
+    /// <param name="serviceUrl">The service URL for the conversation. Cannot be null.</param>
     /// <param name="requestContext">Optional per-request properties (see <see cref="Http.BotRequestContext"/>) to stamp onto the request's options.</param>
     /// <param name="customHeaders">Optional custom headers to include in the request.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the update operation.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the response with the ID of the updated activity.</returns>
     /// <exception cref="HttpRequestException">Thrown if the activity could not be updated successfully.</exception>
-    public virtual async Task<UpdateActivityResponse> UpdateTargetedActivityAsync(string conversationId, string activityId, CoreActivity activity, BotRequestContext? requestContext = null, CustomHeaders? customHeaders = null, CancellationToken cancellationToken = default)
+    public virtual async Task<UpdateActivityResponse> UpdateTargetedActivityAsync(string conversationId, string activityId, CoreActivity activity, Uri serviceUrl, BotRequestContext? requestContext = null, CustomHeaders? customHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
         ArgumentException.ThrowIfNullOrWhiteSpace(activityId);
         ArgumentNullException.ThrowIfNull(activity);
-        ArgumentNullException.ThrowIfNull(activity.ServiceUrl);
+        ArgumentNullException.ThrowIfNull(serviceUrl);
 
-        string url = $"{activity.ServiceUrl.ToString().TrimEnd('/')}/v3/conversations/{Uri.EscapeDataString(conversationId)}/activities/{Uri.EscapeDataString(activityId)}?isTargetedActivity=true";
+        string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/conversations/{Uri.EscapeDataString(conversationId)}/activities/{Uri.EscapeDataString(activityId)}?isTargetedActivity=true";
 
         string body = activity.ToJson();
 
@@ -195,7 +198,7 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
         if (span is not null)
         {
             span.SetTag(Telemetry.Tags.Operation, Telemetry.Operations.UpdateActivity);
-            span.SetTag(Telemetry.Tags.ServiceUrl, activity.ServiceUrl.ToString());
+            span.SetTag(Telemetry.Tags.ServiceUrl, serviceUrl.ToString());
             span.SetTag(Telemetry.Tags.ConversationId, conversationId);
             span.SetTag(Telemetry.Tags.ActivityId, activityId);
             span.SetTag(Telemetry.Tags.ActivityType, activity.Type);
@@ -303,24 +306,25 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
     /// Deletes an existing activity from a conversation using activity context.
     /// </summary>
     /// <param name="conversationId">The ID of the conversation.</param>
-    /// <param name="activity">The activity to delete. Must contain valid Id and ServiceUrl. Cannot be null.</param>
+    /// <param name="activity">The activity to delete. Must contain a valid Id. Cannot be null.</param>
+    /// <param name="serviceUrl">The service URL for the conversation. Cannot be null.</param>
     /// <param name="isTargeted">Whether this is a targeted activity.</param>
     /// <param name="requestContext">Optional per-request properties (see <see cref="Http.BotRequestContext"/>) to stamp onto the request's options.</param>
     /// <param name="customHeaders">Optional custom headers to include in the request.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the delete operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     /// <exception cref="HttpRequestException">Thrown if the activity could not be deleted successfully.</exception>
-    public virtual async Task DeleteActivityAsync(string conversationId, CoreActivity activity, bool isTargeted = false, BotRequestContext? requestContext = null, CustomHeaders? customHeaders = null, CancellationToken cancellationToken = default)
+    public virtual async Task DeleteActivityAsync(string conversationId, CoreActivity activity, Uri serviceUrl, bool isTargeted = false, BotRequestContext? requestContext = null, CustomHeaders? customHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
+        ArgumentNullException.ThrowIfNull(serviceUrl);
         ArgumentException.ThrowIfNullOrWhiteSpace(activity.Id);
         ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
-        ArgumentNullException.ThrowIfNull(activity.ServiceUrl);
 
         await DeleteActivityAsync(
             conversationId,
             activity.Id,
-            activity.ServiceUrl,
+            serviceUrl,
             isTargeted,
             requestContext,
             customHeaders,

--- a/core/src/Microsoft.Teams.Core/Schema/CoreActivityBuilder.cs
+++ b/core/src/Microsoft.Teams.Core/Schema/CoreActivityBuilder.cs
@@ -41,27 +41,6 @@ public abstract class CoreActivityBuilder<TActivity, TBuilder>
     }
 
     /// <summary>
-    /// Sets the service URL.
-    /// </summary>
-    /// <param name="serviceUrl">The service URL.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    public TBuilder WithServiceUrl(Uri? serviceUrl)
-    {
-        _activity.ServiceUrl = serviceUrl;
-        return (TBuilder)this;
-    }
-    /// <summary>
-    /// Sets the service URL from a string.
-    /// </summary>
-    /// <param name="serviceUrlString">The service URL as a string.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    public TBuilder WithServiceUrl(string serviceUrlString)
-    {
-        _activity.ServiceUrl = new Uri(serviceUrlString);
-        return (TBuilder)this;
-    }
-
-    /// <summary>
     /// Sets the channel ID.
     /// </summary>
     /// <param name="channelId">The channel ID.</param>

--- a/core/test/IntegrationTests/ConversationClientTests.cs
+++ b/core/test/IntegrationTests/ConversationClientTests.cs
@@ -35,7 +35,7 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
             .WithProperty("text", $"[ConversationClient] SendActivity at `{DateTime.UtcNow:s}`")
             .Build();
 
-        SendActivityResponse? res = await _f.ConversationClient.SendActivityAsync(activity);
+        SendActivityResponse? res = await _f.ConversationClient.SendActivityAsync(activity, _f.ServiceUrl);
 
         Assert.NotNull(res);
         Assert.NotNull(res.Id);
@@ -54,7 +54,7 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
             .WithProperty("text", $"[ConversationClient] Original at `{DateTime.UtcNow:s}`")
             .Build();
 
-        SendActivityResponse? sent = await _f.ConversationClient.SendActivityAsync(activity);
+        SendActivityResponse? sent = await _f.ConversationClient.SendActivityAsync(activity, _f.ServiceUrl);
         Assert.NotNull(sent?.Id);
 
         CoreActivity updated = CoreActivity.CreateBuilder()
@@ -66,7 +66,7 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
             .Build();
 
         UpdateActivityResponse res = await _f.ConversationClient.UpdateActivityAsync(
-            _f.ConversationId, sent.Id, updated, false, BotRequestContext.FromAgenticIdentity(_f.AgenticIdentity));
+            _f.ConversationId, sent.Id, updated, _f.ServiceUrl, false, BotRequestContext.FromAgenticIdentity(_f.AgenticIdentity));
 
         Assert.NotNull(res?.Id);
         _output.WriteLine($"Updated activity: {res.Id}");
@@ -84,7 +84,7 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
             .WithProperty("text", $"[ConversationClient] To delete at `{DateTime.UtcNow:s}`")
             .Build();
 
-        SendActivityResponse? sent = await _f.ConversationClient.SendActivityAsync(activity);
+        SendActivityResponse? sent = await _f.ConversationClient.SendActivityAsync(activity, _f.ServiceUrl);
         Assert.NotNull(sent?.Id);
 
         await Task.Delay(2000);
@@ -159,7 +159,7 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
             .WithProperty("text", $"[ConversationClient] Reaction test at `{DateTime.UtcNow:s}`")
             .Build();
 
-        SendActivityResponse? sent = await _f.ConversationClient.SendActivityAsync(activity);
+        SendActivityResponse? sent = await _f.ConversationClient.SendActivityAsync(activity, _f.ServiceUrl);
         Assert.NotNull(sent?.Id);
 
         await _f.ConversationClient.AddReactionAsync(

--- a/core/test/IntegrationTests/ConversationClientTests.cs
+++ b/core/test/IntegrationTests/ConversationClientTests.cs
@@ -30,7 +30,6 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
         CoreActivity activity = CoreActivity.CreateBuilder()
             .WithType(ActivityType.Message)
             .WithFrom(IntegrationTestFixture.GetChannelAccountWithAgenticProperties())
-            .WithServiceUrl(_f.ServiceUrl)
             .WithConversation(new(_f.ConversationId))
             .WithProperty("text", $"[ConversationClient] SendActivity at `{DateTime.UtcNow:s}`")
             .Build();
@@ -49,7 +48,6 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
         CoreActivity activity = CoreActivity.CreateBuilder()
             .WithType(ActivityType.Message)
             .WithFrom(IntegrationTestFixture.GetChannelAccountWithAgenticProperties())
-            .WithServiceUrl(_f.ServiceUrl)
             .WithConversation(new(_f.ConversationId))
             .WithProperty("text", $"[ConversationClient] Original at `{DateTime.UtcNow:s}`")
             .Build();
@@ -60,7 +58,6 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
         CoreActivity updated = CoreActivity.CreateBuilder()
             .WithType(ActivityType.Message)
             .WithFrom(IntegrationTestFixture.GetChannelAccountWithAgenticProperties())
-            .WithServiceUrl(_f.ServiceUrl)
             .WithConversation(new(_f.ConversationId))
             .WithProperty("text", $"[ConversationClient] Updated at `{DateTime.UtcNow:s}`")
             .Build();
@@ -79,7 +76,6 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
         CoreActivity activity = CoreActivity.CreateBuilder()
             .WithType(ActivityType.Message)
             .WithFrom(IntegrationTestFixture.GetChannelAccountWithAgenticProperties())
-            .WithServiceUrl(_f.ServiceUrl)
             .WithConversation(new(_f.ConversationId))
             .WithProperty("text", $"[ConversationClient] To delete at `{DateTime.UtcNow:s}`")
             .Build();
@@ -153,7 +149,6 @@ public class ConversationClientTests : IClassFixture<IntegrationTestFixture>
 
         CoreActivity activity = CoreActivity.CreateBuilder()
             .WithType(ActivityType.Message)
-            .WithServiceUrl(_f.ServiceUrl)
             .WithFrom(IntegrationTestFixture.GetChannelAccountWithAgenticProperties())
             .WithConversation(new(_f.ConversationId))
             .WithProperty("text", $"[ConversationClient] Reaction test at `{DateTime.UtcNow:s}`")

--- a/core/test/IntegrationTests/CreateConversationTests.cs
+++ b/core/test/IntegrationTests/CreateConversationTests.cs
@@ -85,7 +85,6 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
         CoreActivity activity = CoreActivity.CreateBuilder()
             .WithType(ActivityType.Message)
             .WithFrom(IntegrationTestFixture.GetChannelAccountWithAgenticProperties())
-            .WithServiceUrl(_f.ServiceUrl)
             .WithConversation(new(response.Id))
             .WithProperty("text", $"[Core] 1:1 message at `{DateTime.UtcNow:s}`")
             .Build();
@@ -189,7 +188,6 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
         CoreActivity activity = CoreActivity.CreateBuilder()
             .WithType(ActivityType.Message)
             .WithFrom(IntegrationTestFixture.GetChannelAccountWithAgenticProperties())
-            .WithServiceUrl(_f.ServiceUrl)
             .WithConversation(new(response.Id))
             .WithProperty("text", $"[Core] Group message at `{DateTime.UtcNow:s}`")
             .Build();

--- a/core/test/IntegrationTests/CreateConversationTests.cs
+++ b/core/test/IntegrationTests/CreateConversationTests.cs
@@ -90,7 +90,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
             .WithProperty("text", $"[Core] 1:1 message at `{DateTime.UtcNow:s}`")
             .Build();
 
-        SendActivityResponse? sent = await _f.ConversationClient.SendActivityAsync(activity);
+        SendActivityResponse? sent = await _f.ConversationClient.SendActivityAsync(activity, _f.ServiceUrl);
         Assert.NotNull(sent?.Id);
         _output.WriteLine($"Created 1:1 conversation {response.Id} and sent activity {sent.Id}");
     }
@@ -194,7 +194,7 @@ public class CreateConversationTests : IClassFixture<IntegrationTestFixture>
             .WithProperty("text", $"[Core] Group message at `{DateTime.UtcNow:s}`")
             .Build();
 
-        SendActivityResponse? sent = await _f.ConversationClient.SendActivityAsync(activity);
+        SendActivityResponse? sent = await _f.ConversationClient.SendActivityAsync(activity, _f.ServiceUrl);
         Assert.NotNull(sent?.Id);
         _output.WriteLine($"Created group {response.Id} and sent activity {sent.Id}");
     }

--- a/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatBotAdapterTests.cs
+++ b/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatBotAdapterTests.cs
@@ -146,12 +146,13 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
         }
 
         [Fact]
-        public async Task SendActivitiesAsync_SetsServiceUrlFromTurnContext()
+        public async Task SendActivitiesAsync_PassesServiceUrlFromTurnContext()
         {
             // Arrange
             Mock<ConversationClient> mockConversationClient = CreateMockConversationClient();
             mockConversationClient.Setup(c => c.SendActivityAsync(
                     It.IsAny<CoreActivity>(),
+                    It.IsAny<Uri>(),
                     It.IsAny<BotRequestContext?>(),
                     It.IsAny<Dictionary<string, string>?>(),
                     It.IsAny<CancellationToken>()))
@@ -178,7 +179,8 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
 
             mockConversationClient.Verify(
                 c => c.SendActivityAsync(
-                    It.Is<CoreActivity>(a => a.ServiceUrl != null && a.ServiceUrl.ToString().TrimEnd('/') == "https://turn-context-service-url.com"),
+                    It.Is<CoreActivity>(a => a.ServiceUrl == null),
+                    It.Is<Uri>(u => u.ToString().TrimEnd('/') == "https://turn-context-service-url.com"),
                     It.Is<BotRequestContext?>(c => c != null && c.BotAppId == "bot-123"),
                     It.IsAny<Dictionary<string, string>?>(),
                     It.IsAny<CancellationToken>()),
@@ -186,7 +188,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
         }
 
         [Fact]
-        public async Task UpdateActivityAsync_SetsServiceUrlFromTurnContext()
+        public async Task UpdateActivityAsync_PassesServiceUrlFromTurnContext()
         {
             // Arrange
             Mock<ConversationClient> mockConversationClient = CreateMockConversationClient();
@@ -194,6 +196,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<CoreActivity>(),
+                    It.IsAny<Uri>(),
                     It.IsAny<bool>(),
                     It.IsAny<BotRequestContext?>(),
                     It.IsAny<Dictionary<string, string>?>(),
@@ -223,7 +226,8 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
                 c => c.UpdateActivityAsync(
                     "conversation-123",
                     "activity-123",
-                    It.Is<CoreActivity>(a => a.ServiceUrl != null && a.ServiceUrl.ToString().TrimEnd('/') == "https://turn-context-service-url.com"),
+                    It.Is<CoreActivity>(a => a.ServiceUrl == null),
+                    It.Is<Uri>(u => u.ToString().TrimEnd('/') == "https://turn-context-service-url.com"),
                     It.IsAny<bool>(),
                     It.IsAny<BotRequestContext?>(),
                     It.IsAny<Dictionary<string, string>?>(),
@@ -248,6 +252,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
 
             mock.Setup(c => c.SendActivityAsync(
                     It.IsAny<CoreActivity>(),
+                    It.IsAny<Uri>(),
                     It.IsAny<BotRequestContext?>(),
                     It.IsAny<Dictionary<string, string>?>(),
                     It.IsAny<CancellationToken>()))

--- a/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatConversationsTests.cs
+++ b/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatConversationsTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
         private const string TestActivityId = "test-activity-id";
 
         [Fact]
-        public async Task SendToConversationWithHttpMessagesAsync_SetsServiceUrlFromProperty_WhenActivityServiceUrlIsNull()
+        public async Task SendToConversationWithHttpMessagesAsync_PassesServiceUrlFromProperty_WhenActivityServiceUrlIsNull()
         {
             // Arrange
             Mock<ConversationClient> mockConversationClient = CreateMockConversationClient();
@@ -33,9 +33,14 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             };
 
             CoreActivity? capturedActivity = null;
+            Uri? capturedServiceUrl = null;
             mockConversationClient
-                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
-                .Callback<CoreActivity, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((act, _, _, _) => capturedActivity = act)
+                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
+                .Callback<CoreActivity, Uri, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((act, serviceUrl, _, _, _) =>
+                {
+                    capturedActivity = act;
+                    capturedServiceUrl = serviceUrl;
+                })
                 .ReturnsAsync(new SendActivityResponse { Id = TestActivityId });
 
             // Act
@@ -43,10 +48,11 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
 
             // Assert
             Assert.NotNull(capturedActivity);
-            Assert.NotNull(capturedActivity.ServiceUrl);
-            Assert.Equal(TestServiceUrl.TrimEnd('/'), capturedActivity.ServiceUrl.ToString().TrimEnd('/'));
+            Assert.Null(capturedActivity.ServiceUrl);
+            Assert.NotNull(capturedServiceUrl);
+            Assert.Equal(TestServiceUrl.TrimEnd('/'), capturedServiceUrl.ToString().TrimEnd('/'));
             mockConversationClient.Verify(
-                c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()),
+                c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -69,9 +75,14 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             };
 
             CoreActivity? capturedActivity = null;
+            Uri? capturedServiceUrl = null;
             mockConversationClient
-                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
-                .Callback<CoreActivity, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((act, _, _, _) => capturedActivity = act)
+                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
+                .Callback<CoreActivity, Uri, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((act, serviceUrl, _, _, _) =>
+                {
+                    capturedActivity = act;
+                    capturedServiceUrl = serviceUrl;
+                })
                 .ReturnsAsync(new SendActivityResponse { Id = TestActivityId });
 
             // Act
@@ -81,13 +92,15 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             Assert.NotNull(capturedActivity);
             Assert.NotNull(capturedActivity.ServiceUrl);
             Assert.Equal(activityServiceUrl.TrimEnd('/'), capturedActivity.ServiceUrl.ToString().TrimEnd('/'));
+            Assert.NotNull(capturedServiceUrl);
+            Assert.Equal(TestServiceUrl.TrimEnd('/'), capturedServiceUrl.ToString().TrimEnd('/'));
             mockConversationClient.Verify(
-                c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()),
+                c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
         [Fact]
-        public async Task ReplyToActivityWithHttpMessagesAsync_SetsServiceUrlFromProperty_WhenActivityServiceUrlIsNull()
+        public async Task ReplyToActivityWithHttpMessagesAsync_PassesServiceUrlFromProperty_WhenActivityServiceUrlIsNull()
         {
             // Arrange
             Mock<ConversationClient> mockConversationClient = CreateMockConversationClient();
@@ -103,9 +116,14 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             };
 
             CoreActivity? capturedActivity = null;
+            Uri? capturedServiceUrl = null;
             mockConversationClient
-                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
-                .Callback<CoreActivity, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((act, _, _, _) => capturedActivity = act)
+                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
+                .Callback<CoreActivity, Uri, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((act, serviceUrl, _, _, _) =>
+                {
+                    capturedActivity = act;
+                    capturedServiceUrl = serviceUrl;
+                })
                 .ReturnsAsync(new SendActivityResponse { Id = TestActivityId });
 
             // Act
@@ -113,11 +131,12 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
 
             // Assert
             Assert.NotNull(capturedActivity);
-            Assert.NotNull(capturedActivity.ServiceUrl);
-            Assert.Equal(TestServiceUrl.TrimEnd('/'), capturedActivity.ServiceUrl.ToString().TrimEnd('/'));
+            Assert.Null(capturedActivity.ServiceUrl);
+            Assert.NotNull(capturedServiceUrl);
+            Assert.Equal(TestServiceUrl.TrimEnd('/'), capturedServiceUrl.ToString().TrimEnd('/'));
             Assert.Equal(TestActivityId, capturedActivity.ReplyToId);
             mockConversationClient.Verify(
-                c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()),
+                c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -140,9 +159,14 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             };
 
             CoreActivity? capturedActivity = null;
+            Uri? capturedServiceUrl = null;
             mockConversationClient
-                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
-                .Callback<CoreActivity, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((act, _, _, _) => capturedActivity = act)
+                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
+                .Callback<CoreActivity, Uri, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((act, serviceUrl, _, _, _) =>
+                {
+                    capturedActivity = act;
+                    capturedServiceUrl = serviceUrl;
+                })
                 .ReturnsAsync(new SendActivityResponse { Id = TestActivityId });
 
             // Act
@@ -152,13 +176,15 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             Assert.NotNull(capturedActivity);
             Assert.NotNull(capturedActivity.ServiceUrl);
             Assert.Equal(activityServiceUrl.TrimEnd('/'), capturedActivity.ServiceUrl.ToString().TrimEnd('/'));
+            Assert.NotNull(capturedServiceUrl);
+            Assert.Equal(TestServiceUrl.TrimEnd('/'), capturedServiceUrl.ToString().TrimEnd('/'));
             mockConversationClient.Verify(
-                c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()),
+                c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
         [Fact]
-        public async Task UpdateActivityWithHttpMessagesAsync_SetsServiceUrlFromProperty_WhenActivityServiceUrlIsNull()
+        public async Task UpdateActivityWithHttpMessagesAsync_PassesServiceUrlFromProperty_WhenActivityServiceUrlIsNull()
         {
             // Arrange
             Mock<ConversationClient> mockConversationClient = CreateMockConversationClient();
@@ -174,16 +200,22 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             };
 
             CoreActivity? capturedActivity = null;
+            Uri? capturedServiceUrl = null;
             mockConversationClient
                 .Setup(c => c.UpdateActivityAsync(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<CoreActivity>(),
+                    It.IsAny<Uri>(),
                     It.IsAny<bool>(),
                     It.IsAny<BotRequestContext?>(),
                     It.IsAny<Dictionary<string, string>?>(),
                     It.IsAny<CancellationToken>()))
-                .Callback<string, string, CoreActivity, bool, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((_, _, act, _, _, _, _) => capturedActivity = act)
+                .Callback<string, string, CoreActivity, Uri, bool, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((_, _, act, serviceUrl, _, _, _, _) =>
+                {
+                    capturedActivity = act;
+                    capturedServiceUrl = serviceUrl;
+                })
                 .ReturnsAsync(new UpdateActivityResponse { Id = TestActivityId });
 
             // Act
@@ -191,13 +223,15 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
 
             // Assert
             Assert.NotNull(capturedActivity);
-            Assert.NotNull(capturedActivity.ServiceUrl);
-            Assert.Equal(TestServiceUrl.TrimEnd('/'), capturedActivity.ServiceUrl.ToString().TrimEnd('/'));
+            Assert.Null(capturedActivity.ServiceUrl);
+            Assert.NotNull(capturedServiceUrl);
+            Assert.Equal(TestServiceUrl.TrimEnd('/'), capturedServiceUrl.ToString().TrimEnd('/'));
             mockConversationClient.Verify(
                 c => c.UpdateActivityAsync(
                     TestConversationId,
                     TestActivityId,
                     It.IsAny<CoreActivity>(),
+                    It.IsAny<Uri>(),
                     It.IsAny<bool>(),
                     It.IsAny<BotRequestContext?>(),
                     It.IsAny<Dictionary<string, string>?>(),
@@ -230,6 +264,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
                     TestConversationId,
                     TestActivityId,
                     It.IsAny<CoreActivity>(),
+                    It.IsAny<Uri>(),
                     It.IsAny<bool>(),
                     It.Is<BotRequestContext?>(c => ReferenceEquals(c, requestContext)),
                     It.IsAny<Dictionary<string, string>?>(),
@@ -262,16 +297,22 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             };
 
             CoreActivity? capturedActivity = null;
+            Uri? capturedServiceUrl = null;
             mockConversationClient
                 .Setup(c => c.UpdateActivityAsync(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<CoreActivity>(),
+                    It.IsAny<Uri>(),
                     It.IsAny<bool>(),
                     It.IsAny<BotRequestContext?>(),
                     It.IsAny<Dictionary<string, string>?>(),
                     It.IsAny<CancellationToken>()))
-                .Callback<string, string, CoreActivity, bool, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((_, _, act, _, _, _, _) => capturedActivity = act)
+                .Callback<string, string, CoreActivity, Uri, bool, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((_, _, act, serviceUrl, _, _, _, _) =>
+                {
+                    capturedActivity = act;
+                    capturedServiceUrl = serviceUrl;
+                })
                 .ReturnsAsync(new UpdateActivityResponse { Id = TestActivityId });
 
             // Act
@@ -281,11 +322,14 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             Assert.NotNull(capturedActivity);
             Assert.NotNull(capturedActivity.ServiceUrl);
             Assert.Equal(activityServiceUrl.TrimEnd('/'), capturedActivity.ServiceUrl.ToString().TrimEnd('/'));
+            Assert.NotNull(capturedServiceUrl);
+            Assert.Equal(TestServiceUrl.TrimEnd('/'), capturedServiceUrl.ToString().TrimEnd('/'));
             mockConversationClient.Verify(
                 c => c.UpdateActivityAsync(
                     TestConversationId,
                     TestActivityId,
                     It.IsAny<CoreActivity>(),
+                    It.IsAny<Uri>(),
                     It.IsAny<bool>(),
                     It.IsAny<BotRequestContext?>(),
                     It.IsAny<Dictionary<string, string>?>(),
@@ -311,8 +355,8 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
 
             CoreActivity? capturedActivity = null;
             mockConversationClient
-                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
-                .Callback<CoreActivity, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((act, _, _, _) => capturedActivity = act)
+                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
+                .Callback<CoreActivity, Uri, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((act, _, _, _, _) => capturedActivity = act)
                 .ReturnsAsync(new SendActivityResponse { Id = TestActivityId });
 
             // Act
@@ -341,8 +385,8 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
 
             CoreActivity? capturedActivity = null;
             mockConversationClient
-                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
-                .Callback<CoreActivity, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((act, _, _, _) => capturedActivity = act)
+                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
+                .Callback<CoreActivity, Uri, BotRequestContext?, Dictionary<string, string>?, CancellationToken>((act, _, _, _, _) => capturedActivity = act)
                 .ReturnsAsync(new SendActivityResponse { Id = TestActivityId });
 
             // Act
@@ -365,7 +409,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             // Arrange
             Mock<ConversationClient> mockConversationClient = CreateMockConversationClient();
             mockConversationClient
-                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
+                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((SendActivityResponse?)null); // Simulate 202 Accepted with no body
 
             CompatConversations compatConversations = new(mockConversationClient.Object)
@@ -398,7 +442,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             // Arrange
             Mock<ConversationClient> mockConversationClient = CreateMockConversationClient();
             mockConversationClient
-                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
+                .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((SendActivityResponse?)null); // Simulate 202 Accepted with no body
 
             CompatConversations compatConversations = new(mockConversationClient.Object)

--- a/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatConversationsTests.cs
+++ b/core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/CompatConversationsTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
         }
 
         [Fact]
-        public async Task SendToConversationWithHttpMessagesAsync_DoesNotOverrideServiceUrl_WhenActivityServiceUrlIsSet()
+        public async Task SendToConversationWithHttpMessagesAsync_UsesActivityServiceUrl_WhenActivityServiceUrlIsSet()
         {
             // Arrange
             const string activityServiceUrl = "https://custom.service.url/";
@@ -93,7 +93,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             Assert.NotNull(capturedActivity.ServiceUrl);
             Assert.Equal(activityServiceUrl.TrimEnd('/'), capturedActivity.ServiceUrl.ToString().TrimEnd('/'));
             Assert.NotNull(capturedServiceUrl);
-            Assert.Equal(TestServiceUrl.TrimEnd('/'), capturedServiceUrl.ToString().TrimEnd('/'));
+            Assert.Equal(activityServiceUrl.TrimEnd('/'), capturedServiceUrl.ToString().TrimEnd('/'));
             mockConversationClient.Verify(
                 c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -141,7 +141,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
         }
 
         [Fact]
-        public async Task ReplyToActivityWithHttpMessagesAsync_DoesNotOverrideServiceUrl_WhenActivityServiceUrlIsSet()
+        public async Task ReplyToActivityWithHttpMessagesAsync_UsesActivityServiceUrl_WhenActivityServiceUrlIsSet()
         {
             // Arrange
             const string activityServiceUrl = "https://custom.service.url/";
@@ -177,7 +177,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             Assert.NotNull(capturedActivity.ServiceUrl);
             Assert.Equal(activityServiceUrl.TrimEnd('/'), capturedActivity.ServiceUrl.ToString().TrimEnd('/'));
             Assert.NotNull(capturedServiceUrl);
-            Assert.Equal(TestServiceUrl.TrimEnd('/'), capturedServiceUrl.ToString().TrimEnd('/'));
+            Assert.Equal(activityServiceUrl.TrimEnd('/'), capturedServiceUrl.ToString().TrimEnd('/'));
             mockConversationClient.Verify(
                 c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -279,7 +279,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
         }
 
         [Fact]
-        public async Task UpdateActivityWithHttpMessagesAsync_DoesNotOverrideServiceUrl_WhenActivityServiceUrlIsSet()
+        public async Task UpdateActivityWithHttpMessagesAsync_UsesActivityServiceUrl_WhenActivityServiceUrlIsSet()
         {
             // Arrange
             const string activityServiceUrl = "https://custom.service.url/";
@@ -323,7 +323,7 @@ namespace Microsoft.Teams.Apps.BotBuilder.UnitTests
             Assert.NotNull(capturedActivity.ServiceUrl);
             Assert.Equal(activityServiceUrl.TrimEnd('/'), capturedActivity.ServiceUrl.ToString().TrimEnd('/'));
             Assert.NotNull(capturedServiceUrl);
-            Assert.Equal(TestServiceUrl.TrimEnd('/'), capturedServiceUrl.ToString().TrimEnd('/'));
+            Assert.Equal(activityServiceUrl.TrimEnd('/'), capturedServiceUrl.ToString().TrimEnd('/'));
             mockConversationClient.Verify(
                 c => c.UpdateActivityAsync(
                     TestConversationId,

--- a/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTelemetryTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTelemetryTests.cs
@@ -492,7 +492,7 @@ public class OAuthFlowTelemetryTests
     private static void SetupSendActivity(TestHarness harness)
     {
         harness.MockConversationClient
-            .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SendActivityResponse { Id = "activity-1" });
     }
 

--- a/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTests.cs
@@ -555,7 +555,7 @@ public class OAuthFlowTests
     private static void SetupSendActivity(TestHarness harness)
     {
         harness.MockConversationClient
-            .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .Setup(c => c.SendActivityAsync(It.IsAny<CoreActivity>(), It.IsAny<Uri>(), It.IsAny<BotRequestContext?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SendActivityResponse { Id = "activity-1" });
     }
 }

--- a/core/test/Microsoft.Teams.Apps.UnitTests/PromptPreviewTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/PromptPreviewTests.cs
@@ -190,11 +190,12 @@ public class PromptPreviewTests
         harness.MockConversationClient
             .Setup(c => c.SendActivityAsync(
                 It.IsAny<CoreActivity>(),
+                It.IsAny<Uri>(),
                 It.IsAny<BotRequestContext?>(),
                 It.IsAny<Dictionary<string, string>?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<CoreActivity, BotRequestContext?, Dictionary<string, string>?, CancellationToken>(
-                (activity, _, _, _) => slot.Value = activity)
+            .Callback<CoreActivity, Uri, BotRequestContext?, Dictionary<string, string>?, CancellationToken>(
+                (activity, _, _, _, _) => slot.Value = activity)
             .ReturnsAsync(new SendActivityResponse { Id = "sent-id" });
         return slot;
     }

--- a/core/test/Microsoft.Teams.Core.UnitTests/BotApplicationTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/BotApplicationTests.cs
@@ -171,7 +171,7 @@ public class BotApplicationTests
             ServiceUrl = new Uri("https://test.service.url/"),
             Conversation = new("conv123")
         };
-        SendActivityResponse? result = await botApp.SendActivityAsync(activity);
+        SendActivityResponse? result = await botApp.SendActivityAsync(activity, new Uri("https://test.service.url/"));
 
         Assert.NotNull(result);
         Assert.Contains("activity123", result.Id);
@@ -183,7 +183,7 @@ public class BotApplicationTests
         BotApplication botApp = CreateBotApplication();
 
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            botApp.SendActivityAsync(null!));
+            botApp.SendActivityAsync(null!, new Uri("https://test.service.url/")));
     }
 
     [Fact]

--- a/core/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
@@ -37,7 +37,7 @@ public class ConversationClientTests
             Conversation = new("conv123")
         };
 
-        SendActivityResponse? result = await conversationClient.SendActivityAsync(activity);
+        SendActivityResponse? result = await conversationClient.SendActivityAsync(activity, new Uri("https://test.service.url/"));
 
         Assert.NotNull(result);
         Assert.Contains("activity123", result.Id);
@@ -50,7 +50,7 @@ public class ConversationClientTests
         ConversationClient conversationClient = new(httpClient);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            conversationClient.SendActivityAsync(null!));
+            conversationClient.SendActivityAsync(null!, new Uri("https://test.service.url/")));
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class ConversationClientTests
         };
 
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            conversationClient.SendActivityAsync(activity));
+            conversationClient.SendActivityAsync(activity, new Uri("https://test.service.url/")));
     }
 
     [Fact]
@@ -83,11 +83,11 @@ public class ConversationClientTests
         };
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
-            conversationClient.SendActivityAsync(activity));
+            conversationClient.SendActivityAsync(activity, new Uri("https://test.service.url/")));
     }
 
     [Fact]
-    public async Task SendActivityAsync_WithNullServiceUrl_ThrowsArgumentNullException()
+    public async Task SendActivityAsync_WithNullServiceUrlParameter_ThrowsArgumentNullException()
     {
         HttpClient httpClient = new();
         ConversationClient conversationClient = new(httpClient);
@@ -99,7 +99,7 @@ public class ConversationClientTests
         };
 
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            conversationClient.SendActivityAsync(activity));
+            conversationClient.SendActivityAsync(activity, null!));
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public class ConversationClientTests
         };
 
         HttpRequestException exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
-            conversationClient.SendActivityAsync(activity));
+            conversationClient.SendActivityAsync(activity, new Uri("https://test.service.url/")));
 
         Assert.Contains("Error sending activity", exception.Message);
         Assert.Contains("BadRequest", exception.Message);
@@ -159,11 +159,11 @@ public class ConversationClientTests
         CoreActivity activity = new()
         {
             Type = ActivityType.Message,
-            ServiceUrl = new Uri("https://test.service.url/"),
+            ServiceUrl = new Uri("https://ignored.service.url/"),
             Conversation = new("conv123")
         };
 
-        await conversationClient.SendActivityAsync(activity);
+        await conversationClient.SendActivityAsync(activity, new Uri("https://test.service.url/"));
 
         Assert.NotNull(capturedRequest);
         Assert.Equal("https://test.service.url/v3/conversations/conv123/activities/", capturedRequest.RequestUri?.ToString());
@@ -199,7 +199,7 @@ public class ConversationClientTests
             Recipient = new ChannelAccount { IsTargeted = true }
         };
 
-        await conversationClient.SendActivityAsync(activity);
+        await conversationClient.SendActivityAsync(activity, new Uri("https://test.service.url/"));
 
         Assert.NotNull(capturedRequest);
         Assert.Contains("isTargetedActivity=true", capturedRequest.RequestUri?.ToString());
@@ -232,7 +232,7 @@ public class ConversationClientTests
             ServiceUrl = new Uri("https://test.service.url/")
         };
 
-        await conversationClient.UpdateActivityAsync("conv123", "activity123", activity, isTargeted: true);
+        await conversationClient.UpdateActivityAsync("conv123", "activity123", activity, new Uri("https://test.service.url/"), isTargeted: true);
 
         Assert.NotNull(capturedRequest);
         Assert.Contains("isTargetedActivity=true", capturedRequest.RequestUri?.ToString());
@@ -297,7 +297,7 @@ public class ConversationClientTests
             ServiceUrl = new Uri("https://test.service.url/")
         };
 
-        await conversationClient.DeleteActivityAsync("conv123", activity, isTargeted: true);
+        await conversationClient.DeleteActivityAsync("conv123", activity, new Uri("https://test.service.url/"), isTargeted: true);
 
         Assert.NotNull(capturedRequest);
         Assert.Contains("isTargetedActivity=true", capturedRequest.RequestUri?.ToString());
@@ -336,7 +336,7 @@ public class ConversationClientTests
             ServiceUrl = new Uri("https://test.service.url/"),
         };
 
-        await conversationClient.UpdateTargetedActivityAsync("conv123", "activity123", activity);
+        await conversationClient.UpdateTargetedActivityAsync("conv123", "activity123", activity, new Uri("https://test.service.url/"));
 
         Assert.NotNull(capturedRequest);
         Assert.Contains("isTargetedActivity=true", capturedRequest.RequestUri?.ToString());
@@ -405,7 +405,7 @@ public class ConversationClientTests
             Conversation = new(longConversationId)
         };
 
-        await conversationClient.SendActivityAsync(activity);
+        await conversationClient.SendActivityAsync(activity, new Uri("https://test.service.url/"));
 
         Assert.NotNull(capturedRequest);
         string expectedTruncatedId = "acf";
@@ -444,7 +444,7 @@ public class ConversationClientTests
         """;
         CoreActivity activity = CoreActivity.FromJsonString(activityJson);
 
-        await conversationClient.SendActivityAsync(activity);
+        await conversationClient.SendActivityAsync(activity, new Uri("https://test.service.url/"));
 
         Assert.NotNull(capturedRequest);
         Assert.Contains("isTargetedActivity=true", capturedRequest.RequestUri?.ToString());
@@ -482,7 +482,7 @@ public class ConversationClientTests
         """;
         CoreActivity activity = CoreActivity.FromJsonString(activityJson);
 
-        await conversationClient.SendActivityAsync(activity);
+        await conversationClient.SendActivityAsync(activity, new Uri("https://test.service.url/"));
 
         // Verify the request was made (agenticIdentity is passed to BotHttpClient via request options)
         Assert.NotNull(capturedRequest);
@@ -518,7 +518,7 @@ public class ConversationClientTests
             From = from
         };
 
-        SendActivityResponse? result = await conversationClient.SendActivityAsync(activity);
+        SendActivityResponse? result = await conversationClient.SendActivityAsync(activity, new Uri("https://test.service.url/"));
 
         Assert.NotNull(result);
     }

--- a/core/test/Microsoft.Teams.Core.UnitTests/CoreActivityBuilderTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/CoreActivityBuilderTests.cs
@@ -47,18 +47,6 @@ public class CoreActivityBuilderTests
     }
 
     [Fact]
-    public void WithServiceUrl_SetsServiceUrl()
-    {
-        Uri serviceUrl = new("https://smba.trafficmanager.net/teams/");
-
-        CoreActivity activity = new CoreActivityBuilder()
-            .WithServiceUrl(serviceUrl)
-            .Build();
-
-        Assert.Equal(serviceUrl, activity.ServiceUrl);
-    }
-
-    [Fact]
     public void WithChannelId_SetsChannelId()
     {
         CoreActivity activity = new CoreActivityBuilder()
@@ -96,7 +84,6 @@ public class CoreActivityBuilderTests
             .WithId("activity-123")
             .WithChannelId("msteams")
             .WithProperty("text", "Test message")
-            .WithServiceUrl(new Uri("https://smba.trafficmanager.net/teams/"))
             .Build();
 
         Assert.Equal(ActivityType.Message, activity.Type);
@@ -194,16 +181,6 @@ public class CoreActivityBuilderTests
 
         Assert.Same(activity1, activity2);
         Assert.Equal("id-2", activity2.Id);
-    }
-
-    [Fact]
-    public void WithServiceUrl_String_SetsServiceUrl()
-    {
-        CoreActivity activity = new CoreActivityBuilder()
-            .WithServiceUrl("https://smba.trafficmanager.net/teams/")
-            .Build();
-
-        Assert.Equal(new Uri("https://smba.trafficmanager.net/teams/"), activity.ServiceUrl);
     }
 
 }

--- a/core/test/Microsoft.Teams.Core.UnitTests/Diagnostics/TelemetryTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Diagnostics/TelemetryTests.cs
@@ -114,7 +114,7 @@ public class TelemetryTests
             Type = ActivityType.Message,
             ServiceUrl = new Uri("https://smba.example/"),
             Conversation = new("conv-1"),
-        });
+        }, new Uri("https://smba.example/"));
 
         Assert.NotNull(response);
         Activity span = Assert.Single(spanCapture.Stopped, a => a.OperationName == "conversation_client");
@@ -144,7 +144,7 @@ public class TelemetryTests
             Type = ActivityType.Message,
             ServiceUrl = new Uri("https://smba.example/"),
             Conversation = new("conv-1"),
-        }));
+        }, new Uri("https://smba.example/")));
 
         Activity span = Assert.Single(spanCapture.Stopped, a => a.OperationName == "conversation_client");
         Assert.Equal(ActivityStatusCode.Error, span.Status);


### PR DESCRIPTION
## Summary

Make Core `ConversationClient` activity operations take an explicit `Uri serviceUrl` instead of deriving it from `CoreActivity.ServiceUrl`.

This unifies the pattern across Core, Compat, TeamsApps, and the other language SDKs. It removes the awkward behavior where some APIs derived routing information from `CoreActivity`, while others required it explicitly. Values like `serviceUrl` come from the inbound activity and act as SDK signals for which URL to call for the outbound request; they are not meant to be properties of the outbound activity itself.

## Changes

- Updated `SendActivityAsync`, `UpdateActivityAsync`, `UpdateTargetedActivityAsync`, and `DeleteActivityAsync(string, CoreActivity, ...)` to require `serviceUrl`.
- Stopped mutating outbound activities just to populate `ServiceUrl` in app/API/BotBuilder wrapper paths.
- Updated tests, samples, and mocks for the breaking signature change.

This PR includes breaking changes in Core. Since Core is still in preview, we believe this is the right time to make the change.

## Validation

- `dotnet test core/test/Microsoft.Teams.Core.UnitTests/Microsoft.Teams.Core.UnitTests.csproj`
- `dotnet test core/test/Microsoft.Teams.Apps.UnitTests/Microsoft.Teams.Apps.UnitTests.csproj`
- `dotnet test core/test/Microsoft.Teams.Apps.BotBuilder.UnitTests/Microsoft.Teams.Apps.BotBuilder.UnitTests.csproj`
- `dotnet build Microsoft.Teams.sln --no-restore --verbosity minimal`