### PR TITLE
fix: remove internal set from JSON-deserialized activity value types

### DIFF
--- a/core/samples/ExtAIBot/Properties/launchSettings.TEMPLATE.json
+++ b/core/samples/ExtAIBot/Properties/launchSettings.TEMPLATE.json
@@ -9,7 +9,10 @@
         "AzureAd__TenantId": "",
         "AzureAd__ClientId": "",
         "AzureAd__ClientCredentials__0__SourceType": "ClientSecret",
-        "AzureAd__ClientCredentials__0__ClientSecret": ""
+        "AzureAd__ClientCredentials__0__ClientSecret": "",
+        "AzureOpenAI__Endpoint": "",
+        "AzureOpenAI__ApiKey": "",
+        "AzureOpenAI__Deployment": ""
       },
       "applicationUrl": "http://localhost:3978"
     }

--- a/core/samples/ExtAIBot/README.md
+++ b/core/samples/ExtAIBot/README.md
@@ -17,33 +17,13 @@ A Teams bot powered by [Microsoft.Extensions.AI](https://learn.microsoft.com/dot
 - .NET 10 SDK
 - Azure OpenAI resource with a deployed model (e.g. `gpt-4o`)
 - Teams bot registration (App ID + client secret)
-
-## Setup
-
-Fill in `appsettings.json` with your Azure OpenAI details:
+- Azure Open AI configured
 
 ```json
-{
-  "AzureOpenAI": {
-    "Endpoint": "https://<your-resource>.openai.azure.com",
-    "ApiKey":   "<your-api-key>",
-    "ModelId":  "<deployment-name>"
-  }
-}
+"AzureOpenAI__Endpoint": "",
+"AzureOpenAI__ApiKey": "",
+"AzureOpenAI__Deployment": ""
 ```
-
-`ModelId` is the **deployment name**, not the base model name.
-
-Configure bot credentials via environment variables (or `launchSettings.json`):
-
-```
-AzureAD__TenantId=<tenant-id>
-AzureAD__ClientId=<app-id>
-AzureAD__ClientCredentials__0__SourceType=ClientSecret
-AzureAD__ClientCredentials__0__ClientSecret=<client-secret>
-```
-
-Then point your bot's messaging endpoint at this service (e.g. using [Dev Tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/overview) for local development).
 
 ## Running
 

--- a/core/src/Microsoft.Teams.Apps/Handlers/AdaptiveCardHandlers.Values.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/AdaptiveCardHandlers.Values.cs
@@ -15,19 +15,19 @@ namespace Microsoft.Teams.Apps
         /// The action of this adaptive card invoke action value.
         /// </summary>
         [JsonPropertyName("action")]
-        public AdaptiveCardAction? Action { get; internal set; }
+        public AdaptiveCardAction? Action { get; set; }
 
         /// <summary>
         /// The state for this adaptive card invoke action value.
         /// </summary>
         [JsonPropertyName("state")]
-        public string? State { get; internal set; }
+        public string? State { get; set; }
 
         /// <summary>
         /// What triggered the action.
         /// </summary>
         [JsonPropertyName("trigger")]
-        public string? Trigger { get; internal set; }
+        public string? Trigger { get; set; }
     }
 
     /// <summary>
@@ -40,31 +40,31 @@ namespace Microsoft.Teams.Apps
         /// The Type of this Adaptive Card Invoke Action.
         /// </summary>
         [JsonPropertyName("type")]
-        public string? Type { get; internal set; }
+        public string? Type { get; set; }
 
         /// <summary>
         /// The id of this Adaptive Card Invoke Action.
         /// </summary>
         [JsonPropertyName("id")]
-        public string? Id { get; internal set; }
+        public string? Id { get; set; }
 
         /// <summary>
         /// The title of this Adaptive Card Invoke Action.
         /// </summary>
         [JsonPropertyName("title")]
-        public string? Title { get; internal set; }
+        public string? Title { get; set; }
 
         /// <summary>
         /// The Verb of this adaptive card action invoke.
         /// </summary>
         [JsonPropertyName("verb")]
-        public string? Verb { get; internal set; }
+        public string? Verb { get; set; }
 
         /// <summary>
         /// The Data of this adaptive card action invoke.
         /// </summary>
         [JsonPropertyName("data")]
-        public Dictionary<string, object>? Data { get; internal set; }
+        public Dictionary<string, object>? Data { get; set; }
     }
 }
 

--- a/core/src/Microsoft.Teams.Apps/Handlers/FeedbackHandlers.Values.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/FeedbackHandlers.Values.cs
@@ -17,7 +17,7 @@ public class MessageFetchTaskInvokeValue
     /// The data payload containing action name and value.
     /// </summary>
     [JsonPropertyName("data")]
-    public MessageFetchTaskData? Data { get; internal set; }
+    public MessageFetchTaskData? Data { get; set; }
 }
 
 /// <summary>
@@ -29,13 +29,13 @@ public class MessageFetchTaskData
     /// The name of the action.
     /// </summary>
     [JsonPropertyName("actionName")]
-    public string? ActionName { get; internal set; }
+    public string? ActionName { get; set; }
 
     /// <summary>
     /// Contains the user's reaction.
     /// </summary>
     [JsonPropertyName("actionValue")]
-    public MessageFetchTaskActionValue? ActionValue { get; internal set; }
+    public MessageFetchTaskActionValue? ActionValue { get; set; }
 }
 
 /// <summary>
@@ -47,7 +47,7 @@ public class MessageFetchTaskActionValue
     /// The feedback button the user clicked. Either "like" or "dislike".
     /// </summary>
     [JsonPropertyName("reaction")]
-    public string? Reaction { get; internal set; }
+    public string? Reaction { get; set; }
 }
 
 /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Handlers/MessageHandlers.Activities.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/MessageHandlers.Activities.cs
@@ -900,13 +900,13 @@ public class MessageDeleteActivity : TeamsActivity
         /// Gets or sets the reactions added to the message.
         /// </summary>
         [JsonPropertyName("reactionsAdded")]
-        public IList<MessageReaction>? ReactionsAdded { get; internal set; }
+        public IList<MessageReaction>? ReactionsAdded { get;  set; }
 
         /// <summary>
         /// Gets or sets the reactions removed from the message.
         /// </summary>
         [JsonPropertyName("reactionsRemoved")]
-        public IList<MessageReaction>? ReactionsRemoved { get; internal set; }
+        public IList<MessageReaction>? ReactionsRemoved { get;  set; }
     }
 
     /// <summary>
@@ -919,7 +919,7 @@ public class MessageDeleteActivity : TeamsActivity
         /// See <see cref="ReactionTypes"/> for common values.
         /// </summary>
         [JsonPropertyName("type")]
-        public ReactionType? Type { get; internal set; }
+        public ReactionType? Type { get; set; }
     }
 
     /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Schema/TeamsActivity.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/TeamsActivity.cs
@@ -107,41 +107,41 @@ public class TeamsActivity : CoreActivity
     /// Gets the Teams-specific channel data associated with this activity.
     /// </summary>
     [JsonPropertyName("channelData")]
-    public TeamsChannelData? ChannelData { get; internal set; }
+    public TeamsChannelData? ChannelData { get; set; }
 
     /// <summary>
     /// Gets the entities specific to Teams.
     /// </summary>
     [JsonPropertyName("entities")]
-    public EntityList? Entities { get; internal set; }
+    public EntityList? Entities { get; set; }
 
     /// <summary>
     /// UTC timestamp of when the activity was sent.
     /// </summary>
     [JsonPropertyName("timestamp")]
-    public string? Timestamp { get; internal set; }
+    public string? Timestamp { get; set; }
 
     /// <summary>
     /// Local timestamp of when the activity was sent, including timezone offset.
     /// </summary>
     [JsonPropertyName("localTimestamp")]
-    public string? LocalTimestamp { get; internal set; }
+    public string? LocalTimestamp { get; set; }
 
     /// <summary>
     /// Locale of the activity set by the client (e.g., "en-US").
     /// </summary>
     [JsonPropertyName("locale")]
-    public string? Locale { get; internal set; }
+    public string? Locale { get; set; }
 
     /// <summary>
     /// Local timezone of the client (e.g., "America/Los_Angeles").
     /// </summary>
     [JsonPropertyName("localTimezone")]
-    public string? LocalTimezone { get; internal set; }
+    public string? LocalTimezone { get; set; }
 
     /// <summary>
     /// Gets the suggested actions for the message.
     /// </summary>
     [JsonPropertyName("suggestedActions")]
-    public SuggestedActions? SuggestedActions { get; internal set; }
+    public SuggestedActions? SuggestedActions { get; set; }
 }


### PR DESCRIPTION
System.Text.Json only sets publicly settable properties by default. Properties with internal set were silently skipped during deserialization, causing Activity.Value.Action, ChannelData, Entities, Timestamp, Locale, and reaction/feedback payload properties to always be null at runtime.