### PR TITLE
Ctx/App helpers

### DIFF
--- a/core/samples/MeetingsBot/Program.cs
+++ b/core/samples/MeetingsBot/Program.cs
@@ -42,27 +42,4 @@ teamsApp.OnMeetingLeave(async (context, cancellationToken) =>
     await context.SendAsync($"Participant(s) left: {names}", cancellationToken);
 });
 
-//TODO : review if we can trigger these
-// ==================== COMMAND HANDLERS ====================
-/*
-
-teamsApp.OnCommand(async (context, cancellationToken) =>
-{
-    var commandId = context.Activity.Value?.CommandId ?? "unknown";
-    Console.WriteLine($"[Command] CommandId: {commandId}");
-    await context.SendAsync($"Received command: **{commandId}**", cancellationToken);
-});
-
-teamsApp.OnCommandResult(async (context, cancellationToken) =>
-{
-    var commandId = context.Activity.Value?.CommandId ?? "unknown";
-    var error = context.Activity.Value?.Error;
-    Console.WriteLine($"[CommandResult] CommandId: {commandId}, HasError: {error is not null}");
-
-    if (error is not null)
-        await context.SendAsync($"Command **{commandId}** failed: {error.Message}", cancellationToken);
-    else
-        await context.SendAsync($"Command **{commandId}** completed successfully.", cancellationToken);
-});
-*/
 webApp.Run();

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -218,6 +218,11 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     public Task<SendActivityResponse?> Typing(CancellationToken cancellationToken = default)
         => TypingAsync(cancellationToken);
 
+    /// <inheritdoc cref="TeamsStreamingWriter.CreateFromContext{TActivity}(Context{TActivity})"/>
+    [Obsolete("Use TeamsStreamingWriter.CreateFromContext(context) instead.")]
+    public TeamsStreamingWriter Stream()
+        => TeamsStreamingWriter.CreateFromContext(this);
+
     /// <inheritdoc cref="QuoteAsync(string, string, CancellationToken)"/>
     [Obsolete("Use QuoteAsync instead.")]
     public Task<SendActivityResponse?> Quote(string messageId, string text, CancellationToken cancellationToken = default)

--- a/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
@@ -238,13 +238,14 @@ public class TeamsBotApplication : BotApplication
     /// <param name="conversationId">The conversation ID.</param>
     /// <param name="messageId">The thread root message ID.</param>
     /// <param name="text">The text to send.</param>
+    /// <param name="serviceUrl">The service URL. If null, uses the last-seen service URL from an incoming activity.</param>
     /// <param name="agenticIdentity">The agentic identity for user-delegated token acquisition. Extract from the inbound activity's <see cref="CoreActivity.Recipient"/> via <see cref="ChannelAccount.GetAgenticIdentity"/>.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> ReplyAsync(string conversationId, string messageId, string text, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> ReplyAsync(string conversationId, string messageId, string text, Uri? serviceUrl = null, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
     {
         string threadedConversationId = ConversationExtensions.ToThreadedConversationId(conversationId, messageId);
-        return SendAsync(threadedConversationId, text, agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
+        return SendAsync(threadedConversationId, text, serviceUrl, agenticIdentity, cancellationToken);
     }
 
     /// <summary>
@@ -254,13 +255,14 @@ public class TeamsBotApplication : BotApplication
     /// <param name="conversationId">The conversation ID.</param>
     /// <param name="messageId">The thread root message ID.</param>
     /// <param name="activity">The activity to send.</param>
+    /// <param name="serviceUrl">The service URL. If null, uses the last-seen service URL from an incoming activity.</param>
     /// <param name="agenticIdentity">The agentic identity for user-delegated token acquisition. Extract from the inbound activity's <see cref="CoreActivity.Recipient"/> via <see cref="ChannelAccount.GetAgenticIdentity"/>.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
-    public Task<SendActivityResponse?> ReplyAsync(string conversationId, string messageId, TeamsActivityInput activity, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
+    public Task<SendActivityResponse?> ReplyAsync(string conversationId, string messageId, TeamsActivityInput activity, Uri? serviceUrl = null, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
     {
         string threadedConversationId = ConversationExtensions.ToThreadedConversationId(conversationId, messageId);
-        return SendAsync(threadedConversationId, activity, agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
+        return SendAsync(threadedConversationId, activity, serviceUrl, agenticIdentity, cancellationToken);
     }
 
     /// <inheritdoc cref="SendAsync(string, string, Uri?, AgenticIdentity?, CancellationToken)"/>
@@ -278,12 +280,12 @@ public class TeamsBotApplication : BotApplication
         return SendActivityAsync(conversationId, CoreActivityInput.FromActivity(activity), resolvedUrl, agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
     }
 
-    /// <inheritdoc cref="ReplyAsync(string, string, string, AgenticIdentity?, CancellationToken)"/>
+    /// <inheritdoc cref="ReplyAsync(string, string, string, Uri?, AgenticIdentity?, CancellationToken)"/>
     [Obsolete("Use ReplyAsync instead.")]
     public Task<SendActivityResponse?> Reply(string conversationId, string messageId, string text, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
-        => ReplyAsync(conversationId, messageId, text, agenticIdentity, cancellationToken);
+        => ReplyAsync(conversationId, messageId, text, null, agenticIdentity, cancellationToken);
 
-    /// <inheritdoc cref="ReplyAsync(string, string, TeamsActivityInput, AgenticIdentity?, CancellationToken)"/>
+    /// <inheritdoc cref="ReplyAsync(string, string, TeamsActivityInput, Uri?, AgenticIdentity?, CancellationToken)"/>
     [Obsolete("Use ReplyAsync with a TeamsActivityInput built via new MessageActivityInput() instead.")]
     public Task<SendActivityResponse?> Reply(string conversationId, string messageId, TeamsActivity activity, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
     {

--- a/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
@@ -247,15 +247,52 @@ public class TeamsBotApplication : BotApplication
         return SendAsync(threadedConversationId, text, agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
     }
 
+    /// <summary>
+    /// Sends an activity proactively as a threaded reply.
+    /// Constructs a threaded conversation ID from the conversation ID and message ID.
+    /// </summary>
+    /// <param name="conversationId">The conversation ID.</param>
+    /// <param name="messageId">The thread root message ID.</param>
+    /// <param name="activity">The activity to send.</param>
+    /// <param name="agenticIdentity">The agentic identity for user-delegated token acquisition. Extract from the inbound activity's <see cref="CoreActivity.Recipient"/> via <see cref="ChannelAccount.GetAgenticIdentity"/>.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The response from the send operation.</returns>
+    public Task<SendActivityResponse?> ReplyAsync(string conversationId, string messageId, TeamsActivityInput activity, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
+    {
+        string threadedConversationId = ConversationExtensions.ToThreadedConversationId(conversationId, messageId);
+        return SendAsync(threadedConversationId, activity, agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
+    }
+
     /// <inheritdoc cref="SendAsync(string, string, Uri?, AgenticIdentity?, CancellationToken)"/>
     [Obsolete("Use SendAsync instead.")]
     public Task<SendActivityResponse?> Send(string conversationId, string text, Uri? serviceUrl = null, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
         => SendAsync(conversationId, text, serviceUrl, agenticIdentity, cancellationToken);
 
+    /// <inheritdoc cref="SendAsync(string, TeamsActivityInput, Uri?, AgenticIdentity?, CancellationToken)"/>
+    [Obsolete("Use SendAsync with a TeamsActivityInput built via new MessageActivityInput() instead.")]
+    public Task<SendActivityResponse?> Send(string conversationId, TeamsActivity activity, Uri? serviceUrl = null, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        Uri resolvedUrl = serviceUrl ?? _lastServiceUrl
+            ?? throw new InvalidOperationException("No service URL available. Either pass a serviceUrl parameter or ensure the bot has received at least one activity.");
+        return SendActivityAsync(conversationId, CoreActivityInput.FromActivity(activity), resolvedUrl, agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
+    }
+
     /// <inheritdoc cref="ReplyAsync(string, string, string, AgenticIdentity?, CancellationToken)"/>
     [Obsolete("Use ReplyAsync instead.")]
     public Task<SendActivityResponse?> Reply(string conversationId, string messageId, string text, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
         => ReplyAsync(conversationId, messageId, text, agenticIdentity, cancellationToken);
+
+    /// <inheritdoc cref="ReplyAsync(string, string, TeamsActivityInput, AgenticIdentity?, CancellationToken)"/>
+    [Obsolete("Use ReplyAsync with a TeamsActivityInput built via new MessageActivityInput() instead.")]
+    public Task<SendActivityResponse?> Reply(string conversationId, string messageId, TeamsActivity activity, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        string threadedConversationId = ConversationExtensions.ToThreadedConversationId(conversationId, messageId);
+        Uri resolvedUrl = _lastServiceUrl
+            ?? throw new InvalidOperationException("No service URL available. Either pass a serviceUrl parameter or ensure the bot has received at least one activity.");
+        return SendActivityAsync(threadedConversationId, CoreActivityInput.FromActivity(activity), resolvedUrl, agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
+    }
 
     /// <summary>
     /// NuGet package version


### PR DESCRIPTION
This pull request introduces new methods for sending threaded replies and streaming activities, as well as deprecates older methods in favor of more modern alternatives. It also includes cleanup of commented-out code related to command handlers.

**New features and API improvements:**

* Added `ReplyAsync` method to `TeamsBotApplication` for sending activities as threaded replies, constructing the threaded conversation ID internally.
* Introduced a `Stream()` method to `Context<TActivity>`, allowing easy creation of a streaming writer from the current context. This method is marked as obsolete in favor of the static `TeamsStreamingWriter.CreateFromContext`.

**Deprecations and backward compatibility:**

* Marked several `Send` and `Reply` methods in `TeamsBotApplication` as obsolete, guiding developers to use the newer `SendAsync` and `ReplyAsync` methods with `TeamsActivityInput`. These obsolete methods internally call the new implementations to maintain backward compatibility.

**Code cleanup:**

* Removed commented-out command handler code from `MeetingsBot/Program.cs` to reduce clutter.