### PR TITLE
fix: omit sequence from final stream messages

### DIFF
--- a/core/src/Microsoft.Teams.Apps/Schema/Entities/StreamInfoEntity.Extensions.cs
+++ b/core/src/Microsoft.Teams.Apps/Schema/Entities/StreamInfoEntity.Extensions.cs
@@ -40,18 +40,18 @@ public static class StreamInfoEntityExtensions
 
         activity.ChannelData.StreamId = resolvedStreamId;
         activity.ChannelData.StreamType = streamType;
-        if (streamSequence.HasValue)
-        {
-            activity.ChannelData.StreamSequence = streamSequence.Value;
-        }
+        activity.ChannelData.StreamSequence = streamSequence;
 
         activity.Entities ??= [];
         StreamInfoEntity entity = new()
         {
             StreamId = resolvedStreamId,
-            StreamType = streamType,
-            StreamSequence = streamSequence
+            StreamType = streamType
         };
+        if (streamSequence.HasValue)
+        {
+            entity.StreamSequence = streamSequence.Value;
+        }
 
         activity.Entities.Add(entity);
         return entity;

--- a/core/test/Microsoft.Teams.Apps.UnitTests/MessageActivityInputTests.cs
+++ b/core/test/Microsoft.Teams.Apps.UnitTests/MessageActivityInputTests.cs
@@ -69,6 +69,20 @@ public class MessageActivityInputTests
     }
 
     [Fact]
+    public void AddStreamFinal_OmitsStreamSequence()
+    {
+        MessageActivityInput activity = new MessageActivityInput
+        {
+            ChannelData = new TeamsOutboundChannelData { StreamSequence = 3 }
+        };
+
+        activity.AddStreamFinal();
+
+        Assert.Null(activity.ChannelData.StreamSequence);
+        Assert.DoesNotContain("\"streamSequence\"", activity.ToJson());
+    }
+
+    [Fact]
     public void FluentApi_CompleteActivity_BuildsCorrectly()
     {
         MessageActivityInput activity = new MessageActivityInput()


### PR DESCRIPTION
## Summary

- clear stale channel `StreamSequence` when final stream metadata is added
- omit the stream entity sequence property when no sequence is supplied
- add serialized payload regression coverage

Follow-up to microsoft/teams.ts#688.

## Testing

- `dotnet format core/core.slnx --include core/src/Microsoft.Teams.Apps/Schema/Entities/StreamInfoEntity.Extensions.cs core/test/Microsoft.Teams.Apps.UnitTests/MessageActivityInputTests.cs --verify-no-changes --no-restore`
- `dotnet test core/test/Microsoft.Teams.Apps.UnitTests/Microsoft.Teams.Apps.UnitTests.csproj -f net10.0 -v minimal --no-restore` (484 passed)