### PR TITLE
Document cross-platform filesystem requirements

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Repository guidance
+
+Release validation may run on Windows as well as Linux. Keep filesystem code and tests cross-platform: use .NET path APIs instead of hard-coded separators, specify UTF-8 when text APIs would otherwise use platform-default encodings, and avoid locale-dependent or Unix-only filesystem assumptions.


### PR DESCRIPTION
## Summary

Release validation can run on Windows as well as Linux, so contributors and agents need explicit filesystem portability expectations. This guidance helps prevent platform-only release failures while avoiding redundant encoding arguments where APIs already define the required default.