### PR TITLE
Fix FromActivity to prefer BotId over Id for app identification

### DIFF
--- a/core/src/Microsoft.Teams.Core/Http/BotRequestContext.cs
+++ b/core/src/Microsoft.Teams.Core/Http/BotRequestContext.cs
@@ -44,7 +44,7 @@ public record BotRequestContext
     /// <param name="activity">The outbound activity, or null.</param>
     /// <returns>The context, or null when nothing could be derived.</returns>
     public static BotRequestContext? FromActivity(CoreActivity? activity)
-        => Build(Schema.AgenticIdentity.FromAccount(activity?.From), NormalizeAppId(activity?.From?.Id));
+        => Build(Schema.AgenticIdentity.FromAccount(activity?.From), NormalizeAppId(activity?.From?.BotId ?? activity?.From?.Id));
 
     /// <summary>
     /// Builds context for an <b>inbound</b> activity: the bot is the recipient, so both the bot app id and the

--- a/core/test/Microsoft.Teams.Core.UnitTests/Http/BotRequestContextTests.cs
+++ b/core/test/Microsoft.Teams.Core.UnitTests/Http/BotRequestContextTests.cs
@@ -93,6 +93,36 @@ public class BotRequestContextTests
     }
 
     [Fact]
+    public void FromActivity_PrefersBotId_WhenBothPresent()
+    {
+        CoreActivity activity = new()
+        {
+            Type = ActivityType.Message,
+            From = new ChannelAccount { Id = "28:from-account-id", BotId = "28:from-bot-id" },
+        };
+
+        BotRequestContext? ctx = BotRequestContext.FromActivity(activity);
+
+        Assert.NotNull(ctx);
+        Assert.Equal("from-bot-id", ctx!.BotAppId);
+    }
+
+    [Fact]
+    public void FromActivity_FallsBackToId_WhenBotIdAbsent()
+    {
+        CoreActivity activity = new()
+        {
+            Type = ActivityType.Message,
+            From = new ChannelAccount { Id = "28:from-app-id" },
+        };
+
+        BotRequestContext? ctx = BotRequestContext.FromActivity(activity);
+
+        Assert.NotNull(ctx);
+        Assert.Equal("from-app-id", ctx!.BotAppId);
+    }
+
+    [Fact]
     public void FromActivity_WithNullActivity_ReturnsNull()
     {
         Assert.Null(BotRequestContext.FromActivity(null));


### PR DESCRIPTION
Updated `BotRequestContext.FromActivity` to use `From.BotId ?? From.Id` instead of just `From.Id`, aligning with how `FromInboundActivity` already works.