### PR TITLE
Bug bash fixes: Msgextension cardbutton clicked, onsetting added, activity preview fix, SSO status reconciliation

### DIFF
--- a/core/samples/A2ABot/README.md
+++ b/core/samples/A2ABot/README.md
@@ -68,7 +68,6 @@ The bots are symmetric — same flow runs in reverse from Bob to Alice.
   each installed for the user in the same tenant (so `CreateConversation`
   can open a proactive DM).
 - An Azure OpenAI resource with a chat deployment (e.g. `gpt-4o-mini`).
-- .NET 10 SDK.
 
 ## Configuration
 

--- a/core/samples/AdaptiveCardTaskModuleBot/Cards.cs
+++ b/core/samples/AdaptiveCardTaskModuleBot/Cards.cs
@@ -70,16 +70,12 @@ public static class Cards
         };
     }
 
-    public static JsonElement CreateAdaptiveActionResponseCard(string? verb, string? message)
+    public static JsonElement CreateAdaptiveActionResponseCard(string? verb)
     {
         AdaptiveCard card = new([
             new TextBlock($"Action '{verb}' executed")
             {
                 Weight = TextWeight.Bolder
-            },
-            new TextBlock($"Message: {message}")
-            {
-                Wrap = true
             }])
         {
             Version = Microsoft.Teams.Cards.Version.Version1_4

--- a/core/samples/AdaptiveCardTaskModuleBot/Program.cs
+++ b/core/samples/AdaptiveCardTaskModuleBot/Program.cs
@@ -54,9 +54,7 @@ bot.OnAdaptiveCardAction(async (context, cancellationToken) =>
         return AdaptiveCardResponse.CreateMessageResponse("File Consent requested!");
     }
 
-    string? message = data != null && data.TryGetValue("message", out object? msgValue) ? msgValue?.ToString() : null;
-
-    JsonElement adaptiveActionCard = Cards.CreateAdaptiveActionResponseCard(verb, message);
+    JsonElement adaptiveActionCard = Cards.CreateAdaptiveActionResponseCard(verb);
     TeamsAttachment adaptiveActionCardResponse = TeamsAttachment.CreateBuilder().WithAdaptiveCard(adaptiveActionCard).Build();
     await context.SendAsync(new MessageActivityInput().AddAttachment(adaptiveActionCardResponse), cancellationToken);
 

--- a/core/samples/CustomHosting/README.md
+++ b/core/samples/CustomHosting/README.md
@@ -13,6 +13,7 @@ This sample shows how to use a custom `TeamsBotApplication` subclass. Instead of
 - Default message handling coming from the custom app instead of top-level setup code.
 
 This pattern is useful when you want to wrap shared bot behavior in a reusable application type and keep `Program.cs` small.
+
 ## Running the Sample
 
 ~~~bash

--- a/core/samples/ExtAIBot/README.md
+++ b/core/samples/ExtAIBot/README.md
@@ -18,12 +18,9 @@ A Teams bot powered by [Microsoft.Extensions.AI](https://learn.microsoft.com/dot
 - Azure OpenAI resource with a deployed model (e.g. `gpt-4o`)
 - Teams bot registration (App ID + client secret)
 - Azure Open AI configured
-
-```json
-"AzureOpenAI__Endpoint": "",
-"AzureOpenAI__ApiKey": "",
-"AzureOpenAI__Deployment": ""
-```
+  - `AzureOpenAI__Endpoint`
+  - `AzureOpenAI__ApiKey`
+  - `AzureOpenAI__Deployment`
 
 ## Running
 

--- a/core/samples/ExtAIBot/README.md
+++ b/core/samples/ExtAIBot/README.md
@@ -14,20 +14,12 @@ A Teams bot powered by [Microsoft.Extensions.AI](https://learn.microsoft.com/dot
 
 ## Prerequisites
 
-- .NET 10 SDK
-- Azure OpenAI resource with a deployed model (e.g. `gpt-4o`)
-- Teams bot registration (App ID + client secret)
+- Bot registered and installed in Teams.
 - Azure Open AI configured
   - `AzureOpenAI__Endpoint`
   - `AzureOpenAI__ApiKey`
   - `AzureOpenAI__Deployment`
 
-## Running
-
-```bash
-cd samples/ExtAIBot
-dotnet run
-```
 
 The bot initializes the MS Learn MCP tool set at startup before accepting messages. If the MCP server is unreachable the app will fail to start.
 

--- a/core/samples/GraphBot/README.md
+++ b/core/samples/GraphBot/README.md
@@ -22,24 +22,6 @@ Use the same Entra app registration as your bot (`AzureAd:ClientId`) and configu
 
 Without admin consent, app-only Graph calls fail with "Insufficient privileges to complete the operation."
 
-## Local config
-
-Set these values in `appsettings.Development.json` or environment variables:
-
-```json
-{
-  "AzureAd": {
-    "TenantId": "<tenant-id>",
-    "ClientId": "<client-id>",
-    "ClientCredentials": [
-      {
-        "SourceType": "ClientSecret",
-        "ClientSecret": "<client-secret>"
-      }
-    ]
-  }
-}
-```
 
 ## Run
 

--- a/core/samples/McpServer/README.md
+++ b/core/samples/McpServer/README.md
@@ -30,25 +30,12 @@ wait for them to reply or approve.
 - Bot registered and installed in Teams.
 - Microsoft Graph application permission `User.ReadBasic.All` granted with admin consent.
 
-## Configure
-
-Set credentials in `Properties/launchSettings.TEMPLATE.json`, then copy to `launchSettings.json` for local runs.
-
-Required env vars:
-
-```
-AzureAd__TenantId=<your-tenant-id>
-AzureAd__ClientId=<your-azure-bot-app-id>
-AzureAd__ClientCredentials__0__SourceType=ClientSecret
-AzureAd__ClientCredentials__0__ClientSecret=<your-azure-bot-app-secret>
-```
+## Graph permissions
 
 The `userId` argument passed to `notify`, `ask`, and `request_approval` is the
 **AAD object id** of someone in the same tenant. Either call `find_user` to
 resolve a name, or DM the bot once and read the AAD object id off the first
 incoming activity in the server log.
-
-## Graph permissions
 
 `find_user` calls Microsoft Graph as the bot's app identity. In the bot's
 Azure AD app registration → **API permissions**, add **`User.ReadBasic.All`**

--- a/core/samples/MessageExtensionBot/Cards.cs
+++ b/core/samples/MessageExtensionBot/Cards.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Microsoft.Teams.Cards;
+using Microsoft.Teams.Common;
 
 namespace MessageExtensionBot;
 
@@ -62,7 +63,14 @@ public static class Cards
                 new("Item ID:", itemId ?? string.Empty)
             })])
         {
-            Version = Microsoft.Teams.Cards.Version.Version1_4
+            Version = Microsoft.Teams.Cards.Version.Version1_4,
+            Actions =
+            [
+                new OpenUrlAction($"https://www.microsoft.com/")
+                {
+                    Title = "🔗 View Details"
+                }
+            ]
         };
 
         return JsonSerializer.SerializeToElement(card);

--- a/core/samples/MessageExtensionBot/Program.cs
+++ b/core/samples/MessageExtensionBot/Program.cs
@@ -12,6 +12,14 @@ WebApplicationBuilder webAppBuilder = WebApplication.CreateSlimBuilder(args);
 webAppBuilder.Services.AddTeamsBotApplication();
 WebApplication webApp = webAppBuilder.Build();
 
+webApp.UseStaticFiles();
+webApp.MapGet("/tabs/settings", async context =>
+{
+    string html = await File.ReadAllTextAsync("wwwroot/settings.html");
+    context.Response.ContentType = "text/html";
+    await context.Response.WriteAsync(html);
+});
+
 TeamsBotApplication bot = webApp.UseTeamsBotApplication();
 
 // ==================== MESSAGE EXTENSION QUERY ====================
@@ -184,14 +192,37 @@ bot.OnQuerySettingUrl(async (context, cancellationToken) =>
 {
     Console.WriteLine("✓ OnQuerySettingUrl");
 
-    MessageExtensionQuery? query = context.Activity.Value;
+    string botEndpoint = webAppBuilder.Configuration["BotEndpoint"] ?? "";
+    string settingsUrl = $"{botEndpoint}/tabs/settings";
 
-    var action = new SuggestedAction(ActionTypes.OpenUrl, "Open", "https://www.microsoft.com");
+    var action = new SuggestedAction(ActionTypes.OpenUrl, "Settings", settingsUrl);
 
     return MessageExtensionResponse.CreateBuilder()
         .WithType(MessageExtensionResponseTypes.Config)
-        .WithSuggestedActions([action])
+        .WithSuggestedActions(new SuggestedActions().AddAction(action))
         .Build();
+});
+
+// ==================== MESSAGE EXTENSION SETTINGS SAVED ====================
+bot.OnSetting(async (context, cancellationToken) =>
+{
+    string? state = context.Activity.Value?.State;
+    Console.WriteLine($"✓ OnSettings - state: {state}");
+
+    if (state == "CancelledByUser")
+    {
+        Console.WriteLine("User cancelled settings.");
+        return MessageExtensionResponse.CreateBuilder()
+            .WithType(MessageExtensionResponseTypes.Message)
+            .WithText("settings cancelled")
+            .Build();
+    }
+
+    Console.WriteLine($"User saved setting: {state}");
+    return MessageExtensionResponse.CreateBuilder()
+            .WithType(MessageExtensionResponseTypes.Message)
+            .WithText("settings saved")
+            .Build();
 });
 
 webApp.Run();

--- a/core/samples/MessageExtensionBot/Program.cs
+++ b/core/samples/MessageExtensionBot/Program.cs
@@ -74,6 +74,14 @@ bot.OnSelectItem(async (context, cancellationToken) =>
         .Build();
 });
 
+// ==================== MESSAGE EXTENSION CARD BUTTON CLICKED ====================
+bot.OnCardButtonClicked(async (context, cancellationToken) =>
+{
+    Console.WriteLine("✓ OnCardButtonClicked");
+    return new InvokeResponse(200);
+});
+
+
 // ==================== MESSAGE EXTENSION FETCH TASK ====================
 bot.OnFetchTask(async (context, cancellationToken) =>
 {
@@ -186,7 +194,6 @@ bot.OnQueryLink(async (context, cancellationToken) =>
         .Build();
 });
 
-
 // ==================== MESSAGE EXTENSION QUERY SETTING URL ====================
 bot.OnQuerySettingUrl(async (context, cancellationToken) =>
 {
@@ -212,17 +219,11 @@ bot.OnSetting(async (context, cancellationToken) =>
     if (state == "CancelledByUser")
     {
         Console.WriteLine("User cancelled settings.");
-        return MessageExtensionResponse.CreateBuilder()
-            .WithType(MessageExtensionResponseTypes.Message)
-            .WithText("settings cancelled")
-            .Build();
+        return new InvokeResponse(200);
     }
 
     Console.WriteLine($"User saved setting: {state}");
-    return MessageExtensionResponse.CreateBuilder()
-            .WithType(MessageExtensionResponseTypes.Message)
-            .WithText("settings saved")
-            .Build();
+    return new InvokeResponse(200);
 });
 
 webApp.Run();

--- a/core/samples/MessageExtensionBot/Program.cs
+++ b/core/samples/MessageExtensionBot/Program.cs
@@ -85,12 +85,12 @@ bot.OnFetchTask(async (context, cancellationToken) =>
 });
 
 // Helper: Extract title and description from preview card
-static (string?, string?) GetDataFromPreview(TeamsActivityInput? preview)
+static (string?, string?) GetDataFromPreview(MessageExtensionActivityPreview? preview)
 {
-    if (preview is not MessageActivityInput msg || msg.Attachments == null) return (null, null);
+    if (preview?.Attachments == null) return (null, null);
 
     JsonElement cardData = JsonSerializer.Deserialize<JsonElement>(
-        JsonSerializer.Serialize(msg.Attachments[0].Content));
+        JsonSerializer.Serialize(preview.Attachments[0].Content));
 
     if (!cardData.TryGetProperty("body", out JsonElement body) || body.ValueKind != JsonValueKind.Array)
         return (null, null);
@@ -155,7 +155,7 @@ bot.OnSubmitAction(async (context, cancellationToken) =>
     return MessageExtensionActionResponse.CreateBuilder()
             .WithComposeExtension(MessageExtensionResponse.CreateBuilder()
                 .WithType(MessageExtensionResponseTypes.BotMessagePreview)
-                .WithActivityPreview(new MessageActivityInput().AddAttachment(attachment))
+                .WithActivityPreview(new MessageExtensionActivityPreview().AddAttachment(attachment))
                 )
             .Build();
 });

--- a/core/samples/MessageExtensionBot/Properties/launchSettings.TEMPLATE.json
+++ b/core/samples/MessageExtensionBot/Properties/launchSettings.TEMPLATE.json
@@ -6,6 +6,7 @@
       "applicationUrl": "http://localhost:3978",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
+        "BotEndpoint": "",
         "AzureAd__Instance": "https://login.microsoftonline.com/",
         "AzureAd__TenantId": "",
         "AzureAd__ClientId": "",

--- a/core/samples/MessageExtensionBot/README.md
+++ b/core/samples/MessageExtensionBot/README.md
@@ -5,7 +5,6 @@ A sample bot demonstrating Teams message extension handlers.
 ## Prerequisites
 
 - Bot registered and installed in Teams.
-- Manifest package created from the inline manifest plus `color.png` / `outline.png`.
 
 ## Manifest Setup
 

--- a/core/samples/MessageExtensionBot/README.md
+++ b/core/samples/MessageExtensionBot/README.md
@@ -104,13 +104,20 @@ A sample bot demonstrating Teams message extension handlers.
 3. Type a search term
 4. Verify results display in list format
 5. Type "help" to test message response
-
 ### OnSelectItem
 **Manifest:** No specific requirement (works with OnQuery results)
 
 1. After running a search (OnQuery)
 2. Click on any search result
 3. Verify adaptive card preview appears
+
+
+### OnCardButtonClicked (Card Button)
+**Manifest:** No specific requirement (works with any message extension result card that has `Action` buttons)
+
+1. Click the **View Details** button on the adaptive card
+2. Verify `OnCardButtonClicked` fires — link opens)
+
 
 ### OnFetchTask (Action - Task Module)
 **Manifest:** `composeExtensions.commands` with `type: "action"` and `fetchTask: true`

--- a/core/samples/MessageExtensionBot/README.md
+++ b/core/samples/MessageExtensionBot/README.md
@@ -7,30 +7,10 @@ A sample bot demonstrating Teams message extension handlers.
 - Bot registered and installed in Teams.
 - Manifest package created from the inline manifest plus `color.png` / `outline.png`.
 
-## Setup
-
-1. Configure bot credentials in `Properties/launchSettings.TEMPLATE.json` (or environment variables).
-2. Run the bot: `dotnet run`.
-3. Sideload the Teams app package.
-
-## Manifest (inline)
+## Manifest Setup
 
 ```json
 {
-  "staticTabs": [
-    {
-      "entityId": "conversations",
-      "scopes": [
-        "personal"
-      ]
-    },
-    {
-      "entityId": "about",
-      "scopes": [
-        "personal"
-      ]
-    }
-  ],
   "bots": [
     {
       "botId": "YOUR_BOT_ID",
@@ -48,6 +28,7 @@ A sample bot demonstrating Teams message extension handlers.
   "composeExtensions": [
     {
       "botId": "YOUR_BOT_ID",
+      "canUpdateConfiguration": true,
       "commands": [
         {
           "id": "searchQuery",
@@ -92,7 +73,6 @@ A sample bot demonstrating Teams message extension handlers.
           ]
         }
       ],
-      "canUpdateConfiguration": true,
       "messageHandlers": [
         {
           "type": "link",
@@ -106,6 +86,10 @@ A sample bot demonstrating Teams message extension handlers.
         }
       ]
     }
+  ],
+   "validDomains": [
+    "*.botframework.com",
+    "xxx.devtunnels.ms"
   ]
 }
 ```
@@ -141,7 +125,7 @@ A sample bot demonstrating Teams message extension handlers.
 2. Click submit
 3. Verify preview card appears with Edit/Send buttons
 4. Click Edit - verify form reopens with values
-5. Click Send - verify final card posts to conversation -- Currently this only works when we start from commandbox.
+5. Click Send - verify final card posts to conversation — currently only works when started from the command box
 
 ### OnQueryLink (Link Unfurling)
 **Manifest:** `composeExtensions.messageHandlers` with `type: "link"` and `domains`
@@ -149,12 +133,22 @@ A sample bot demonstrating Teams message extension handlers.
 1. Paste a URL in compose box that matches the unfurl domain in manifest (*.example.com)
 2. Verify card unfurls automatically
 
-### OnQuerySettingUrl (Settings)
-**Manifest:** `composeExtensions.canUpdateConfiguration: true`
+### OnQuerySettingUrl + OnSettings (Settings)
+**Manifest:** `composeExtensions.canUpdateConfiguration: true` (must be at the top level of the compose extension, not inside a command)
 
-1. Right-click message extension icon
-2. Select Settings
-3. Verify settings URL opens (microsoft.com)
+> **Important:** Add your bot's domain to `validDomains` in the manifest, otherwise Teams will block the settings page from loading in the iframe:
+> ```json
+> "validDomains": [
+>   "YOUR_DEVTUNNEL_SOMAIN"
+> ]
+> ```
+
+1. Right-click the message extension icon in the compose box
+2. Select **Settings** — Teams calls `OnQuerySettingUrl` which returns the settings page URL
+3. A popup opens at `{BOT_ENDPOINT}/tabs/settings`
+4. Select an option and click **Save Settings** — Teams calls `OnSettings` with `Value.State` set to the submitted value
+5. If the user dismisses the dialog, `Value.State` will be `"CancelledByUser"`
+
 ## Running the Sample
 
 ~~~bash

--- a/core/samples/MessageExtensionBot/wwwroot/settings.html
+++ b/core/samples/MessageExtensionBot/wwwroot/settings.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Message Extension Settings</title>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" />
+  <script src="https://res.cdn.office.net/teams-js/2.22.0/js/MicrosoftTeams.min.js"></script>
+  <style>
+    body { margin: 0; padding: 10px; }
+    .form-group { margin-bottom: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h3>Message Extension Settings</h3>
+    <form id="settingsForm">
+      <div class="form-group">
+        <label>Selected Option:</label>
+        <select class="form-control" id="selectedOption" name="selectedOption">
+          <option value="">Please select an option</option>
+          <option value="option1">Option 1</option>
+          <option value="option2">Option 2</option>
+          <option value="option3">Option 3</option>
+        </select>
+      </div>
+      <button type="submit" class="btn btn-primary">Save Settings</button>
+    </form>
+  </div>
+  <script>
+    // Settings popup opens in "authentication" frame context -- use notifySuccess to close and send result
+    const sdkReady = microsoftTeams.app.initialize();
+
+    sdkReady.then(() => {
+      const urlParams = new URLSearchParams(window.location.search);
+      const selectedOption = urlParams.get('selectedOption');
+      if (selectedOption) {
+        document.getElementById('selectedOption').value = selectedOption;
+      }
+    }).catch(err => console.error('Teams SDK init failed:', err));
+
+    document.getElementById('settingsForm').addEventListener('submit', async function (event) {
+      event.preventDefault();
+      const selectedValue = document.getElementById('selectedOption').value;
+      await sdkReady;
+      microsoftTeams.authentication.notifySuccess(selectedValue);
+    });
+  </script>
+</body>
+</html>

--- a/core/samples/ObservabilityBot/ObservabilityBotApp.cs
+++ b/core/samples/ObservabilityBot/ObservabilityBotApp.cs
@@ -29,6 +29,7 @@ public class ObservabilityBotApp : TeamsBotApplication
         ApiClient teamsApiClient,
         IHttpContextAccessor httpContextAccessor,
         ILogger<ObservabilityBotApp> logger,
+        IConfiguration configuration,
         IChatClient chatClient,
         ChatOptions chatOptions,
         TeamsBotApplicationOptions? teamsOptions = null,
@@ -38,7 +39,7 @@ public class ObservabilityBotApp : TeamsBotApplication
         _teamsApiClient = teamsApiClient;
         _chatClient = chatClient;
         _chatOptions = chatOptions;
-        _deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT") ?? "unknown";
+        _deploymentName = configuration["AzureOpenAI:Deployment"] ?? "unknown";
         _oauthFlow = this.GetOAuthFlow(OAuthConnectionName);
 
         _oauthFlow.OnSignInComplete(async (context, tokenResponse, ct) =>

--- a/core/samples/ObservabilityBot/Program.cs
+++ b/core/samples/ObservabilityBot/Program.cs
@@ -43,6 +43,7 @@ builder.Services.AddOpenTelemetry()
     .UseMicrosoftOpenTelemetry(o =>
     {
         o.Exporters = ExportTarget.Otlp | ExportTarget.AzureMonitor; // | ExportTarget.Agent365
+        o.AzureMonitor.ConnectionString = builder.Configuration.GetConnectionString("AppInsights");
         o.Instrumentation.EnableHttpClientInstrumentation = true;
         o.Instrumentation.EnableAspNetCoreInstrumentation = true;
 
@@ -74,13 +75,13 @@ builder.Services.AddKeyedSingleton("msdocs", (sp, key) =>
         })));
 
 // Register IChatClient
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidDataException("AZURE_OPENAI_ENDPOINT not found");
-var azoai_key = Environment.GetEnvironmentVariable("AZURE_OPENAI_KEY") ?? throw new InvalidDataException("AZURE_OPENAI_KEY not found");
-var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT") ?? throw new InvalidDataException("AZURE_OPENAI_DEPLOYMENT not found");
+var endpoint = builder.Configuration["AzureOpenAI:Endpoint"] ?? throw new InvalidOperationException("AzureOpenAI:Endpoint is required.");
+var apiKey = builder.Configuration["AzureOpenAI:ApiKey"] ?? throw new InvalidOperationException("AzureOpenAI:ApiKey is required.");
+var deploymentName = builder.Configuration["AzureOpenAI:Deployment"] ?? throw new InvalidOperationException("AzureOpenAI:Deployment is required.");
 
 builder.Services.AddSingleton<IChatClient>(sp =>
     new ChatClientBuilder(
-        new AzureOpenAIClient(new Uri(endpoint), new System.ClientModel.ApiKeyCredential(azoai_key))
+        new AzureOpenAIClient(new Uri(endpoint), new System.ClientModel.ApiKeyCredential(apiKey))
             .GetChatClient(deploymentName)
             .AsIChatClient())
     .UseFunctionInvocation()

--- a/core/samples/ObservabilityBot/Properties/launchSettings.TEMPLATE.json
+++ b/core/samples/ObservabilityBot/Properties/launchSettings.TEMPLATE.json
@@ -10,10 +10,10 @@
         "AzureAd__ClientId": "",
         "AzureAd__ClientCredentials__0__SourceType": "ClientSecret",
         "AzureAd__ClientCredentials__0__ClientSecret": "",
-        "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
-        "AZURE_OPENAI_ENDPOINT": "",
-        "AZURE_OPENAI_KEY": "",
-        "AZURE_OPENAI_DEPLOYMENT": "",
+        "ConnectionStrings__AppInsights": "",
+        "AzureOpenAI__Endpoint": "",
+        "AzureOpenAI__ApiKey": "",
+        "AzureOpenAI__Deployment": "",
         "ConnectionStrings__Redis": ""
       },
       "applicationUrl": "http://localhost:3978"

--- a/core/samples/ObservabilityBot/README.md
+++ b/core/samples/ObservabilityBot/README.md
@@ -6,22 +6,32 @@ Minimal Teams bot wired to the [`Microsoft.OpenTelemetry`](https://github.com/mi
 
 - Bot registered and installed in Teams.
 - OpenTelemetry export target available (for local demo, Grafana LGTM).
-- Azure OpenAI configuration (required by the sample's AI path).
+- Azure OpenAI configured:
+  - `AzureOpenAI__Endpoint`
+  - `AzureOpenAI__ApiKey`
+  - `AzureOpenAI__Deployment` 
 - OAuth connection named `sso` configured on the bot resource.
+- [optional for multiple instances] Redis available and configured through `ConnectionStrings__Redis`.
 
 ## What it shows
 
 ```csharp
 builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o => o.Exporters = ExportTarget.Console | ExportTarget.Otlp)
-    .WithTracing(t => t
-        .AddSource(CoreTelemetryNames.ActivitySourceName)
-        .AddSource(TeamsBotApplicationTelemetry.ActivitySourceName))
-    .WithMetrics(m => m
-        .AddMeter(CoreTelemetryNames.MeterName)
-        .AddMeter(TeamsBotApplicationTelemetry.MeterName));
-
-builder.Logging.AddOpenTelemetry(o => o.IncludeFormattedMessage = true);
+    .ConfigureResource(r => r
+        .AddService(serviceName: "ObservabilityBot", serviceVersion: "0.0.1")
+        .AddAttributes(new Dictionary<string, object>
+        {
+            ["deployment.environment"] = builder.Environment.EnvironmentName,
+            ["service.namespace"] = "Microsoft.Teams"
+        }))
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.Otlp | ExportTarget.AzureMonitor;
+        o.Instrumentation.EnableHttpClientInstrumentation = true;
+        o.Instrumentation.EnableAspNetCoreInstrumentation = true;
+    })
+    .WithTracing(t => t.AddSource(activitySources))
+    .WithMetrics(m => m.AddMeter(meterNames));
 ```
 
 The two `.AddSource` / `.AddMeter` calls are the only Teams-specific OTel wiring. Everything else is standard distro setup.
@@ -39,11 +49,6 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 export OTEL_SERVICE_NAME=teams-observability-bot
 export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=local,service.version=dev"
 
-# Required for the AI chat client (Azure OpenAI):
-export AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
-export AZURE_OPENAI_KEY=your-key
-export AZURE_OPENAI_DEPLOYMENT=your-deployment-name
-
 dotnet run --project core/samples/ObservabilityBot
 ```
 
@@ -51,10 +56,6 @@ Open http://localhost:3000 (`admin` / `admin`) and explore Tempo, Mimir, and Lok
 
 ## Send a test activity
 
-To exercise the pipeline you need to POST a Bot Framework activity payload (with a valid bearer token) to the bot's `/api/messages` endpoint. Reasonable options:
-
-- Use the `core/test/ABSTokenServiceClient` helper to mint a token, then `curl` a JSON activity.
-- Drive the bot from one of the harnesses under `core/test/IntegrationTests`.
 - Deploy the bot to a Teams tenant and chat with it.
 
 Then use these commands in chat:
@@ -64,8 +65,7 @@ Then use these commands in chat:
 
 ## Export targets
 
-- Set `APPLICATIONINSIGHTS_CONNECTION_STRING` to additionally export to Azure Monitor / Application Insights.
-- Remove `ExportTarget.Console` for production.
+- Set `ConnectionStrings__AppInsights` to additionally export to Azure Monitor / Application Insights.
 - See the [Microsoft OpenTelemetry distro README](https://github.com/microsoft/opentelemetry-distro-dotnet#readme) for the full set of `ExportTarget` values, sampling, and Azure Monitor options.
 
 ## What you should see
@@ -89,6 +89,7 @@ HTTP server span                       (auto, OTel ASP.NET Core)
 Metrics (Prometheus / Mimir names): `teams_activities_received_total`, `teams_turn_duration_milliseconds_bucket/sum/count`, `teams_handler_errors_total`, `teams_middleware_duration_milliseconds_*`, `teams_outbound_calls_total`, `teams_outbound_errors_total`.
 
 Logs: every `ILogger` record produced inside a turn carries the active `TraceId` / `SpanId` so Loki queries can pivot from a slow trace to its log lines.
+
 ## Running the Sample
 
 ~~~bash

--- a/core/samples/StreamingBot/Program.cs
+++ b/core/samples/StreamingBot/Program.cs
@@ -13,9 +13,9 @@ using Microsoft.Teams.Cards;
 WebApplicationBuilder builder = WebApplication.CreateSlimBuilder(args);
 builder.Services.AddTeamsBotApplication();
 
-string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"] ?? throw new InvalidOperationException("AzureOpenAI:Endpoint is required.");
-string apiKey = builder.Configuration["AZURE_OPENAI_KEY"] ?? throw new InvalidOperationException("AzureOpenAI:ApiKey is required.");
-string deployment = builder.Configuration["AZURE_OPENAI_DEPLOYMENT"] ?? throw new InvalidOperationException("AzureOpenAI:Deployment is required.");
+string endpoint = builder.Configuration["AzureOpenAI:Endpoint"] ?? throw new InvalidOperationException("AzureOpenAI:Endpoint is required.");
+string apiKey = builder.Configuration["AzureOpenAI:ApiKey"] ?? throw new InvalidOperationException("AzureOpenAI:ApiKey is required.");
+string deployment = builder.Configuration["AzureOpenAI:Deployment"] ?? throw new InvalidOperationException("AzureOpenAI:Deployment is required.");
 
 builder.Services.AddSingleton<AzureOpenAIClient>(_ => new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey)));
 builder.Services.AddSingleton<IChatClient>(sp =>

--- a/core/samples/StreamingBot/Properties/launchSettings.TEMPLATE.json
+++ b/core/samples/StreamingBot/Properties/launchSettings.TEMPLATE.json
@@ -12,10 +12,7 @@
         "AzureAd__ClientCredentials__0__ClientSecret": "",
         "AzureOpenAI__Endpoint": "",
         "AzureOpenAI__ApiKey": "",
-        "AzureOpenAI__Deployment": "",
-        "AZURE_OPENAI_ENDPOINT": "",
-        "AZURE_OPENAI_KEY": "",
-        "AZURE_OPENAI_DEPLOYMENT": ""
+        "AzureOpenAI__Deployment": ""
       },
       "applicationUrl": "http://localhost:3978"
     }

--- a/core/samples/StreamingBot/README.md
+++ b/core/samples/StreamingBot/README.md
@@ -6,9 +6,9 @@ Shows streaming responses in Teams using `TeamsStreamingWriter`, including incre
 
 - Bot registered and installed in Teams.
 - Azure OpenAI configured:
-  - `AZURE_OPENAI_ENDPOINT`
-  - `AZURE_OPENAI_KEY`
-  - `AZURE_OPENAI_DEPLOYMENT`
+  - `AzureOpenAI__Endpoint`
+  - `AzureOpenAI__ApiKey`
+  - `AzureOpenAI__Deployment`
 
 ## What it shows
 

--- a/core/src/Microsoft.Teams.Apps/Context.cs
+++ b/core/src/Microsoft.Teams.Apps/Context.cs
@@ -354,15 +354,38 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// </summary>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A list of token status results for all configured connections.</returns>
-    public Task<IList<GetTokenStatusResult>> GetConnectionStatusAsync(CancellationToken cancellationToken = default)
+    public async Task<IList<GetTokenStatusResult>> GetConnectionStatusAsync(CancellationToken cancellationToken = default)
     {
         OAuthFlowRegistry registry = TeamsBotApplication.OAuthRegistry
             ?? throw new InvalidOperationException("No OAuthFlow registered. Call AddOAuthFlow(connectionName) on the TeamsBotApplication first.");
 
-        // Use any flow -- GetConnectionStatusAsync returns all connections regardless
-        OAuthFlow flow = registry.GetAllFlows().First();
+        // Use any flow to call the GetTokenStatus API (returns all connections)
+        OAuthFlow first = registry.GetAllFlows().First();
+        IList<GetTokenStatusResult> statuses = await first.GetConnectionStatusAsync(this, cancellationToken).ConfigureAwait(false);
 
-        return flow.GetConnectionStatusAsync(this, cancellationToken);
+        // GetTokenStatus doesn't reliably reflect tokens obtained via silent SSO token exchange.
+        // For any connection that the API reports as not connected, verify by calling GetTokenAsync
+        // directly — if a token is actually present, correct the result.
+        List<GetTokenStatusResult> results = statuses.ToList();
+        foreach (OAuthFlow flow in registry.GetAllFlows())
+        {
+            GetTokenStatusResult? existing = results.FirstOrDefault(s =>
+                string.Equals(s.ConnectionName, flow.ConnectionName, StringComparison.OrdinalIgnoreCase));
+
+            if (existing?.HasToken == true)
+                continue;
+
+            string? token = await flow.GetTokenAsync(this, cancellationToken).ConfigureAwait(false);
+            if (token is not null)
+            {
+                if (existing is not null)
+                    existing.HasToken = true;
+                else
+                    results.Add(new GetTokenStatusResult { ConnectionName = flow.ConnectionName, HasToken = true });
+            }
+        }
+
+        return results;
     }
 
     private OAuthFlow ResolveOAuthFlow(string? connectionName)

--- a/core/src/Microsoft.Teams.Apps/Handlers/InvokeHandler.Activity.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/InvokeHandler.Activity.cs
@@ -136,6 +136,8 @@ public class InvokeName(string value) : StringEnum(value)
     public static readonly InvokeName MessageExtensionSelectItem = new("composeExtension/selectItem");
     /// <summary>Message extension submit action invoke name.</summary>
     public static readonly InvokeName MessageExtensionSubmitAction = new("composeExtension/submitAction");
+    /// <summary>Message extension setting invoke name. Sent when the user saves settings after the config URL flow.</summary>
+    public static readonly InvokeName MessageExtensionSetting = new("composeExtension/setting");
     /// <summary>Message fetch task invoke name.</summary>
     public static readonly InvokeName MessageFetchTask = new("message/fetchTask");
     /// <summary>Message submit action invoke name.</summary>
@@ -226,6 +228,11 @@ public static class InvokeNames
     /// Message extension submit action invoke name.
     /// </summary>
     public static InvokeName MessageExtensionSubmitAction => InvokeName.MessageExtensionSubmitAction;
+
+    /// <summary>
+    /// Message extension setting invoke name. Sent when the user saves settings after the config URL flow.
+    /// </summary>
+    public static InvokeName MessageExtensionSetting => InvokeName.MessageExtensionSetting;
 
     /// <summary>
     /// Message fetch task invoke name. Sent when the user clicks a feedback button on an AI-generated message.

--- a/core/src/Microsoft.Teams.Apps/Handlers/InvokeHandler.Activity.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/InvokeHandler.Activity.cs
@@ -138,6 +138,8 @@ public class InvokeName(string value) : StringEnum(value)
     public static readonly InvokeName MessageExtensionSubmitAction = new("composeExtension/submitAction");
     /// <summary>Message extension setting invoke name. Sent when the user saves settings after the config URL flow.</summary>
     public static readonly InvokeName MessageExtensionSetting = new("composeExtension/setting");
+    /// <summary>Message extension on card button clicked invoke name. Sent when a user clicks an Action.Submit button on a message extension result card.</summary>
+    public static readonly InvokeName MessageExtensionCardButtonClicked = new("composeExtension/onCardButtonClicked");
     /// <summary>Message fetch task invoke name.</summary>
     public static readonly InvokeName MessageFetchTask = new("message/fetchTask");
     /// <summary>Message submit action invoke name.</summary>
@@ -233,6 +235,12 @@ public static class InvokeNames
     /// Message extension setting invoke name. Sent when the user saves settings after the config URL flow.
     /// </summary>
     public static InvokeName MessageExtensionSetting => InvokeName.MessageExtensionSetting;
+
+    /// <summary>
+    /// Message extension on card button clicked invoke name.
+    /// Sent when a user clicks an <c>Action.Submit</c> button on a message extension result card.
+    /// </summary>
+    public static InvokeName MessageExtensionCardButtonClicked => InvokeName.MessageExtensionCardButtonClicked;
 
     /// <summary>
     /// Message fetch task invoke name. Sent when the user clicks a feedback button on an AI-generated message.

--- a/core/src/Microsoft.Teams.Apps/Handlers/InvokeHandler.Response.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/InvokeHandler.Response.cs
@@ -72,6 +72,7 @@ public class InvokeResponse<TBody>(int status, TBody? body = default) : InvokeRe
     /// This property shadows the base class Body property but uses the same underlying storage,
     /// ensuring no synchronization issues between typed and untyped access.
     /// </summary>
+    [JsonPropertyName("value")]
     public new TBody? Body
     {
         get => (TBody?)base.Body;

--- a/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionAction.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionAction.cs
@@ -125,9 +125,8 @@ public class MessageExtensionAction
     /// The activity preview that was originally sent to Teams when showing the bot message preview.
     /// This is sent back by Teams when the user clicks 'edit' or 'send' on the preview.
     /// </summary>
-    // TODO : this needs to be activity type or something else - format is type, attachments[]
     [JsonPropertyName("botActivityPreview")]
-    public IList<TeamsActivityInput>? BotActivityPreview { get; set; }
+    public IList<MessageExtensionActivityPreview>? BotActivityPreview { get; set; }
 
     /// <summary>
     /// Data included with the submit action.

--- a/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionHandlers.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionHandlers.cs
@@ -48,7 +48,14 @@ public delegate Task<InvokeResponse<MessageExtensionResponse>> MessageExtensionQ
 /// Delegate for handling message extension setting invoke activities.
 /// Sent by Teams when the user saves settings after the config URL popup.
 /// </summary>
-public delegate Task<InvokeResponse<MessageExtensionResponse>> MessageExtensionSettingsHandler(Context<InvokeActivity<MessageExtensionQuery>> context, CancellationToken cancellationToken = default);
+public delegate Task<InvokeResponse> MessageExtensionSettingsHandler(Context<InvokeActivity<MessageExtensionQuery>> context, CancellationToken cancellationToken = default);
+
+/// <summary>
+/// Delegate for handling message extension card button clicked invoke activities.
+/// Sent when a user clicks an <c>Action.Submit</c> button on a message extension result card.
+/// The activity value contains the data payload from the button.
+/// </summary>
+public delegate Task<InvokeResponse> OnCardButtonClickedHandler(Context<InvokeActivity<JsonElement>> context, CancellationToken cancellationToken = default);
 
 
 /// <summary>
@@ -274,8 +281,33 @@ public static class MessageExtensionExtensions
             {
                 InvokeActivity<MessageExtensionQuery> typedActivity = new(ctx.Activity);
                 var typedContext = ctx.CreateDerivedContext(typedActivity);
-                await handler(typedContext, cancellationToken).ConfigureAwait(false);
-                return new InvokeResponse(200);
+                return await handler(typedContext, cancellationToken).ConfigureAwait(false);
+            }
+        });
+
+        return app;
+    }
+
+    /// <summary>
+    /// Registers a handler for message extension card button clicked invoke activities.
+    /// Called when a user clicks an <c>Action.Submit</c> button on a message extension result card.
+    /// Cannot be combined with <see cref="InvokeExtensions.OnInvoke"/>.
+    /// </summary>
+    /// <param name="app">The Teams bot application.</param>
+    /// <param name="handler">The handler to register.</param>
+    /// <returns>The updated Teams bot application.</returns>
+    public static TeamsBotApplication OnCardButtonClicked(this TeamsBotApplication app, OnCardButtonClickedHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(app, nameof(app));
+        app.Router.Register(new Route<InvokeActivity>
+        {
+            Name = string.Join("/", TeamsActivityTypes.Invoke, InvokeNames.MessageExtensionCardButtonClicked),
+            Selector = activity => activity.Name == InvokeNames.MessageExtensionCardButtonClicked,
+            HandlerWithReturn = async (ctx, cancellationToken) =>
+            {
+                InvokeActivity<JsonElement> typedActivity = new(ctx.Activity);
+                var typedContext = ctx.CreateDerivedContext(typedActivity);
+                return await handler(typedContext, cancellationToken).ConfigureAwait(false);
             }
         });
 

--- a/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionHandlers.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionHandlers.cs
@@ -44,6 +44,12 @@ public delegate Task<InvokeResponse<MessageExtensionResponse>> MessageExtensionS
 /// </summary>
 public delegate Task<InvokeResponse<MessageExtensionResponse>> MessageExtensionQuerySettingUrlHandler(Context<InvokeActivity<MessageExtensionQuery>> context, CancellationToken cancellationToken = default);
 
+/// <summary>
+/// Delegate for handling message extension setting invoke activities.
+/// Sent by Teams when the user saves settings after the config URL popup.
+/// </summary>
+public delegate Task<InvokeResponse<MessageExtensionResponse>> MessageExtensionSettingsHandler(Context<InvokeActivity<MessageExtensionQuery>> context, CancellationToken cancellationToken = default);
+
 
 /// <summary>
 /// Extension methods for registering message extension invoke handlers.
@@ -243,6 +249,33 @@ public static class MessageExtensionExtensions
                 InvokeActivity<MessageExtensionQuery> typedActivity = new(ctx.Activity);
                 var typedContext = ctx.CreateDerivedContext(typedActivity);
                 return await handler(typedContext, cancellationToken).ConfigureAwait(false);
+            }
+        });
+
+        return app;
+    }
+
+    /// <summary>
+    /// Registers a handler for message extension setting invoke activities.
+    /// Called by Teams when the user saves settings after the config URL popup.
+    /// Must be paired with <see cref="OnQuerySettingUrl"/> to complete the settings flow.
+    /// </summary>
+    /// <param name="app">The Teams bot application.</param>
+    /// <param name="handler">The handler to register.</param>
+    /// <returns>The updated Teams bot application.</returns>
+    public static TeamsBotApplication OnSetting(this TeamsBotApplication app, MessageExtensionSettingsHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(app, nameof(app));
+        app.Router.Register(new Route<InvokeActivity>
+        {
+            Name = string.Join("/", TeamsActivityTypes.Invoke, InvokeNames.MessageExtensionSetting),
+            Selector = activity => activity.Name == InvokeNames.MessageExtensionSetting,
+            HandlerWithReturn = async (ctx, cancellationToken) =>
+            {
+                InvokeActivity<MessageExtensionQuery> typedActivity = new(ctx.Activity);
+                var typedContext = ctx.CreateDerivedContext(typedActivity);
+                await handler(typedContext, cancellationToken).ConfigureAwait(false);
+                return new InvokeResponse(200);
             }
         });
 

--- a/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionQuery.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionQuery.cs
@@ -28,14 +28,11 @@ public class MessageExtensionQuery
     [JsonPropertyName("queryOptions")]
     public QueryOptions? QueryOptions { get; set; }
 
-    //TODO : check how to use this ? auth ?
-    /*
     /// <summary>
-    /// State parameter passed back to the bot after authentication/configuration flow.
+    /// State value after selecting config
     /// </summary>
     [JsonPropertyName("state")]
     public string? State { get; set; }
-    */
 }
 
 /// <summary>

--- a/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionQueryLink.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionQueryLink.cs
@@ -15,13 +15,4 @@ public class MessageExtensionQueryLink
     /// </summary>
     [JsonPropertyName("url")]
     public Uri? Url { get; set; }
-
-    //TODO : review
-    /*
-    /// <summary>
-    /// State parameter for OAuth flow.
-    /// </summary>
-    [JsonPropertyName("state")]
-    public string? State { get; set; }
-    */
 }

--- a/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionResponse.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionResponse.cs
@@ -106,15 +106,48 @@ public class ComposeExtension
     /// <summary>
     /// Activity preview for bot message preview.
     /// </summary>
-    //TODO : this needs to be activity type or something else - format is type, attachments[]
     [JsonPropertyName("activityPreview")]
-    public TeamsActivityInput? ActivityPreview { get; set; }
+    public MessageExtensionActivityPreview? ActivityPreview { get; set; }
 
     /// <summary>
     /// Suggested actions for config type.
     /// </summary>
     [JsonPropertyName("suggestedActions")]
     public MessageExtensionSuggestedAction? SuggestedActions { get; set; }
+}
+
+
+/// <summary>
+/// Represents an activity preview used in <see cref="MessageExtensionResponseTypes.BotMessagePreview"/> responses.
+/// Teams renders this as a card preview before the user confirms sending.
+/// On the inbound side, Teams echoes this back via <see cref="MessageExtensionAction.BotActivityPreview"/>
+/// when the user clicks 'send' or 'edit'.
+/// </summary>
+public class MessageExtensionActivityPreview
+{
+    /// <summary>
+    /// The activity type. Defaults to "message".
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "message";
+
+    /// <summary>
+    /// The attachments (cards) to show in the preview.
+    /// </summary>
+    [JsonPropertyName("attachments")]
+    public IList<TeamsAttachment>? Attachments { get; set; }
+
+    /// <summary>
+    /// Adds one or more attachments to the preview.
+    /// </summary>
+    public MessageExtensionActivityPreview AddAttachment(params TeamsAttachment[] attachments)
+    {
+        ArgumentNullException.ThrowIfNull(attachments);
+        Attachments ??= new List<TeamsAttachment>();
+        foreach (TeamsAttachment attachment in attachments)
+            Attachments.Add(attachment);
+        return this;
+    }
 }
 
 /// <summary>
@@ -138,7 +171,7 @@ public class MessageExtensionResponseBuilder
     private MessageExtensionResponseType? _type;
     private AttachmentLayoutType? _attachmentLayout;
     private TeamsAttachment[]? _attachments;
-    private TeamsActivityInput? _activityPreview;
+    private MessageExtensionActivityPreview? _activityPreview;
     private SuggestedAction[]? _suggestedActions;
     private string? _text;
 
@@ -172,7 +205,7 @@ public class MessageExtensionResponseBuilder
     /// <summary>
     /// Sets the activity preview for <see cref="MessageExtensionResponseTypes.BotMessagePreview"/> responses.
     /// </summary>
-    public MessageExtensionResponseBuilder WithActivityPreview(TeamsActivityInput activityPreview)
+    public MessageExtensionResponseBuilder WithActivityPreview(MessageExtensionActivityPreview activityPreview)
     {
         _activityPreview = activityPreview;
         return this;

--- a/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionResponse.cs
+++ b/core/src/Microsoft.Teams.Apps/Handlers/MessageExtensions/MessageExtensionResponse.cs
@@ -113,7 +113,7 @@ public class ComposeExtension
     /// Suggested actions for config type.
     /// </summary>
     [JsonPropertyName("suggestedActions")]
-    public MessageExtensionSuggestedAction? SuggestedActions { get; set; }
+    public SuggestedActions? SuggestedActions { get; set; }
 }
 
 
@@ -151,19 +151,6 @@ public class MessageExtensionActivityPreview
 }
 
 /// <summary>
-/// Suggested actions for messaging extension configuration.
-/// </summary>
-public class MessageExtensionSuggestedAction
-{
-    /// <summary>
-    /// Array of actions.
-    /// </summary>
-    [JsonPropertyName("actions")]
-    public IList<SuggestedAction>? Actions { get; set; }
-}
-
-
-/// <summary>
 /// Builder for MessageExtensionResponse.
 /// </summary>
 public class MessageExtensionResponseBuilder
@@ -172,7 +159,7 @@ public class MessageExtensionResponseBuilder
     private AttachmentLayoutType? _attachmentLayout;
     private TeamsAttachment[]? _attachments;
     private MessageExtensionActivityPreview? _activityPreview;
-    private SuggestedAction[]? _suggestedActions;
+    private SuggestedActions? _suggestedActions;
     private string? _text;
 
     /// <summary>
@@ -214,7 +201,7 @@ public class MessageExtensionResponseBuilder
     /// <summary>
     /// Sets suggested actions for <see cref="MessageExtensionResponseTypes.Config"/> responses.
     /// </summary>
-    public MessageExtensionResponseBuilder WithSuggestedActions(params SuggestedAction[] actions)
+    public MessageExtensionResponseBuilder WithSuggestedActions(SuggestedActions actions)
     {
         _suggestedActions = actions;
         return this;
@@ -354,7 +341,7 @@ public class MessageExtensionResponseBuilder
 
     private MessageExtensionResponse ValidateConfigType()
     {
-        if (_suggestedActions == null || _suggestedActions.Length == 0)
+        if (_suggestedActions == null)
         {
             throw new InvalidOperationException("SuggestedActions must be set for Config type. Use WithSuggestedActions().");
         }
@@ -384,7 +371,7 @@ public class MessageExtensionResponseBuilder
             ComposeExtension = new ComposeExtension
             {
                 Type = _type,
-                SuggestedActions = new MessageExtensionSuggestedAction { Actions = _suggestedActions }
+                SuggestedActions = _suggestedActions
             }
         };
     }

--- a/core/src/Microsoft.Teams.Core/UserTokenClient.cs
+++ b/core/src/Microsoft.Teams.Core/UserTokenClient.cs
@@ -66,11 +66,9 @@ public class UserTokenClient(HttpClient httpClient, IConfiguration configuration
 
                 if (result == null || result.Count == 0)
                 {
-                    return new[] { new GetTokenStatusResult { HasToken = false } };
+                    return [new GetTokenStatusResult { HasToken = false }];
                 }
-                GetTokenStatusResult[] values = new GetTokenStatusResult[result.Count];
-                result.CopyTo(values, 0);
-                return values;
+                return [.. result];
             }).ConfigureAwait(false))!;
 
     }


### PR DESCRIPTION
This pull request introduces significant improvements and new features to the `MessageExtensionBot` sample, streamlines configuration for several other samples, and enhances code maintainability and clarity. The most notable changes include the addition of a working message extension settings flow (with UI and manifest updates), improved adaptive card actions, and the migration of sensitive configuration from environment variables to `appsettings` for better local development experience.

**Message Extension Settings & Actions**

* Added a static settings page (`wwwroot/settings.html`) for message extension configuration, with Teams SDK integration for saving/cancelling settings.
* Implemented the `OnQuerySettingUrl` and `OnSetting` handlers in `Program.cs` to support opening and saving extension settings, including proper manifest and domain configuration. [[1]](diffhunk://#diff-9da189387a8b06507339b8044bf5a572c0f84620969ebe735248a73252da901fL181-R228) [[2]](diffhunk://#diff-0715c045fd4cde11cc997a7e18a46d9ec15a85f6424849f991aa59cc4033f371R9) [[3]](diffhunk://#diff-59dd48fbb263d072bb3b1aa2e09a9a69a936223b33faf7f6cf6e592e39534f16R31) [[4]](diffhunk://#diff-59dd48fbb263d072bb3b1aa2e09a9a69a936223b33faf7f6cf6e592e39534f16R89-R92) [[5]](diffhunk://#diff-59dd48fbb263d072bb3b1aa2e09a9a69a936223b33faf7f6cf6e592e39534f16L144-L157)
* Updated manifest guidance and documentation to clarify `canUpdateConfiguration` placement and required `validDomains` for settings. (F2f34638L2R2, [[1]](diffhunk://#diff-59dd48fbb263d072bb3b1aa2e09a9a69a936223b33faf7f6cf6e592e39534f16R89-R92) [[2]](diffhunk://#diff-59dd48fbb263d072bb3b1aa2e09a9a69a936223b33faf7f6cf6e592e39534f16L144-L157)

**Adaptive Card and Action Improvements**

* Added a "View Details" button (`OpenUrlAction`) to adaptive cards in `CreateSelectItemCard`, and handled card button clicks in the bot with the new `OnCardButtonClicked` handler. [[1]](diffhunk://#diff-c36a5afc0c5dc9bfa77c9dd73378dae8c40835e290185cb8cb9bc49d9ac9eb3eL65-R73) [[2]](diffhunk://#diff-9da189387a8b06507339b8044bf5a572c0f84620969ebe735248a73252da901fR77-R84)
* Refactored adaptive card response creation to remove unused parameters and simplify usage. [[1]](diffhunk://#diff-90979d4791ec69de4624d77dbc32fc28af3a36bf6f96562b82e34d02dd3c0589L73-L82) [[2]](diffhunk://#diff-ac66e625445e8b192f426d1079a5fb62a19909d9e1e6d5a5257816dc04cd1d90L57-R57)

**Configuration and Environment Variable Migration**

* Moved OpenAI and bot configuration from environment variables to `appsettings`/launch settings for `ObservabilityBot`, `ExtAIBot`, and `McpServer` samples, and updated documentation accordingly. [[1]](diffhunk://#diff-d1f6e0bbf0adebdbaa1e005336ebdf86af28eacf2c6596b12343d0f280d65bdfR32) [[2]](diffhunk://#diff-d1f6e0bbf0adebdbaa1e005336ebdf86af28eacf2c6596b12343d0f280d65bdfL41-R42) [[3]](diffhunk://#diff-794a9cdc0fede6b2d690becd0906782956dcdb82ee5f9cf384fe6dced9d87abfR46) [[4]](diffhunk://#diff-794a9cdc0fede6b2d690becd0906782956dcdb82ee5f9cf384fe6dced9d87abfL77-R84) [[5]](diffhunk://#diff-186b57f61fda5eddff7849833ba478cf98ceebeda00b281f52d056f297201dfbL21-R23) [[6]](diffhunk://#diff-8e07cd53d777479841d197f2884a7d3c82aca1bc96e72c88bc92f0c5d8c59f9aL25-L42) [[7]](diffhunk://#diff-10fc9baec87e90e3fdee17b4d35d90f927b1be354e3dd09777aa5606243db131L33-L52) [[8]](diffhunk://#diff-0715c045fd4cde11cc997a7e18a46d9ec15a85f6424849f991aa59cc4033f371R9)

**Codebase and Documentation Cleanup**

* Updated and clarified README files for multiple samples to reflect new configuration patterns and manifest requirements, and removed redundant or outdated setup instructions. [[1]](diffhunk://#diff-59dd48fbb263d072bb3b1aa2e09a9a69a936223b33faf7f6cf6e592e39534f16L10-L33) [[2]](diffhunk://#diff-59dd48fbb263d072bb3b1aa2e09a9a69a936223b33faf7f6cf6e592e39534f16L95) [[3]](diffhunk://#diff-8bc8bcc4ffe6e693d0033ac505186ab14f7401424c8c85ba5d89d515117ae9abR16) [[4]](diffhunk://#diff-186b57f61fda5eddff7849833ba478cf98ceebeda00b281f52d056f297201dfbL21-R23) [[5]](diffhunk://#diff-8e07cd53d777479841d197f2884a7d3c82aca1bc96e72c88bc92f0c5d8c59f9aL25-L42) [[6]](diffhunk://#diff-10fc9baec87e90e3fdee17b4d35d90f927b1be354e3dd09777aa5606243db131L33-L52)

**Other Enhancements**

* Improved helper method type safety for extracting preview card data. [[1]](diffhunk://#diff-9da189387a8b06507339b8044bf5a572c0f84620969ebe735248a73252da901fL88-R109) [[2]](diffhunk://#diff-9da189387a8b06507339b8044bf5a572c0f84620969ebe735248a73252da901fL158-R174)
* Enabled static file serving for the settings page in the bot web app.

These changes collectively make the samples more robust, easier to configure, and better aligned with Teams extensibility best practices.