### PR TITLE
Polish state management

### DIFF
--- a/core/docs/TurnState-Design.md
+++ b/core/docs/TurnState-Design.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Enable per-turn state management in `BotApplication`, backed by `IDistributedCache` from the ASP.NET ecosystem. This allows developers to use any session state provider (Redis, SQL Server, in-memory, etc.) to persist state scoped to conversations and users.
+Enable per-turn state management in `TeamsBotApplication`, backed by `IDistributedCache` from the ASP.NET ecosystem. This allows developers to use any session state provider (Redis, SQL Server, in-memory, etc.) to persist state scoped to conversations and users.
 
 ## State Scopes
 
@@ -25,6 +25,9 @@ Per-turn state storage backed by `Dictionary<string, object?>`. Tracks dirty sta
 - Typed objects stored under `$FullTypeName` (e.g. `$MyApp.UserPreferences`).
 - Serialized to/from JSON via `System.Text.Json`.
 - Handles `JsonElement` values from deserialization — both key-value `Get<T>(key)` and typed `Get<T>()` deserialize `JsonElement` to the requested type after a cache round-trip.
+- `Clear()` removes all values in the scope; if a persisted scope is emptied this way, save removes it from storage.
+- State is sealed at end-of-turn (`Complete()`), and further access throws `InvalidOperationException`.
+- `IsCompleted` lets background code detect post-turn state without triggering the guard.
 
 ### `TurnStateContainer`
 
@@ -35,10 +38,12 @@ public sealed class TurnStateContainer
 {
     public TurnState ConversationState { get; }
     public TurnState? UserState { get; }
+    public Task DeleteAsync(CancellationToken cancellationToken = default);
 }
 ```
 
 `UserState` is null when the activity has no `From` field.
+`Complete()` is framework-internal and used by `TeamsBotApplication` to seal scopes at end of turn.
 
 ### `TurnStateLoader`
 
@@ -48,7 +53,9 @@ Loads and saves per-turn state from a distributed cache. Injected into `TeamsBot
 2. `SaveAsync`: Save each scope independently if dirty.
 3. `DeleteAsync`: Remove conversation and/or user state from the cache.
 
-State is loaded at the start of `OnActivity` and saved in a `finally` block, ensuring dirty state is persisted even on handler errors.
+`TurnStateContainer.DeleteAsync()` invokes this loader delete operation, then clears in-memory scopes immediately so reads in the same turn reflect deletion.
+
+State is loaded at the start of `OnActivity` and saved in a `finally` block. After save, `TeamsBotApplication` calls `defaultContext.State.Complete()` to seal both scopes for the rest of the turn lifecycle.
 
 ### `TurnStateOptions`
 
@@ -57,10 +64,7 @@ Configuration POCO:
 ```csharp
 public class TurnStateOptions
 {
-    public DistributedCacheEntryOptions CacheEntryOptions { get; set; } = new()
-    {
-        SlidingExpiration = TimeSpan.FromHours(1)
-    };
+    public DistributedCacheEntryOptions CacheEntryOptions { get; set; } = new();
 }
 ```
 

--- a/core/docs/sso/OAuthFlow-Design.md
+++ b/core/docs/sso/OAuthFlow-Design.md
@@ -120,7 +120,7 @@ Teams client) and null for server-side token-exchange / verify-state failures.
 | Scenario | Behavior |
 | --- | --- |
 | Channel or group chat | Silent SSO can't complete, so the card omits `TokenExchangeResource` and Teams shows the sign-in button directly. |
-| `resourcematchfailed` | The silent SSO leg failed — the Entra app's *Expose an API → Application ID URI* must match the connection's Token Exchange URL (`api://<domain>/botid-<appId>`). Teams then falls back to the button. |
+| `resourcematchfailed` | The silent SSO leg failed — the Entra app's *Expose an API → Application ID URI* must match the connection's Token Exchange URL (`api://<domain>/botid-<appId>`).|
 | User denies consent / exchange fails | Responds `412`, Teams shows the button fallback; `OnSignInFailure` fires with `failure: null`. |
 | Token expired | `GetTokenAsync` returns null; `SignInAsync` restarts the flow. |
 | Non-Entra provider (GitHub, etc.) | No `TokenExchangeResource`; sign-in always completes via the button + `signin/verifyState`. |

--- a/core/docs/sso/OAuthState-MultiConnection.md
+++ b/core/docs/sso/OAuthState-MultiConnection.md
@@ -1,0 +1,133 @@
+# Pending OAuth Connections in Multi-Connection Flows
+
+When a bot supports more than one OAuth connection, the callback payload does not always say which connection it belongs to. That is why the repo's pending-sign-in state matters.
+
+The main problem is with `signin/failure` and `signin/verifyState`:
+
+- `signin/tokenExchange` includes a `connectionName`
+- `signin/failure` does **not**
+- `signin/verifyState` does **not**
+
+Without a connection name, the app has to guess which flow the callback belongs to. In a multi-connection bot, that is fragile.
+
+## Example
+
+Imagine two connections:
+
+- `graph`
+- `github`
+
+The bot can start both flows:
+
+```csharp
+OAuthFlow graph = bot.GetOAuthFlow("graph");
+OAuthFlow github = bot.GetOAuthFlow("github");
+
+string? graphToken = await graph.SignInAsync(context, ct);
+string? githubToken = await github.SignInAsync(context, ct);
+```
+
+Now the bot receives a callback like this:
+
+```csharp
+// signin/failure payload
+new SignInFailureValue
+{
+    Code = "resource_match_failed",
+    Message = "SSO could not complete"
+}
+```
+
+There is no `connectionName` in that payload, so the app cannot tell whether it was `graph` or `github`.
+
+## What state is doing here
+
+We use turn state to remember which OAuth connections already started a sign-in.
+That lets the app make a best-effort choice when Teams sends back a callback without a
+connection name.
+
+The flow stores per-connection timestamps in user state:
+
+```csharp
+string pendingKey = $"__oauth:pending:{_connectionName}";
+string ssoPendingKey = $"__oauth:pending:sso:{_connectionName}";
+
+context.State.UserState.Set(pendingKey, now);
+if (ssoOffered)
+{
+    context.State.UserState.Set(ssoPendingKey, now);
+}
+```
+
+If state is not available, it falls back to in-memory tracking:
+
+```csharp
+_pendingSignIns[userId] = now;
+if (ssoOffered)
+{
+    _pendingSsoSignIns[userId] = now;
+}
+```
+
+## Current behavior
+
+The current implementation already has to work around the missing connection name:
+
+```csharp
+// signin/failure has no connection name, so the registry tries to attribute it
+// to the flow with a pending silent-SSO sign-in from repo state.
+OAuthFlow? target = registry.ResolvePendingSsoFlow(ctx);
+```
+
+That is only a best guess: it picks the most recent flow that offered silent SSO, and if
+that cannot be resolved it falls back to notifying every flow.
+
+For `signin/verifyState`, the registry first tries the most recently pending flow, then falls back to the rest:
+
+```csharp
+// Pseudocode: pick the most recent pending flow, then try the others.
+OAuthFlow? mostRecent = ...;
+if (mostRecent is not null)
+{
+    var response = await mostRecent.HandleVerifyStateAsync(ctx, verifyValue, ct);
+    if (response.Status == 200)
+    {
+        return response;
+    }
+}
+
+foreach (OAuthFlow flow in registry.GetAllFlows())
+{
+    if (flow == mostRecent)
+    {
+        continue;
+    }
+
+    var response = await flow.HandleVerifyStateAsync(ctx, verifyValue, ct);
+    if (response.Status == 200)
+    {
+        return response;
+    }
+}
+```
+
+That works, but it is still a fallback.
+
+## What would be better
+
+The service should include the `connectionName` in `signin/failure` and `signin/verifyState`, just like it already does for token exchange.
+
+```csharp
+// Ideal payload shape
+new
+{
+    connectionName = "graph",
+    state = "flow-123"
+}
+```
+
+If that were available, the app would not need to track the most recent sign-in failure or search across all flows.
+
+## Bottom line
+
+In multi-connection OAuth, repo state is a stop gap for remembering recent pending connections. It keeps the callbacks working, but this flow is not ideal and really needs service changes so `signin/failure` and `signin/verifyState` carry enough context to identify the right connection directly.

--- a/core/samples/OAuthFlowBot/OAuthFlowBot.csproj
+++ b/core/samples/OAuthFlowBot/OAuthFlowBot.csproj
@@ -7,6 +7,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.6" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\..\src\Microsoft.Teams.Apps\Microsoft.Teams.Apps.csproj" />
 	</ItemGroup>
 

--- a/core/samples/OAuthFlowBot/Program.cs
+++ b/core/samples/OAuthFlowBot/Program.cs
@@ -34,6 +34,14 @@ webAppBuilder.Services.AddTeamsBotApplication(options =>
     });
 });
 
+// Configure distributed cache for turn state persistence. This is optional, but recommended for production scenarios.
+// The sample below uses Redis, but you can use any IDistributedCache implementation.
+/*
+webAppBuilder.Services.AddStackExchangeRedisCache(options =>
+{
+    options.Configuration = webAppBuilder.Configuration.GetConnectionString("Redis") ?? throw new InvalidProgramException("Redis connection string not found");
+});*/
+
 WebApplication webApp = webAppBuilder.Build();
 
 TeamsBotApplication bot = webApp.UseTeamsBotApplication();

--- a/core/samples/OAuthFlowBot/Properties/launchSettings.TEMPLATE.json
+++ b/core/samples/OAuthFlowBot/Properties/launchSettings.TEMPLATE.json
@@ -10,7 +10,7 @@
         "AzureAD__ClientId": "",
         "AzureAD__ClientCredentials__0__SourceType": "ClientSecret",
         "AzureAd__ClientCredentials__0__ClientSecret": "",
-        //"ConnectionStrings__Redis": ""
+        "ConnectionStrings__Redis": ""
       },
       "applicationUrl": "http://localhost:3978"
     }

--- a/core/samples/OAuthFlowBot/Properties/launchSettings.TEMPLATE.json
+++ b/core/samples/OAuthFlowBot/Properties/launchSettings.TEMPLATE.json
@@ -9,7 +9,8 @@
         "AzureAD__TenantId": "",
         "AzureAD__ClientId": "",
         "AzureAD__ClientCredentials__0__SourceType": "ClientSecret",
-        "AzureAd__ClientCredentials__0__ClientSecret": ""
+        "AzureAd__ClientCredentials__0__ClientSecret": "",
+        //"ConnectionStrings__Redis": ""
       },
       "applicationUrl": "http://localhost:3978"
     }

--- a/core/samples/OAuthFlowBot/README.md
+++ b/core/samples/OAuthFlowBot/README.md
@@ -6,6 +6,7 @@ This sample shows multiple OAuth flows in one bot. It demonstrates how to keep s
 
 - Bot registered and installed in Teams.
 - Azure Bot OAuth connection settings created for both Graph and GitHub.
+- [optional for multiple instances] Redis available and configured via `ConnectionStrings__Redis` (for shared OAuth pending state across instances).
 
 ## OAuth connection setup
 
@@ -13,8 +14,8 @@ Configure these two connection settings in your bot resource:
 
 | Connection name | Provider | Scopes |
 |---|---|---|
-| `GraphConnection` | Azure AD v2 | `User.Read Calendars.Read` |
-| `GitHubConnection` | GitHub | `repo read:user` |
+| `sso` | Azure AD v2 | `User.Read Calendars.Read` |
+| `gh` | GitHub | `repo read:user` |
 
 ## What it shows
 

--- a/core/samples/StateBot/Program.cs
+++ b/core/samples/StateBot/Program.cs
@@ -57,7 +57,7 @@ teamsApp.OnMessage("(?i)^my name is (.+)$", async (context, ct) =>
     }
 
     context.State.UserState?.Set("name", name);
-    await context.SendAsync($"Got it. I'll remember you as **{name}**.", ct);
+    await context.SendAsync(MessageActivityInput.CreateBuilder().WithText($"Got it. I'll remember you as **{name}**.", TextFormats.Markdown).Build(), ct);
 });
 
 teamsApp.OnMessage("(?i)^who am i$", async (context, ct) =>

--- a/core/samples/StateBot/Program.cs
+++ b/core/samples/StateBot/Program.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Handlers;
+using Microsoft.Teams.Apps.Schema;
 
 WebApplicationBuilder webAppBuilder = WebApplication.CreateSlimBuilder(args);
 
@@ -16,33 +17,92 @@ webAppBuilder.Services.AddStackExchangeRedisCache(options =>
 });
 
 WebApplication webApp = webAppBuilder.Build();
+ILogger logger = webApp.Logger;
 
 TeamsBotApplication teamsApp = webApp.UseTeamsBotApplication();
 
-teamsApp.OnMessage(async (ctx, ct) =>
+teamsApp.OnMessage("(?i)^help$", async (context, ct) =>
 {
-    int counter = ctx.State.ConversationState.Get<int>("counter");
-    counter++;
-    ctx.State.ConversationState.Set("counter", counter);
-    await ctx.SendAsync($"Message #{counter} in this conversation.", ct);
+    string helpText = """
+        **StateBot commands**
+        - `count` - increment conversation counter
+        - `my name is <name>` - store your name in user state
+        - `who am i` - read your name from user state
+        - `show completed` - demo sealed state behavior after turn
+        - `reset counter` - clear this conversation's state
+        - `help` - show this message
+        """;
 
-    UserPrefs up = ctx.State.UserState?.Get<UserPrefs>() ?? new UserPrefs();
-    await ctx.SendAsync($"Your name is {up.UserName} and your favorite color is {up.FavoriteColor}.", ct);
+    await context.SendAsync(
+        MessageActivityInput.CreateBuilder().WithText(helpText, TextFormats.Markdown).Build(), ct);
+});
 
-    up.UserName = "User" + counter;
-    up.FavoriteColor = Colors[counter % Colors.Length];
-    ctx.State.UserState?.Set(up);
+// Persisted per conversation: shared by everyone in the chat.
+teamsApp.OnMessage("(?i)^count$", async (context, ct) =>
+{
+    int count = context.State.ConversationState.Get<int>("count") + 1;
+    context.State.ConversationState.Set("count", count);
+    await context.SendAsync($"This conversation's counter is now **{count}**.", ct);
+});
+
+// Persisted per user in this conversation.
+teamsApp.OnMessage("(?i)^my name is (.+)$", async (context, ct) =>
+{
+    string text = context.Activity.TextWithoutMentions?.Trim() ?? string.Empty;
+    string name = text["my name is ".Length..].Trim();
+    if (name.Length == 0)
+    {
+        await context.SendAsync("Please send `my name is <name>`.", ct);
+        return;
+    }
+
+    context.State.UserState?.Set("name", name);
+    await context.SendAsync($"Got it. I'll remember you as **{name}**.", ct);
+});
+
+teamsApp.OnMessage("(?i)^who am i$", async (context, ct) =>
+{
+    string? name = context.State.UserState?.Get<string>("name");
+    if (string.IsNullOrWhiteSpace(name))
+    {
+        await context.SendAsync("I don't know yet. Tell me with `my name is <name>`.", ct);
+        return;
+    }
+
+    await context.SendAsync($"You are **{name}**.", ct);
+});
+
+teamsApp.OnMessage("(?i)^show completed$", async (context, ct) =>
+{
+    var state = context.State;
+
+    _ = Task.Run(async () =>
+    {
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        // IsCompleted lets background code observe that the turn ended without tripping the guard.
+        bool completed = state.UserState?.IsCompleted ?? state.ConversationState.IsCompleted;
+        if (completed)
+        {
+            try
+            {
+                _ = state.UserState?.Get<string>("name");
+            }
+            catch (InvalidOperationException ex)
+            {
+                logger.LogWarning("Expected — state is sealed after the turn: {Message}", ex.Message);
+            }
+        }
+
+    });
+
+    await context.SendAsync("Started completion demo. Check logs in ~2 seconds.", ct);
+});
+
+teamsApp.OnMessage("(?i)^reset counter$", async (context, ct) =>
+{
+    context.State.ConversationState.Clear();
+    await context.SendAsync("Cleared this conversation's state. The counter is back to zero.", ct);
 });
 
 webApp.Run();
-
-static partial class Program
-{
-    internal static readonly string[] Colors = ["Red", "Blue", "Green", "Yellow", "Purple", "Orange", "Cyan", "Magenta"];
-}
-
-class UserPrefs
-{
-    public string FavoriteColor { get; set; } = "White";
-    public string UserName { get; set; } = "anon";
-}

--- a/core/samples/StateBot/Program.cs
+++ b/core/samples/StateBot/Program.cs
@@ -69,7 +69,7 @@ teamsApp.OnMessage("(?i)^who am i$", async (context, ct) =>
         return;
     }
 
-    await context.SendAsync($"You are **{name}**.", ct);
+    await context.SendAsync(MessageActivityInput.CreateBuilder().WithText($"You are **{name}**.", TextFormats.Markdown).Build(), ct);
 });
 
 teamsApp.OnMessage("(?i)^show completed$", async (context, ct) =>

--- a/core/samples/StateBot/Program.cs
+++ b/core/samples/StateBot/Program.cs
@@ -42,7 +42,7 @@ teamsApp.OnMessage("(?i)^count$", async (context, ct) =>
 {
     int count = context.State.ConversationState.Get<int>("count") + 1;
     context.State.ConversationState.Set("count", count);
-    await context.SendAsync($"This conversation's counter is now **{count}**.", ct);
+    await context.SendAsync(MessageActivityInput.CreateBuilder().WithText($"This conversation's counter is now **{count}**.", TextFormats.Markdown).Build(), ct);
 });
 
 // Persisted per user in this conversation.

--- a/core/samples/StateBot/Properties/launchSettings.TEMPLATE.json
+++ b/core/samples/StateBot/Properties/launchSettings.TEMPLATE.json
@@ -8,7 +8,8 @@
         "AzureAd__ClientId": "",
         "AzureAd__ClientCredentials__0__SourceType": "ClientSecret",
         "AzureAd__ClientCredentials__0__ClientSecret": "",
-        "AzureAd__Instance": "https://login.microsoftonline.com/"
+        "AzureAd__Instance": "https://login.microsoftonline.com/",
+        "ConnectionStrings__Redis": ""
       },
       "applicationUrl": "http://localhost:3978",
       "launchBrowser": false

--- a/core/samples/StateBot/README.md
+++ b/core/samples/StateBot/README.md
@@ -7,20 +7,16 @@ Shows conversation state and user state in a Teams bot, backed by Redis so value
 - Bot registered and installed in Teams.
 - Redis available and configured through `ConnectionStrings__Redis`.
 
-## What it shows
+## Commands
 
-- `UseState()` to enable Teams state helpers.
-- Conversation state for a per-conversation message counter.
-- User state for per-user preferences (`UserName`, `FavoriteColor`).
-- Redis-backed persistence instead of in-memory state.
-
-## Behavior
-
-| Interaction | Behavior |
+| Command | Behavior |
 |---|---|
-| first message in a conversation | Returns `Message #1` and default user prefs |
-| more messages in same conversation | Increments conversation counter |
-| same user in another conversation | Counter restarts for that conversation, user prefs continue for the user |
+| `count` | Increments a counter in **conversation** state (shared by everyone in this chat). |
+| `my name is <name>` | Saves your name in **user** state. |
+| `who am i` | Reads your saved name from user state. |
+| `show completed` | Starts a background task that demonstrates sealed state (`IsCompleted`) after turn end. |
+| `reset counter` | Clears this conversation's state (counter resets). |
+| `help` | Shows command help. |
 
 ## Running the Sample
 
@@ -28,4 +24,4 @@ Shows conversation state and user state in a Teams bot, backed by Redis so value
 dotnet run --project samples/StateBot/StateBot.csproj
 ~~~
 
-In Teams, send multiple messages in one chat, then another chat, to verify conversation vs user state behavior.
+In Teams, try `count`, `my name is Ada`, `who am i`, `show completed`, and `reset counter` to verify conversation vs user state behavior.

--- a/core/samples/TeamsBot/Program.cs
+++ b/core/samples/TeamsBot/Program.cs
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Handlers;
-using Microsoft.Teams.Apps.Handlers.TaskModules;
 using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Apps.Schema.Entities;
-using Microsoft.Teams.Core;
 using TeamsBot;
 
 WebApplicationBuilder webAppBuilder = WebApplication.CreateSlimBuilder(args);

--- a/core/src/Microsoft.Teams.Apps/Handlers/InvokeHandler.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/InvokeHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Teams.Apps.Handlers.TaskModules;
 using Microsoft.Teams.Apps.Routing;
 using Microsoft.Teams.Apps.Schema;
 
@@ -24,7 +25,7 @@ public static class InvokeExtensions
     /// <summary>
     /// Registers a catch-all handler for all invoke activities.
     /// Cannot be combined with specific invoke handlers such as <see cref="AdaptiveCardExtensions.OnAdaptiveCardAction"/>,
-    /// <see cref="TaskExtensions.OnTaskFetch"/>, etc.
+    /// <see cref="Microsoft.Teams.Apps.Handlers.TaskModules.TaskExtensions.OnTaskFetch(TeamsBotApplication, TaskModuleHandler)"/>, etc.
     /// </summary>
     /// <remarks>
     /// Breaking change: previously a catch-all invoke handler could be registered alongside specific invoke handlers. This combination now throws at registration time.

--- a/core/src/Microsoft.Teams.Apps/Handlers/TaskModules/TaskHandler.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/TaskModules/TaskHandler.cs
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Teams.Apps.Handlers.TaskModules;
 using Microsoft.Teams.Apps.Routing;
 using Microsoft.Teams.Apps.Schema;
 
-namespace Microsoft.Teams.Apps.Handlers;
+namespace Microsoft.Teams.Apps.Handlers.TaskModules;
 
 /// <summary>
 /// Delegate for handling task module invoke activities.

--- a/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
+++ b/core/src/Microsoft.Teams.Apps/OAuth/OAuthFlow.cs
@@ -409,7 +409,6 @@ public class OAuthFlow
             }
             catch (HttpRequestException ex)
             {
-                ClearPendingSignIn(context, userId);
                 _logger.LogWarning(ex, "Token exchange failed for connection '{ConnectionName}', user '{UserId}'.", connectionName, userId);
                 response = await HandleTokenExchangeFailureAsync(context, exchangeValue, ex.StatusCode, ex.Message, cancellationToken).ConfigureAwait(false);
                 result = AppsTelemetry.OAuthResults.Failure;
@@ -417,6 +416,7 @@ public class OAuthFlow
                 span?.SetTag(AppsTelemetry.Tags.InvokeResponseStatus, response.Status);
                 if (IsUnexpectedHttpStatus(ex.StatusCode))
                 {
+                    ClearPendingSignIn(context, userId);
                     RecordOAuthError(span, AppsTelemetry.OAuthOperations.TokenExchange, AppsTelemetry.OAuthErrorTypes.HttpError, ex, connectionName);
                 }
                 return response;
@@ -467,12 +467,9 @@ public class OAuthFlow
 
         // For unexpected status codes (e.g., 401 Unauthorized, 403 Forbidden),
         // return the original status code so the caller can distinguish the failure.
-        if (statusCode.HasValue
-            && statusCode.Value != System.Net.HttpStatusCode.NotFound
-            && statusCode.Value != System.Net.HttpStatusCode.BadRequest
-            && statusCode.Value != System.Net.HttpStatusCode.PreconditionFailed)
+        if (IsUnexpectedHttpStatus(statusCode))
         {
-            return new InvokeResponse((int)statusCode.Value);
+            return new InvokeResponse((int)statusCode!.Value);
         }
 
         // 412 tells Teams to show the sign-in card as fallback.
@@ -591,57 +588,6 @@ public class OAuthFlow
     }
 
     /// <summary>
-    /// Whether this flow has a pending sign-in for the user in the given context.
-    /// Used to scope <c>signin/failure</c> notifications to flows that initiated a sign-in.
-    /// </summary>
-    /// <remarks>
-    /// When turn state is configured, checks user state (works across instances).
-    /// Falls back to in-memory tracking when state is not configured.
-    /// Callers should fall back to notifying all flows when no flow reports a pending sign-in
-    /// (e.g., multi-instance deployment without distributed state).
-    /// </remarks>
-    internal bool HasPendingSignIn(Context<InvokeActivity> context)
-    {
-        return GetPendingSignInTimestamp(context) is not null;
-    }
-
-    /// <summary>
-    /// Returns the timestamp when this flow's pending sign-in was initiated, or <c>null</c> if none.
-    /// Used to select the most recently initiated flow when multiple flows have pending sign-ins.
-    /// </summary>
-    internal DateTimeOffset? GetPendingSignInTimestamp(Context<InvokeActivity> context)
-    {
-        string pendingKey = $"__oauth:pending:{_connectionName}";
-        if (context.HasState && context.State.UserState is not null)
-        {
-            DateTimeOffset ts = context.State.UserState.Get<DateTimeOffset>(pendingKey);
-            return ts != default ? ts : null;
-        }
-
-        string userId = context.Activity.From?.Id ?? string.Empty;
-        return _pendingSignIns.TryGetValue(userId, out DateTimeOffset timestamp) ? timestamp : null;
-    }
-
-    /// <summary>
-    /// Returns the timestamp when this flow initiated a pending sign-in that actually offered
-    /// silent SSO (an OAuth card with a non-null TokenExchangeResource), or <c>null</c> if none.
-    /// Used to attribute <c>signin/failure</c> — which Teams only emits for SSO attempts — to
-    /// the correct connection, avoiding firing the failure callback on non-SSO flows.
-    /// </summary>
-    internal DateTimeOffset? GetPendingSsoSignInTimestamp<TActivity>(Context<TActivity> context) where TActivity : TeamsActivity
-    {
-        string ssoPendingKey = $"__oauth:pending:sso:{_connectionName}";
-        if (context.HasState && context.State.UserState is not null)
-        {
-            DateTimeOffset ts = context.State.UserState.Get<DateTimeOffset>(ssoPendingKey);
-            return ts != default ? ts : null;
-        }
-
-        string userId = context.Activity.From?.Id ?? string.Empty;
-        return _pendingSsoSignIns.TryGetValue(userId, out DateTimeOffset timestamp) ? timestamp : null;
-    }
-
-    /// <summary>
     /// Handles the signin/failure invoke activity sent by the Teams client when SSO fails client-side.
     /// </summary>
     internal async Task<InvokeResponse> HandleSignInFailureAsync(Context<InvokeActivity> context, SignInFailureValue failureValue, CancellationToken cancellationToken)
@@ -702,6 +648,7 @@ public class OAuthFlow
     /// </summary>
     private bool IsDuplicateExchange(Context<InvokeActivity> context, string exchangeId)
     {
+        CleanupExpiredEntries();
         // Atomic same-instance check — catches concurrent duplicate requests on this node
         if (!_processedExchanges.TryAdd(exchangeId, DateTimeOffset.UtcNow))
         {
@@ -720,8 +667,60 @@ public class OAuthFlow
             context.State.ConversationState.Set(dedupKey, DateTimeOffset.UtcNow);
         }
 
-        CleanupExpiredEntries();
         return false;
+    }
+
+    /// <summary>
+    /// Whether this flow has a pending sign-in for the user in the given context.
+    /// Used to scope <c>signin/failure</c> notifications to flows that initiated a sign-in.
+    /// </summary>
+    /// <remarks>
+    /// When turn state is configured, checks user state (works across instances).
+    /// Falls back to in-memory tracking when state is not configured.
+    /// Callers should fall back to notifying all flows when no flow reports a pending sign-in
+    /// (e.g., multi-instance deployment without distributed state).
+    /// </remarks>
+    internal bool HasPendingSignIn(Context<InvokeActivity> context)
+    {
+        return GetPendingSignInTimestamp(context) is not null;
+    }
+
+    /// <summary>
+    /// Returns the timestamp when this flow's pending sign-in was initiated, or <c>null</c> if none.
+    /// Used to select the most recently initiated flow when multiple flows have pending sign-ins.
+    /// </summary>
+    internal DateTimeOffset? GetPendingSignInTimestamp(Context<InvokeActivity> context)
+    {
+        string pendingKey = $"__oauth:pending:{_connectionName}";
+        if (context.HasState && context.State.UserState is not null)
+        {
+            DateTimeOffset ts = context.State.UserState.Get<DateTimeOffset>(pendingKey);
+            return ts != default ? ts : null;
+        }
+
+        CleanupExpiredEntries();
+        string userId = context.Activity.From?.Id ?? string.Empty;
+        return _pendingSignIns.TryGetValue(userId, out DateTimeOffset timestamp) ? timestamp : null;
+    }
+
+    /// <summary>
+    /// Returns the timestamp when this flow initiated a pending sign-in that actually offered
+    /// silent SSO (an OAuth card with a non-null TokenExchangeResource), or <c>null</c> if none.
+    /// Used to attribute <c>signin/failure</c> — which Teams only emits for SSO attempts — to
+    /// the correct connection, avoiding firing the failure callback on non-SSO flows.
+    /// </summary>
+    internal DateTimeOffset? GetPendingSsoSignInTimestamp<TActivity>(Context<TActivity> context) where TActivity : TeamsActivity
+    {
+        string ssoPendingKey = $"__oauth:pending:sso:{_connectionName}";
+        if (context.HasState && context.State.UserState is not null)
+        {
+            DateTimeOffset ts = context.State.UserState.Get<DateTimeOffset>(ssoPendingKey);
+            return ts != default ? ts : null;
+        }
+
+        CleanupExpiredEntries();
+        string userId = context.Activity.From?.Id ?? string.Empty;
+        return _pendingSsoSignIns.TryGetValue(userId, out DateTimeOffset timestamp) ? timestamp : null;
     }
 
 

--- a/core/src/Microsoft.Teams.Apps/State/TurnState.cs
+++ b/core/src/Microsoft.Teams.Apps/State/TurnState.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Teams.Apps.State;
 public class TurnState
 {
     private readonly Dictionary<string, object?> _data;
+    private bool _completed;
 
     /// <summary>
     /// Initializes a new, empty <see cref="TurnState"/>.
@@ -26,10 +27,22 @@ public class TurnState
     public bool IsDirty { get; internal set; }
 
     /// <summary>
+    /// Returns true once this state scope has been sealed at end of turn.
+    /// </summary>
+    public bool IsCompleted => _completed;
+
+    /// <summary>
+    /// Returns true when the scope contains no values.
+    /// </summary>
+    public bool IsEmpty => _data.Count == 0;
+
+    /// <summary>
     /// Gets a value by key. Returns <c>default</c> if the key is not present or the value cannot be converted.
     /// </summary>
     public T? Get<T>(string key)
     {
+        ThrowIfCompleted();
+
         if (!_data.TryGetValue(key, out object? value) || value is null)
         {
             return default;
@@ -61,6 +74,8 @@ public class TurnState
     /// </summary>
     public void Set<T>(string key, T value)
     {
+        ThrowIfCompleted();
+
         _data[key] = value;
         IsDirty = true;
     }
@@ -70,10 +85,23 @@ public class TurnState
     /// </summary>
     public void Remove(string key)
     {
+        ThrowIfCompleted();
+
         if (_data.Remove(key))
         {
             IsDirty = true;
         }
+    }
+
+    /// <summary>
+    /// Removes every value from the scope.
+    /// A persisted scope emptied this way is deleted from storage on save.
+    /// </summary>
+    public void Clear()
+    {
+        ThrowIfCompleted();
+        IsDirty |= _data.Count > 0;
+        _data.Clear();
     }
 
     /// <summary>
@@ -82,6 +110,8 @@ public class TurnState
     /// </summary>
     public bool TryGet<T>(string key, out T? value)
     {
+        ThrowIfCompleted();
+
         if (!_data.TryGetValue(key, out object? raw) || raw is null)
         {
             value = default;
@@ -115,13 +145,19 @@ public class TurnState
     /// <summary>
     /// Returns <c>true</c> if the key exists in state.
     /// </summary>
-    public bool ContainsKey(string key) => _data.ContainsKey(key);
+    public bool ContainsKey(string key)
+    {
+        ThrowIfCompleted();
+        return _data.ContainsKey(key);
+    }
 
     /// <summary>
     /// Gets a typed state object. Creates a new instance via parameterless constructor if not present.
     /// </summary>
     public T Get<T>() where T : class, new()
     {
+        ThrowIfCompleted();
+
         string key = TypeKey<T>();
 
         if (_data.TryGetValue(key, out object? value) && value is not null)
@@ -158,6 +194,8 @@ public class TurnState
     /// </summary>
     public void Set<T>(T value) where T : class
     {
+        ThrowIfCompleted();
+
         _data[TypeKey<T>()] = value;
         IsDirty = true;
     }
@@ -165,13 +203,19 @@ public class TurnState
     /// <summary>
     /// Returns <c>true</c> if a typed state object of this type exists.
     /// </summary>
-    public bool Has<T>() where T : class => _data.ContainsKey(TypeKey<T>());
+    public bool Has<T>() where T : class
+    {
+        ThrowIfCompleted();
+        return _data.ContainsKey(TypeKey<T>());
+    }
 
     /// <summary>
     /// Removes the typed state object of this type.
     /// </summary>
     public void Remove<T>() where T : class
     {
+        ThrowIfCompleted();
+
         if (_data.Remove(TypeKey<T>()))
         {
             IsDirty = true;
@@ -181,7 +225,11 @@ public class TurnState
     /// <summary>
     /// Serializes the state to a JSON byte array.
     /// </summary>
-    public byte[] ToJsonBytes() => JsonSerializer.SerializeToUtf8Bytes(_data);
+    public byte[] ToJsonBytes()
+    {
+        ThrowIfCompleted();
+        return JsonSerializer.SerializeToUtf8Bytes(_data);
+    }
 
     /// <summary>
     /// Deserializes a <see cref="TurnState"/> from a JSON byte array.
@@ -212,6 +260,22 @@ public class TurnState
     public static TurnState FromDictionary(Dictionary<string, object?> data)
     {
         return new TurnState(new Dictionary<string, object?>(data));
+    }
+
+    /// <summary>
+    /// Seals the state; subsequent access throws.
+    /// </summary>
+    internal void Complete() => _completed = true;
+
+    private void ThrowIfCompleted()
+    {
+        if (_completed)
+        {
+            throw new InvalidOperationException(
+                "TurnState was accessed after the turn completed. State is per-turn and is saved once " +
+                "when the handler returns. Read the values you need during the turn and pass them into " +
+                "any background work, e.g. `var name = ctx.State.UserState.Get<string>(\"name\");`.");
+        }
     }
 
     private static string TypeKey<T>() => $"${typeof(T).FullName}";

--- a/core/src/Microsoft.Teams.Apps/State/TurnStateContainer.cs
+++ b/core/src/Microsoft.Teams.Apps/State/TurnStateContainer.cs
@@ -43,9 +43,17 @@ public sealed class TurnStateContainer
     }
 
     /// <summary>
-    /// Deletes conversation and user state from the backing store.
-    /// The in-memory state remains accessible for the rest of the turn
-    /// but will not be persisted at end-of-turn unless new values are written.
+    /// Seals all scopes; subsequent access throws.
+    /// </summary>
+    internal void Complete()
+    {
+        ConversationState.Complete();
+        UserState?.Complete();
+    }
+
+    /// <summary>
+    /// Deletes conversation and user state from the backing store and clears in-memory scopes.
+    /// Scopes remain available for reads/writes afterward, but as empty state.
     /// </summary>
     /// <param name="cancellationToken">A cancellation token.</param>
     public async Task DeleteAsync(CancellationToken cancellationToken = default)
@@ -57,6 +65,10 @@ public sealed class TurnStateContainer
         }
 
         await _deleteDelegate(cancellationToken).ConfigureAwait(false);
+
+        // Clear in-memory snapshots so state reflects deletion immediately in this turn.
+        ConversationState.Clear();
+        UserState?.Clear();
 
         // Clear dirty flags so end-of-turn save doesn't re-persist the deleted state.
         ConversationState.IsDirty = false;

--- a/core/src/Microsoft.Teams.Apps/State/TurnStateLoader.cs
+++ b/core/src/Microsoft.Teams.Apps/State/TurnStateLoader.cs
@@ -104,17 +104,31 @@ public sealed class TurnStateLoader
             if (convDirty)
             {
                 string conversationKey = $"{_options.KeyPrefix}:conv:{conversationId}";
-                byte[] bytes = container.ConversationState.ToJsonBytes();
-                bytesWritten += bytes.Length;
-                await _cache.SetAsync(conversationKey, bytes, _options.CacheEntryOptions, cancellationToken).ConfigureAwait(false);
+                if (container.ConversationState.IsEmpty)
+                {
+                    await _cache.RemoveAsync(conversationKey, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    byte[] bytes = container.ConversationState.ToJsonBytes();
+                    bytesWritten += bytes.Length;
+                    await _cache.SetAsync(conversationKey, bytes, _options.CacheEntryOptions, cancellationToken).ConfigureAwait(false);
+                }
             }
 
             if (userDirty)
             {
                 string userKey = $"{_options.KeyPrefix}:user:{conversationId}:{userId}";
-                byte[] bytes = container.UserState!.ToJsonBytes();
-                bytesWritten += bytes.Length;
-                await _cache.SetAsync(userKey, bytes, _options.CacheEntryOptions, cancellationToken).ConfigureAwait(false);
+                if (container.UserState!.IsEmpty)
+                {
+                    await _cache.RemoveAsync(userKey, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    byte[] bytes = container.UserState.ToJsonBytes();
+                    bytesWritten += bytes.Length;
+                    await _cache.SetAsync(userKey, bytes, _options.CacheEntryOptions, cancellationToken).ConfigureAwait(false);
+                }
             }
 
             span?.SetTag(AppsTelemetry.Tags.StateConversationDirty, convDirty);

--- a/core/src/Microsoft.Teams.Apps/State/TurnStateOptions.cs
+++ b/core/src/Microsoft.Teams.Apps/State/TurnStateOptions.cs
@@ -12,12 +12,9 @@ public class TurnStateOptions
 {
     /// <summary>
     /// Gets or sets the cache entry options applied when saving state.
-    /// Defaults to a 1-hour sliding expiration.
+    /// Defaults to no expiration.
     /// </summary>
-    public DistributedCacheEntryOptions CacheEntryOptions { get; set; } = new()
-    {
-        SlidingExpiration = TimeSpan.FromHours(1)
-    };
+    public DistributedCacheEntryOptions CacheEntryOptions { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the prefix for cache keys.

--- a/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
@@ -180,6 +180,7 @@ public class TeamsBotApplication : BotApplication
                 if (_stateLoader is not null && defaultContext.HasState)
                 {
                     await _stateLoader.SaveAsync(defaultContext.State, conversationId!, teamsActivity.From?.Id, cancellationToken).ConfigureAwait(false);
+                    defaultContext.State.Complete();
                 }
             }
         };

--- a/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/OAuthFlowTests.cs
@@ -158,7 +158,7 @@ public class OAuthFlowTests
     }
 
     [Fact]
-    public async Task TokenExchange_Failure_ClearsPendingSignIn()
+    public async Task TokenExchange_Non412Failure_ClearsPendingSignIn()
     {
         TestHarness harness = CreateHarness(GraphConnection);
 
@@ -247,6 +247,24 @@ public class OAuthFlowTests
             .ThrowsAsync(new HttpRequestException("Not found", null, System.Net.HttpStatusCode.NotFound));
 
         SignInTokenExchangeValue exchangeValue = new() { Id = "ex-1", ConnectionName = GraphConnection, Token = "sso-token" };
+        Context<InvokeActivity> invokeCtx = CreateInvokeContext(harness, TestUserId);
+
+        InvokeResponse response = await harness.GraphFlow!.HandleTokenExchangeAsync(invokeCtx, exchangeValue, CancellationToken.None);
+
+        Assert.Equal(412, response.Status);
+        Assert.NotNull(response.Body);
+    }
+
+    [Fact]
+    public async Task TokenExchange_PreconditionFailed_Returns412WithBody()
+    {
+        TestHarness harness = CreateHarness(GraphConnection);
+
+        harness.MockUserTokenClient
+            .Setup(c => c.ExchangeTokenAsync(TestUserId, GraphConnection, TestChannelId, "sso-token", null, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Precondition failed", null, System.Net.HttpStatusCode.PreconditionFailed));
+
+        SignInTokenExchangeValue exchangeValue = new() { Id = "ex-412", ConnectionName = GraphConnection, Token = "sso-token" };
         Context<InvokeActivity> invokeCtx = CreateInvokeContext(harness, TestUserId);
 
         InvokeResponse response = await harness.GraphFlow!.HandleTokenExchangeAsync(invokeCtx, exchangeValue, CancellationToken.None);

--- a/core/test/Microsoft.Teams.Apps.UnitTests/State/TurnStateContainerTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/State/TurnStateContainerTests.cs
@@ -84,6 +84,30 @@ public class TurnStateContainerTests
     }
 
     [Fact]
+    public async Task DeleteAsync_ClearsInMemoryConversationState()
+    {
+        TurnStateContainer container = CreateContainer();
+        container.SetDeleteDelegate(_ => Task.CompletedTask);
+        container.ConversationState.Set("key", "value");
+
+        await container.DeleteAsync();
+
+        Assert.False(container.ConversationState.ContainsKey("key"));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ClearsInMemoryUserState()
+    {
+        TurnStateContainer container = CreateContainer();
+        container.SetDeleteDelegate(_ => Task.CompletedTask);
+        container.UserState!.Set("name", "Ada");
+
+        await container.DeleteAsync();
+
+        Assert.False(container.UserState.ContainsKey("name"));
+    }
+
+    [Fact]
     public async Task DeleteAsync_PassesCancellationToken()
     {
         CancellationToken captured = default;

--- a/core/test/Microsoft.Teams.Apps.UnitTests/State/TurnStateLoaderTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/State/TurnStateLoaderTests.cs
@@ -119,6 +119,44 @@ public class TurnStateLoaderTests
     }
 
     [Fact]
+    public async Task SaveAsync_EmptyDirtyUserState_IsRemoved()
+    {
+        TurnStateLoader loader = CreateLoader();
+        TurnStateContainer container = await loader.LoadAsync("conv1", "user1", CancellationToken.None);
+
+        container.UserState!.Set("key", "value");
+        container.UserState.Clear();
+
+        await loader.SaveAsync(container, "conv1", "user1", CancellationToken.None);
+
+        _cacheMock.Verify(c => c.RemoveAsync("ts:user:conv1:user1", It.IsAny<CancellationToken>()), Times.Once);
+        _cacheMock.Verify(c => c.SetAsync(
+            "ts:user:conv1:user1",
+            It.IsAny<byte[]>(),
+            It.IsAny<DistributedCacheEntryOptions>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SaveAsync_EmptyDirtyConversationState_IsRemoved()
+    {
+        TurnStateLoader loader = CreateLoader();
+        TurnStateContainer container = await loader.LoadAsync("conv1", "user1", CancellationToken.None);
+
+        container.ConversationState.Set("key", "value");
+        container.ConversationState.Clear();
+
+        await loader.SaveAsync(container, "conv1", "user1", CancellationToken.None);
+
+        _cacheMock.Verify(c => c.RemoveAsync("ts:conv:conv1", It.IsAny<CancellationToken>()), Times.Once);
+        _cacheMock.Verify(c => c.SetAsync(
+            "ts:conv:conv1",
+            It.IsAny<byte[]>(),
+            It.IsAny<DistributedCacheEntryOptions>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task SaveAsync_NonDirtyState_IsNotSaved()
     {
         TurnStateLoader loader = CreateLoader();

--- a/core/test/Microsoft.Teams.Apps.UnitTests/State/TurnStateTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/State/TurnStateTests.cs
@@ -70,6 +70,29 @@ public class TurnStateTests
     }
 
     [Fact]
+    public void Clear_WithValues_EmptiesStateAndMarksDirty()
+    {
+        TurnState state = new();
+        state.Set("key", "value");
+
+        state.Clear();
+
+        Assert.True(state.IsDirty);
+        Assert.False(state.ContainsKey("key"));
+        Assert.Null(state.Get<string>("key"));
+    }
+
+    [Fact]
+    public void Clear_EmptyState_DoesNotMarkDirty()
+    {
+        TurnState state = new();
+
+        state.Clear();
+
+        Assert.False(state.IsDirty);
+    }
+
+    [Fact]
     public void ContainsKey_ExistingKey_ReturnsTrue()
     {
         TurnState state = new();
@@ -147,6 +170,19 @@ public class TurnStateTests
         state.Remove<FakeState>();
 
         Assert.False(state.Has<FakeState>());
+    }
+
+    [Fact]
+    public void Clear_AfterTypedSet_EmptiesAllTypedValues()
+    {
+        TurnState state = new();
+        state.Set(new FakeState { Name = "custom" });
+        state.Set(new OtherState { Count = 7 });
+
+        state.Clear();
+
+        Assert.False(state.Has<FakeState>());
+        Assert.False(state.Has<OtherState>());
     }
 
     [Fact]
@@ -228,6 +264,21 @@ public class TurnStateTests
         TurnState state = TurnState.FromDictionary(new Dictionary<string, object?> { ["x"] = 1 });
 
         Assert.False(state.IsDirty);
+    }
+
+    [Fact]
+    public void Complete_AfterTurn_ThrowsOnFurtherAccess()
+    {
+        TurnState state = new();
+        state.Set("name", "Alice");
+
+        Assert.False(state.IsCompleted);
+        state.Complete();
+        Assert.True(state.IsCompleted);
+
+        Assert.Throws<InvalidOperationException>(() => state.Get<string>("name"));
+        Assert.Throws<InvalidOperationException>(() => state.Set("other", "value"));
+        Assert.Throws<InvalidOperationException>(() => state.ContainsKey("name"));
     }
 
     // ── Serialization ─────────────────────────────────────────────────


### PR DESCRIPTION
This pull request introduces several improvements and updates focused on state management, OAuth multi-connection flows, and sample code clarity. The most notable changes include enhanced documentation for per-turn state and OAuth flows, improved sample bot implementations, and better guidance for using distributed cache (e.g., Redis) for state persistence.

**State Management Enhancements and Documentation:**

* Updated the per-turn state management documentation to clarify that `TeamsBotApplication` (not `BotApplication`) is the entry point, detailed how state is sealed at end-of-turn, and described new behaviors for `Clear()`, `Complete()`, and `IsCompleted` in state containers. [[1]](diffhunk://#diff-13fa54706e54eae920f8dd60cb376aa29e68d8d344810f06d5ea0f2aa30df679L5-R5) [[2]](diffhunk://#diff-13fa54706e54eae920f8dd60cb376aa29e68d8d344810f06d5ea0f2aa30df679R28-R30) [[3]](diffhunk://#diff-13fa54706e54eae920f8dd60cb376aa29e68d8d344810f06d5ea0f2aa30df679R41-R46) [[4]](diffhunk://#diff-13fa54706e54eae920f8dd60cb376aa29e68d8d344810f06d5ea0f2aa30df679L51-R58)
* Simplified the default `TurnStateOptions` to remove the default sliding expiration, making cache configuration more explicit.

**OAuth Multi-Connection Flow Improvements:**

* Added a new documentation file explaining how pending OAuth sign-ins are tracked in multi-connection scenarios, why this is necessary, and what would improve the flow (i.e., including `connectionName` in all callback payloads).
* Clarified that the `resourcematchfailed` scenario no longer always falls back to the button, and improved table descriptions in the OAuth flow design doc.

**Sample Code and Configuration Updates:**

* Updated the `OAuthFlowBot` sample to show how to configure Redis for distributed cache, updated README and launch settings to reflect new connection names and Redis usage, and clarified requirements. [[1]](diffhunk://#diff-09ea150c55b6f99de807e738ee3b6d235f4dd5d7de9a776b7b98fafb716bb11bR9-R12) [[2]](diffhunk://#diff-af9c636dc98cda2d36169fc80702d34f17d21ece7c261ed06936c36acc67d4caR37-R44) [[3]](diffhunk://#diff-53ba86fa983fd629b5b9fd9f33a5ec602dbcf0e5bddc5b6ef64359a1a8b620ecL12-R13) [[4]](diffhunk://#diff-72f7c8df75ac361bf498fec8870b28795e948a2682b0a3ae51e687ae414f75feR9-R18)
* Refactored the `StateBot` sample to provide command-based interactions, demonstrate sealed state behavior, and add Redis configuration to launch settings and docs. [[1]](diffhunk://#diff-a7ea41bfb56a5c9f8183455f54d218bd84caba7a7a979c3d9130d0148bd0aeafR6) [[2]](diffhunk://#diff-a7ea41bfb56a5c9f8183455f54d218bd84caba7a7a979c3d9130d0148bd0aeafR20-R108) [[3]](diffhunk://#diff-6a1419375671474d8f05d9043d1a73fdcc2e5359ec92375b3316b2d39cea2fa1L11-R12) [[4]](diffhunk://#diff-fd8f19bcf2a3eab53c2eddbfde6a83c0a67aa3a25c18d188c9008d809724dc48L10-R27)

**Codebase Organization and Consistency:**

* Moved the `TaskHandler` delegate to a new namespace (`Microsoft.Teams.Apps.Handlers.TaskModules`) and updated references for clarity and consistency. [[1]](diffhunk://#diff-36fc06a0188e4676200cee500f3a55cf3c56b8c163f747ea06ec975810da14e9L4-R7) [[2]](diffhunk://#diff-33f6a0d391ffcdcf04389d31c51fd85ec5d8f8048f53c6d2e482890fbb2074dbR4) [[3]](diffhunk://#diff-33f6a0d391ffcdcf04389d31c51fd85ec5d8f8048f53c6d2e482890fbb2074dbL27-R28)
* Cleaned up unused usings in the `TeamsBot` sample.

**Other Improvements and Fixes:**

* Adjusted the order of clearing pending sign-in state in the OAuth token exchange flow to only clear on unexpected HTTP status codes, reducing the risk of prematurely forgetting pending sign-ins.

These changes improve reliability, clarity, and maintainability for both the SDK and its samples, especially in scenarios involving multi-connection OAuth flows and distributed state management.