### PR TITLE
docs: mark ExtendedMarkdown as preview in Libraries and Core

### DIFF
--- a/Libraries/Microsoft.Teams.Api/TextFormat.cs
+++ b/Libraries/Microsoft.Teams.Api/TextFormat.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 using Microsoft.Teams.Common;
@@ -19,6 +20,14 @@ public class TextFormat(string value) : StringEnum(value)
     public static readonly TextFormat Xml = new("xml");
     public bool IsXml => Xml.Equals(Value);
 
+    /// <summary>
+    /// Extended markdown text format. Supports GFM tables, LaTeX math blocks,
+    /// and other rich content beyond standard markdown.
+    /// </summary>
+    /// <remarks>
+    /// This format is currently in public preview and may be subject to change.
+    /// </remarks>
+    [Experimental("ExperimentalTeamsExtendedMarkdown")]
     public static readonly TextFormat ExtendedMarkdown = new("extendedmarkdown");
     public bool IsExtendedMarkdown => ExtendedMarkdown.Equals(Value);
 }

--- a/Libraries/Microsoft.Teams.Api/TextFormat.cs
+++ b/Libraries/Microsoft.Teams.Api/TextFormat.cs
@@ -29,5 +29,5 @@ public class TextFormat(string value) : StringEnum(value)
     /// </remarks>
     [Experimental("ExperimentalTeamsExtendedMarkdown")]
     public static readonly TextFormat ExtendedMarkdown = new("extendedmarkdown");
-    public bool IsExtendedMarkdown => ExtendedMarkdown.Equals(Value);
+    public bool IsExtendedMarkdown => "extendedmarkdown".Equals(Value);
 }

--- a/Samples/Samples.FormattedMessaging/Program.cs
+++ b/Samples/Samples.FormattedMessaging/Program.cs
@@ -30,7 +30,9 @@ teams.OnMessage(async (context, cancellationToken) =>
 $$E = mc^2$$
 """)
         {
+#pragma warning disable ExperimentalTeamsExtendedMarkdown
             TextFormat = TextFormat.ExtendedMarkdown
+#pragma warning restore ExperimentalTeamsExtendedMarkdown
         };
         await context.Send(reply, cancellationToken);
     }

--- a/Tests/Microsoft.Teams.Api.Tests/Activities/Message/MessageActivityTests.cs
+++ b/Tests/Microsoft.Teams.Api.Tests/Activities/Message/MessageActivityTests.cs
@@ -561,7 +561,9 @@ public class MessageActivityTests
     [Fact]
     public void TextFormat_ExtendedMarkdown_HasCorrectValue()
     {
+#pragma warning disable ExperimentalTeamsExtendedMarkdown
         Assert.Equal("extendedmarkdown", TextFormat.ExtendedMarkdown.ToString());
+#pragma warning restore ExperimentalTeamsExtendedMarkdown
         Assert.True(new TextFormat("extendedmarkdown").IsExtendedMarkdown);
         Assert.False(new TextFormat("markdown").IsExtendedMarkdown);
     }

--- a/core/samples/TeamsBot/Program.cs
+++ b/core/samples/TeamsBot/Program.cs
@@ -43,6 +43,7 @@ teamsApp.OnMessage("(?i)^help$", async (context, cancellationToken) =>
                  ]
         })
         .Build();
+#pragma warning restore ExperimentalTeamsExtendedMarkdown
 
     await context.SendAsync(helpActivity, cancellationToken);
 });
@@ -60,12 +61,14 @@ teamsApp.OnMessage("(?i)hello", async (context, cancellationToken) =>
         .WithText(replyText)
         .AddMention(context.Activity.From)
         .Build();
+#pragma warning restore ExperimentalTeamsExtendedMarkdown
     await context.SendAsync(ta, cancellationToken);
 });
 
 // Extended Markdown handler: matches "extendedMarkdown" (case-insensitive)
 teamsApp.OnMessage("(?i)^extendedMarkdown$", async (context, cancellationToken) =>
 {
+#pragma warning disable ExperimentalTeamsExtendedMarkdown
     MessageActivityInput extendedMarkdownMessage = MessageActivityInput.CreateBuilder()
         .WithText("""
 # Extended Markdown Demo
@@ -80,6 +83,7 @@ teamsApp.OnMessage("(?i)^extendedMarkdown$", async (context, cancellationToken) 
 $$E = mc^2$$
 """, TextFormats.ExtendedMarkdown)
         .Build();
+#pragma warning restore ExperimentalTeamsExtendedMarkdown
 
     await context.SendAsync(extendedMarkdownMessage, cancellationToken);
 });
@@ -120,6 +124,7 @@ public class Example
 > It can span multiple lines
 """, TextFormats.Markdown)
         .Build();
+#pragma warning restore ExperimentalTeamsExtendedMarkdown
 
     await context.SendAsync(markdownMessage, cancellationToken);
 });
@@ -146,6 +151,7 @@ teamsApp.OnMessage("(?i)citation", async (context, cancellationToken) =>
         .AddAIGenerated()
         .AddFeedback()
         .Build();
+#pragma warning restore ExperimentalTeamsExtendedMarkdown
 
     await context.SendAsync(reply, cancellationToken);
 });
@@ -158,6 +164,7 @@ teamsApp.OnMessage("(?i)^feedback$", async (context, cancellationToken) =>
     TeamsAttachment feedbackCard = TeamsAttachment.CreateBuilder()
             .WithAdaptiveCard(Cards.FeedbackCardObj)
             .Build();
+#pragma warning restore ExperimentalTeamsExtendedMarkdown
     MessageActivityInput feedbackActivity = MessageActivityInput.CreateBuilder().AddAttachment(feedbackCard).Build();
     await context.SendAsync(feedbackActivity, cancellationToken);
 });
@@ -198,6 +205,7 @@ teamsApp.OnAdaptiveCardAction(async (context, cancellationToken) =>
             .Build()
         )
         .Build();
+#pragma warning restore ExperimentalTeamsExtendedMarkdown
 
     await context.SendAsync(reply, cancellationToken);
 

--- a/core/src/Microsoft.Teams.Apps/Schema/MessageActivity.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/MessageActivity.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Microsoft.Teams.Apps.Schema.Entities;
 using Microsoft.Teams.Core.Schema;
@@ -140,5 +141,9 @@ public static class TextFormats
     /// Extended markdown text format. Supports GFM tables, LaTeX math blocks,
     /// and other rich content beyond standard markdown.
     /// </summary>
+    /// <remarks>
+    /// This format is currently in public preview and may be subject to change.
+    /// </remarks>
+    [Experimental("ExperimentalTeamsExtendedMarkdown")]
     public const string ExtendedMarkdown = "extendedmarkdown";
 }

--- a/core/test/Microsoft.Teams.Apps.UnitTests/MessageActivityTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/MessageActivityTests.cs
@@ -69,7 +69,9 @@ public class MessageActivityTests
         activity.TextFormat = TextFormats.Xml;
         Assert.Equal("xml", activity.TextFormat);
 
+#pragma warning disable ExperimentalTeamsExtendedMarkdown
         activity.TextFormat = TextFormats.ExtendedMarkdown;
+#pragma warning restore ExperimentalTeamsExtendedMarkdown
         Assert.Equal("extendedmarkdown", activity.TextFormat);
     }
 


### PR DESCRIPTION
## Summary
- mark `TextFormat.ExtendedMarkdown` as experimental in the Libraries SDK
- mark `TextFormats.ExtendedMarkdown` as experimental in the Core SDK
- note that the format remains in public preview