### PR TITLE
Add app info to Teams channel data

### DIFF
--- a/Libraries/Microsoft.Teams.Api/App.cs
+++ b/Libraries/Microsoft.Teams.Api/App.cs
@@ -18,6 +18,13 @@ public class App
     public string? Id { get; set; }
 
     /// <summary>
+    /// Version of the app.
+    /// </summary>
+    [JsonPropertyName("version")]
+    [JsonPropertyOrder(1)]
+    public string? Version { get; set; }
+
+    /// <summary>
     /// All extra data present
     /// </summary>
     [JsonExtensionData]

--- a/core/src/Microsoft.Teams.Apps/Handlers/MessageHandler.Activity.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/MessageHandler.Activity.cs
@@ -322,7 +322,7 @@ public static class MessageActivityExtensions
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
 
         message.ChannelData ??= new TeamsChannelData();
-        message.ChannelData.Properties["app"] = new Dictionary<string, object?> { ["id"] = value };
+        message.ChannelData.App ??= new AppInfo { Id = value };
         return message;
     }
 

--- a/core/src/Microsoft.Teams.Apps/Handlers/MessageHandler.Activity.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/MessageHandler.Activity.cs
@@ -322,8 +322,8 @@ public static class MessageActivityExtensions
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
 
         message.ChannelData ??= new TeamsChannelData();
-message.ChannelData.App ??= new AppInfo();
-message.ChannelData.App.Id = value;
+        message.ChannelData.App ??= new AppInfo();
+        message.ChannelData.App.Id = value;
         return message;
     }
 

--- a/core/src/Microsoft.Teams.Apps/Handlers/MessageHandler.Activity.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/MessageHandler.Activity.cs
@@ -322,7 +322,8 @@ public static class MessageActivityExtensions
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
 
         message.ChannelData ??= new TeamsChannelData();
-        message.ChannelData.App ??= new AppInfo { Id = value };
+message.ChannelData.App ??= new AppInfo();
+message.ChannelData.App.Id = value;
         return message;
     }
 

--- a/core/src/Microsoft.Teams.Apps/Schema/TeamsChannelData.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/TeamsChannelData.cs
@@ -49,6 +49,22 @@ public class TeamsChannelDataSettings
 }
 
 /// <summary>
+/// Information about the app sending an activity.
+/// </summary>
+public class AppInfo
+{
+    /// <summary>
+    /// Unique identifier representing an app.
+    /// </summary>
+    [JsonPropertyName("id")] public string? Id { get; set; }
+
+    /// <summary>
+    /// Version of the app.
+    /// </summary>
+    [JsonPropertyName("version")] public string? Version { get; set; }
+}
+
+/// <summary>
 /// Represents Teams-specific channel data.
 /// </summary>
 public class TeamsChannelData : ChannelData
@@ -79,6 +95,11 @@ public class TeamsChannelData : ChannelData
     /// Gets or sets the channel information associated with this entity.
     /// </summary>
     [JsonPropertyName("channel")] public TeamsChannel? Channel { get; set; }
+
+    /// <summary>
+    /// Information about the app sending this activity.
+    /// </summary>
+    [JsonPropertyName("app")] public AppInfo? App { get; set; }
 
     /// <summary>
     /// Team information.


### PR DESCRIPTION
This pull request introduces support for including app metadata, such as app ID and version, in Teams activity payloads. The main changes add an `AppInfo` class to represent this information and update how app data is attached to outgoing messages.

**Schema and Metadata Enhancements:**

* Added the `AppInfo` class to encapsulate app ID and version information for activities (`core/src/Microsoft.Teams.Apps/Schema/TeamsChannelData.cs`).
* Updated the `TeamsChannelData` class to include an `App` property of type `AppInfo`, allowing activities to carry app metadata (`core/src/Microsoft.Teams.Apps/Schema/TeamsChannelData.cs`).
* Updated the `App` class to include a `Version` property, enabling version tracking for apps (`Libraries/Microsoft.Teams.Api/App.cs`).

**Message Handling Updates:**

* Changed the `WithAppId` extension method to use the new `AppInfo` property instead of directly manipulating the `Properties` dictionary, improving type safety and clarity (`core/src/Microsoft.Teams.Apps/Handlers/MessageHandler.Activity.cs`).