### PR TITLE
feat(core): add application/search invoke support

### DIFF
--- a/core/src/Microsoft.Teams.Apps/Handlers/InvokeHandler.Activity.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/InvokeHandler.Activity.cs
@@ -114,6 +114,11 @@ public static class InvokeNames
     public const string AdaptiveCardAction = "adaptiveCard/action";
 
     /// <summary>
+    /// Search invoke name. Sent by Adaptive Card dynamic typeahead 'Input.ChoiceSet' inputs.
+    /// </summary>
+    public const string Search = "application/search";
+
+    /// <summary>
     /// Task fetch invoke name.
     /// </summary>
     public const string TaskFetch = "task/fetch";

--- a/core/src/Microsoft.Teams.Apps/Handlers/SearchHandler.Response.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/SearchHandler.Response.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Teams.Apps.Handlers;
+
+/// <summary>
+/// Defines the structure returned as the result of an Invoke activity with Name of
+/// 'application/search'.
+/// </summary>
+public class SearchResponse
+{
+    /// <summary>
+    /// The response status code.
+    /// </summary>
+    [JsonPropertyName("statusCode")]
+    public int StatusCode { get; set; } = 200;
+
+    /// <summary>
+    /// The type of this response.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; } = "application/vnd.microsoft.search.searchResponse";
+
+    /// <summary>
+    /// The response value.
+    /// </summary>
+    [JsonPropertyName("value")]
+    public SearchResponseValue? Value { get; set; }
+}
+
+/// <summary>
+/// The value payload of a <see cref="SearchResponse"/>.
+/// </summary>
+public class SearchResponseValue
+{
+    /// <summary>
+    /// The list of search results.
+    /// </summary>
+    [JsonPropertyName("results")]
+    public IList<SearchResult> Results { get; set; } = [];
+}
+
+/// <summary>
+/// A single result returned in a <see cref="SearchResponse"/>. For Adaptive Card dynamic
+/// typeahead 'Input.ChoiceSet', 'Title' is the display text and 'Value' is the submitted value.
+/// </summary>
+public class SearchResult
+{
+    /// <summary>
+    /// The display text of the result.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// The value submitted when the result is selected.
+    /// </summary>
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
+}

--- a/core/src/Microsoft.Teams.Apps/Handlers/SearchHandler.Response.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/SearchHandler.Response.cs
@@ -27,7 +27,7 @@ public class SearchResponse
     /// The response value.
     /// </summary>
     [JsonPropertyName("value")]
-    public SearchResponseValue? Value { get; set; }
+    public required SearchResponseValue Value { get; set; }
 }
 
 /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Handlers/SearchHandler.Value.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/SearchHandler.Value.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Teams.Apps.Handlers;
+
+/// <summary>
+/// Defines the structure that arrives in the Activity.Value for an Invoke activity with
+/// Name of 'application/search'. Sent by Adaptive Card dynamic typeahead 'Input.ChoiceSet'
+/// inputs (via 'choices.data' / 'Data.Query').
+/// </summary>
+public class SearchValue
+{
+    /// <summary>
+    /// The kind for this search invoke value. Must be either 'search', 'searchAnswer', or 'typeahead'.
+    /// </summary>
+    [JsonPropertyName("kind")]
+    public string? Kind { get; set; }
+
+    /// <summary>
+    /// The query text of this search invoke value.
+    /// </summary>
+    [JsonPropertyName("queryText")]
+    public string? QueryText { get; set; }
+
+    /// <summary>
+    /// The query options for this search invoke.
+    /// </summary>
+    [JsonPropertyName("queryOptions")]
+    public SearchOptions? QueryOptions { get; set; }
+
+    /// <summary>
+    /// Context information about the query, such as the UI control that issued the query.
+    /// </summary>
+    [JsonPropertyName("context")]
+    public object? Context { get; set; }
+
+    /// <summary>
+    /// The identifier of the dataset from which to fetch the choices, as authored on the
+    /// Adaptive Card 'Data.Query'.
+    /// </summary>
+    [JsonPropertyName("dataset")]
+    public string? Dataset { get; set; }
+}
+
+/// <summary>
+/// Defines the query options for an Invoke activity with Name of 'application/search'.
+/// </summary>
+public class SearchOptions
+{
+    /// <summary>
+    /// The starting reference number from which ordered search results should be returned.
+    /// </summary>
+    [JsonPropertyName("skip")]
+    public int? Skip { get; set; }
+
+    /// <summary>
+    /// The number of search results that should be returned.
+    /// </summary>
+    [JsonPropertyName("top")]
+    public int? Top { get; set; }
+}

--- a/core/src/Microsoft.Teams.Apps/Handlers/SearchHandler.Value.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/SearchHandler.Value.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Teams.Apps.Handlers;
 public class SearchValue
 {
     /// <summary>
-    /// The kind for this search invoke value. Must be either 'search', 'searchAnswer', or 'typeahead'.
+    /// The kind for this search invoke value ('search', 'searchAnswer', or 'typeahead'). Omitted by
+    /// Adaptive Card dynamic typeahead 'Input.ChoiceSet' inputs, so this may be null.
     /// </summary>
     [JsonPropertyName("kind")]
     public string? Kind { get; set; }

--- a/core/src/Microsoft.Teams.Apps/Handlers/SearchHandler.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/SearchHandler.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Teams.Apps.Routing;
+using Microsoft.Teams.Apps.Schema;
+
+namespace Microsoft.Teams.Apps.Handlers;
+
+/// <summary>
+/// Delegate for handling 'application/search' invoke activities, sent by Adaptive Card
+/// dynamic typeahead 'Input.ChoiceSet' inputs.
+/// </summary>
+/// <param name="context">The context for the invoke activity, providing access to the activity data and bot application.</param>
+/// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+/// <returns>A task that represents the asynchronous operation. The task result contains the invoke response.</returns>
+public delegate Task<InvokeResponse> SearchHandler(Context<InvokeActivity<SearchValue>> context, CancellationToken cancellationToken = default);
+
+/// <summary>
+/// Extension methods for registering 'application/search' invoke handlers.
+/// </summary>
+public static class SearchExtensions
+{
+    /// <summary>
+    /// Registers a handler for 'application/search' invoke activities. The handler should return
+    /// an <see cref="InvokeResponse"/> whose body is a <see cref="SearchResponse"/>.
+    /// Cannot be combined with <see cref="InvokeExtensions.OnInvoke"/>.
+    /// </summary>
+    /// <remarks>
+    /// Breaking change: previously a catch-all invoke handler could be registered alongside specific invoke handlers. This combination now throws at registration time.
+    /// </remarks>
+    /// <param name="app">The Teams bot application.</param>
+    /// <param name="handler">The handler to register.</param>
+    /// <returns>The updated Teams bot application.</returns>
+    public static TeamsBotApplication OnSearch(this TeamsBotApplication app, SearchHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(app, nameof(app));
+        app.Router.Register(new Route<InvokeActivity>
+        {
+            Name = string.Join("/", TeamsActivityTypes.Invoke, InvokeNames.Search),
+            Selector = activity => activity.Name == InvokeNames.Search,
+            HandlerWithReturn = async (ctx, cancellationToken) =>
+            {
+                InvokeActivity<SearchValue> typedActivity = new(ctx.Activity);
+                var typedContext = ctx.CreateDerivedContext(typedActivity);
+                return await handler(typedContext, cancellationToken).ConfigureAwait(false);
+            }
+        });
+
+        return app;
+    }
+}

--- a/core/src/Microsoft.Teams.Apps/Handlers/SearchHandler.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/SearchHandler.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Teams.Apps.Handlers;
 /// </summary>
 /// <param name="context">The context for the invoke activity, providing access to the activity data and bot application.</param>
 /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
-/// <returns>A task that represents the asynchronous operation. The task result contains the invoke response.</returns>
-public delegate Task<InvokeResponse> SearchHandler(Context<InvokeActivity<SearchValue>> context, CancellationToken cancellationToken = default);
+/// <returns>A task that represents the asynchronous operation. The task result contains the search invoke response.</returns>
+public delegate Task<InvokeResponse<SearchResponse>> SearchHandler(Context<InvokeActivity<SearchValue>> context, CancellationToken cancellationToken = default);
 
 /// <summary>
 /// Extension methods for registering 'application/search' invoke handlers.
@@ -21,8 +21,8 @@ public delegate Task<InvokeResponse> SearchHandler(Context<InvokeActivity<Search
 public static class SearchExtensions
 {
     /// <summary>
-    /// Registers a handler for 'application/search' invoke activities. The handler should return
-    /// an <see cref="InvokeResponse"/> whose body is a <see cref="SearchResponse"/>.
+    /// Registers a handler for 'application/search' invoke activities. The handler returns an
+    /// <see cref="InvokeResponse{TBody}"/> carrying a <see cref="SearchResponse"/> body.
     /// Cannot be combined with <see cref="InvokeExtensions.OnInvoke"/>.
     /// </summary>
     /// <remarks>

--- a/core/test/Microsoft.Teams.Apps.UnitTests/SearchHandlerTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/SearchHandlerTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Teams.Apps.Handlers;
+using Microsoft.Teams.Apps.Routing;
+using Microsoft.Teams.Apps.Schema;
+
+namespace Microsoft.Teams.Apps.UnitTests;
+
+public class SearchHandlerTests
+{
+    [Fact]
+    public void InvokeNames_Search_HasExpectedValue()
+    {
+        Assert.Equal("application/search", InvokeNames.Search);
+    }
+
+    [Fact]
+    public void Register_SearchRoute_Succeeds()
+    {
+        Router router = new(NullLogger.Instance);
+        router.Register(new Route<InvokeActivity>
+        {
+            Name = string.Join("/", TeamsActivityTypes.Invoke, InvokeNames.Search),
+            Selector = activity => activity.Name == InvokeNames.Search,
+        });
+
+        Assert.Single(router.GetRoutes());
+    }
+
+    [Fact]
+    public void Search_RouteSelector_MatchesCorrectInvokeName()
+    {
+        InvokeActivity activity = new(InvokeNames.Search);
+
+        bool matches = activity.Name == InvokeNames.Search;
+        Assert.True(matches);
+    }
+
+    [Fact]
+    public void Search_RouteSelector_DoesNotMatchOtherInvoke()
+    {
+        InvokeActivity activity = new(InvokeNames.AdaptiveCardAction);
+
+        bool matches = activity.Name == InvokeNames.Search;
+        Assert.False(matches);
+    }
+
+    [Fact]
+    public void Search_InvokeActivity_TypedValueDeserializes()
+    {
+        var payload = new
+        {
+            kind = "typeahead",
+            queryText = "sea",
+            queryOptions = new { skip = 0, top = 5 },
+            dataset = "cities"
+        };
+        InvokeActivity activity = new(InvokeNames.Search)
+        {
+            Value = JsonSerializer.SerializeToNode(payload)
+        };
+
+        InvokeActivity<SearchValue> typed = new(activity);
+        SearchValue? value = typed.Value;
+
+        Assert.NotNull(value);
+        Assert.Equal("typeahead", value!.Kind);
+        Assert.Equal("sea", value.QueryText);
+        Assert.Equal("cities", value.Dataset);
+        Assert.NotNull(value.QueryOptions);
+        Assert.Equal(5, value.QueryOptions!.Top);
+    }
+
+    [Fact]
+    public void SearchResponse_SerializesToDocumentedShape()
+    {
+        SearchResponse response = new()
+        {
+            Value = new SearchResponseValue
+            {
+                Results = [new SearchResult { Title = "Seattle", Value = "seattle" }]
+            }
+        };
+
+        JsonNode? node = JsonSerializer.SerializeToNode(response);
+
+        Assert.NotNull(node);
+        Assert.Equal(200, node!["statusCode"]!.GetValue<int>());
+        Assert.Equal("application/vnd.microsoft.search.searchResponse", node["type"]!.GetValue<string>());
+        Assert.Equal("Seattle", node["value"]!["results"]![0]!["title"]!.GetValue<string>());
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for the `application/search` invoke activity (Adaptive Card dynamic typeahead `Input.ChoiceSet`) to the .NET SDK (`core`). Introduces the search value/response types and an `OnSearch` handler registration.

## Changes
- New `SearchValue` / `SearchResponse` / `SearchResponseValue` / `SearchResult` types (`Kind` nullable).
- `SearchHandler` delegate (`Context<InvokeActivity<SearchValue>>` -> `Task<InvokeResponse>`) + `OnSearch` extension and `InvokeNames.Search`.
  - Guard: `OnSearch` cannot be combined with a catch-all `OnInvoke` (throws at registration).
- Unit tests: `SearchHandlerTests` (routing + documented response shape).

## Testing
- `dotnet test core/test/Microsoft.Teams.Apps.UnitTests`

Part of microsoft/teams.ts#252
