### PR TITLE
Thread streamed activities under the inbound message via replyToId

### DIFF
--- a/core/src/Microsoft.Teams.Apps/TeamsStreamingWriter.cs
+++ b/core/src/Microsoft.Teams.Apps/TeamsStreamingWriter.cs
@@ -193,6 +193,7 @@ public sealed class TeamsStreamingWriter
 
         final ??= new MessageActivityInput();
         final.Text ??= _accumulated.ToString();
+        final.ReplyToId = _reference.Id;
 
         if (string.IsNullOrEmpty(final.Text) && (final.Attachments == null || final.Attachments.Count == 0))
             throw new InvalidOperationException(
@@ -374,9 +375,12 @@ public sealed class TeamsStreamingWriter
 
     private StreamingActivityInput BuildActivity(string text, StreamType streamType)
     {
-        return StreamingActivityInput.CreateBuilder()
+        StreamingActivityInput activity = StreamingActivityInput.CreateBuilder()
             .WithText(text)
             .WithStreamInfo(streamType, _streamId, _sequence)
             .Build();
+
+        activity.ReplyToId = _reference.Id;
+        return activity;
     }
 }

--- a/core/test/Microsoft.Teams.Apps.UnitTests/TeamsStreamingWriterTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/TeamsStreamingWriterTests.cs
@@ -266,6 +266,60 @@ public class TeamsStreamingWriterTests
         Assert.Equal(streamIds[1], streamIds[2]);
     }
 
+    // ── replyToId threading ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AllSends_ThreadUnderInboundActivity_WhenReferenceHasId()
+    {
+        TeamsActivity reference = CreateReferenceActivity();
+        reference.Id = "inbound-activity-id";
+        (TeamsStreamingWriter writer, FakeHttpMessageHandler handler) = CreateWriter(reference);
+
+        await writer.SendInformativeUpdateAsync("Thinking…"); // informative update
+        await writer.AppendResponseAsync("hello ");           // streaming chunk
+        await writer.AppendResponseAsync("world");            // accumulated (rate-limited)
+        await writer.FinalizeResponseAsync();                 // final message
+
+        Assert.NotEmpty(handler.RequestBodies);
+
+        // Informative, streaming, and final sends are all threaded to the inbound message.
+        Assert.All(
+            handler.RequestBodies,
+            body => Assert.Contains("\"replyToId\": \"inbound-activity-id\"", body, StringComparison.Ordinal));
+
+        // And specifically the final message.
+        string finalBody = handler.RequestBodies.Last();
+        Assert.Contains("\"streamType\": \"final\"", finalBody);
+        Assert.Contains("\"replyToId\": \"inbound-activity-id\"", finalBody);
+    }
+
+    [Fact]
+    public async Task FinalizeAsync_AfterTimeout_ThreadsInPlaceUpdateUnderInboundActivity()
+    {
+        TeamsActivity reference = CreateReferenceActivity();
+        reference.Id = "inbound-activity-id";
+        (TeamsStreamingWriter writer, FakeHttpMessageHandler handler) = CreateWriter(reference);
+
+        // Informative send assigns the streamId that the in-place update will target.
+        handler.EnqueueResponse("{\"id\":\"stream-1\"}");
+        await writer.SendInformativeUpdateAsync("Thinking…");
+
+        // The next chunk trips the two-minute limit, forcing the in-place update path.
+        handler.EnqueueResponse(
+            "{\"error\":{\"message\":\"Content stream finished due to exceeded streaming time.\"}}",
+            HttpStatusCode.Forbidden);
+        await writer.AppendResponseAsync("Final answer");
+
+        Assert.True(writer.TimedOut);
+
+        await writer.FinalizeResponseAsync();
+
+        // The in-place update (PUT) is still threaded under the inbound message.
+        HttpRequestMessage lastRequest = handler.Requests.Last();
+        Assert.Equal(HttpMethod.Put, lastRequest.Method);
+        Assert.Contains("\"replyToId\": \"inbound-activity-id\"", handler.RequestBodies.Last());
+    }
+
     // ── Error handling (HTTP 403) ─────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## What

Ports [microsoft/teams.ts#646](https://github.com/microsoft/teams.ts/pull/646) to teams.net.

`TeamsStreamingWriter` now sets `ReplyToId` to the inbound activity id on **every** outbound send

Covered send paths:
- Informative updates (`SendInformativeUpdateAsync`)
- Intermediate streaming chunks (`AppendResponseAsync`)
- The final message (`FinalizeResponseAsync`), including the in-place `UpdateActivity` fallback taken after the two-minute streaming timeout

The TS PR applies `replyToId: this.ref.activityId` centrally in `send()`. The .NET streamer has no single send choke point (routing is passed per call), so `ReplyToId = _reference.Id` is set in the two spots that construct outbound activities: `BuildActivity` (informative + streaming) and `FinalizeResponseAsync` (final + timeout in-place update).

## Testing

- **Unit tests**: added two tests to `TeamsStreamingWriterTests` — one asserting informative/streaming/final all carry `replyToId` = inbound id, and one asserting the post-timeout in-place `PUT` is also threaded. Full `TeamsStreamingWriterTests` suite passes (net10.0).
- **Live E2E**: ran the `StreamingBot` sample against real Teams behind a devtunnel with trace logging. Confirmed **14/14** outbound activity sends (informative, every streaming chunk, and final) carried `replyToId` equal to the corresponding inbound activity id.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>