### PR TITLE
Onboard Azure pipelines to CFS NuGet

### DIFF
--- a/.azdo/ci.yaml
+++ b/.azdo/ci.yaml
@@ -26,8 +26,7 @@ pool:
 
 variables:
   buildConfiguration: 'Release'
-  # Temporary test value. Replace with the CFS feed URL before merging.
-  CfsNuGetFeedUrl: 'https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json'
+  CfsNuGetFeedUrl: 'https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/Github_Pipelines_PublicPackages/nuget/v3/index.json'
 
 stages:
 - stage: DetectChanges

--- a/.azdo/ci.yaml
+++ b/.azdo/ci.yaml
@@ -26,7 +26,6 @@ pool:
 
 variables:
   buildConfiguration: 'Release'
-  CfsNuGetFeedUrl: 'https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/Github_Pipelines_PublicPackages/nuget/v3/index.json'
 
 stages:
 - stage: DetectChanges

--- a/.azdo/ci.yaml
+++ b/.azdo/ci.yaml
@@ -26,8 +26,6 @@ pool:
 
 variables:
   buildConfiguration: 'Release'
-  # Temporary fallback. Set the real CFS URL in the Azure DevOps variable group before merging.
-  CfsNuGetFeedUrl: 'https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json'
 
 stages:
 - stage: DetectChanges

--- a/.azdo/ci.yaml
+++ b/.azdo/ci.yaml
@@ -26,6 +26,8 @@ pool:
 
 variables:
   buildConfiguration: 'Release'
+  # Temporary test value. Replace with the CFS feed URL before merging.
+  CfsNuGetFeedUrl: 'https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json'
 
 stages:
 - stage: DetectChanges

--- a/.azdo/ci.yaml
+++ b/.azdo/ci.yaml
@@ -22,9 +22,12 @@ pr:
 
 pool:
   vmImage: 'ubuntu-22.04'
+  # TODO(SR21): Move to the network-isolated 1ES pool after CFS restore is green.
 
 variables:
   buildConfiguration: 'Release'
+  # Temporary fallback. Set the real CFS URL in the Azure DevOps variable group before merging.
+  CfsNuGetFeedUrl: 'https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json'
 
 stages:
 - stage: DetectChanges

--- a/.azdo/publish.yaml
+++ b/.azdo/publish.yaml
@@ -41,8 +41,6 @@ parameters:
 variables:
   buildConfiguration: 'Release'
   folderPath: '$(Build.SourcesDirectory)'
-  # Temporary fallback. Set the real CFS URL in the Azure DevOps variable group before merging.
-  CfsNuGetFeedUrl: 'https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json'
   ${{ if eq(parameters.publishType, 'Public') }}:
     appRegistrationTenantId: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
     authenticodeSignId: '2d5c4ab9-0b7e-4f60-bb92-70322df77b94'

--- a/.azdo/publish.yaml
+++ b/.azdo/publish.yaml
@@ -41,6 +41,8 @@ parameters:
 variables:
   buildConfiguration: 'Release'
   folderPath: '$(Build.SourcesDirectory)'
+  # Temporary test value. Replace with the CFS feed URL before merging.
+  CfsNuGetFeedUrl: 'https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json'
   ${{ if eq(parameters.publishType, 'Public') }}:
     appRegistrationTenantId: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
     authenticodeSignId: '2d5c4ab9-0b7e-4f60-bb92-70322df77b94'

--- a/.azdo/publish.yaml
+++ b/.azdo/publish.yaml
@@ -41,6 +41,8 @@ parameters:
 variables:
   buildConfiguration: 'Release'
   folderPath: '$(Build.SourcesDirectory)'
+  # Temporary fallback. Set the real CFS URL in the Azure DevOps variable group before merging.
+  CfsNuGetFeedUrl: 'https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json'
   ${{ if eq(parameters.publishType, 'Public') }}:
     appRegistrationTenantId: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
     authenticodeSignId: '2d5c4ab9-0b7e-4f60-bb92-70322df77b94'
@@ -74,21 +76,7 @@ extends:
           displayName: 'Build, Test, Pack, and Push to Internal Feed'
           steps:
             - checkout: self
-            - pwsh: |
-                $nugetConfig = @"
-                <?xml version="1.0" encoding="utf-8"?>
-                <configuration>
-                  <packageSources>
-                    <clear />
-                    <add key="TeamsSDKPreviews" value="https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json" />
-                  </packageSources>
-                </configuration>
-                "@
-                $nugetConfig | Out-File -FilePath "$(Build.SourcesDirectory)/nuget.config" -Encoding utf8
-              displayName: 'Create nuget.config'
-
-            - task: NuGetAuthenticate@1
-              displayName: 'Authenticate with NuGet feeds'
+            - template: .azdo/templates/configure-cfs-nuget.yaml@self
 
             - ${{ if eq(parameters.packageSet, 'Legacy') }}:
               - template: .azdo/templates/build-test-pack.yaml@self
@@ -97,6 +85,7 @@ extends:
                   pack: true
                   packPattern: 'Libraries/**/*.csproj'
                   publishArtifact: false
+                  configureNuGet: false
             - ${{ if eq(parameters.packageSet, 'Core') }}:
               - template: .azdo/templates/build-test-pack.yaml@self
                 parameters:
@@ -104,6 +93,7 @@ extends:
                   pack: true
                   packPattern: 'core/src/**/*.csproj'
                   publishArtifact: false
+                  configureNuGet: false
 
             - task: 1ES.PublishNuget@1
               displayName: 'Push NuGet Packages to Internal Feed'
@@ -132,21 +122,7 @@ extends:
           steps:
             - checkout: self
 
-            - pwsh: |
-                $nugetConfig = @"
-                <?xml version="1.0" encoding="utf-8"?>
-                <configuration>
-                  <packageSources>
-                    <clear />
-                    <add key="TeamsSDKPreviews" value="https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json" />
-                  </packageSources>
-                </configuration>
-                "@
-                $nugetConfig | Out-File -FilePath "$(Build.SourcesDirectory)/nuget.config" -Encoding utf8
-              displayName: 'Create nuget.config'
-
-            - task: NuGetAuthenticate@1
-              displayName: 'Authenticate with NuGet feeds'
+            - template: .azdo/templates/configure-cfs-nuget.yaml@self
 
             - ${{ if eq(parameters.packageSet, 'Legacy') }}:
               - template: .azdo/templates/build-test-pack.yaml@self
@@ -154,12 +130,14 @@ extends:
                   sourceRoot: '.'
                   pack: false
                   publishArtifact: false
+                  configureNuGet: false
             - ${{ if eq(parameters.packageSet, 'Core') }}:
               - template: .azdo/templates/build-test-pack.yaml@self
                 parameters:
                   sourceRoot: 'core'
                   pack: false
                   publishArtifact: false
+                  configureNuGet: false
 
             - ${{ if eq(parameters.packageSet, 'Legacy') }}:
               - template: .azdo/templates/sign-and-pack.yaml@self

--- a/.azdo/publish.yaml
+++ b/.azdo/publish.yaml
@@ -41,7 +41,6 @@ parameters:
 variables:
   buildConfiguration: 'Release'
   folderPath: '$(Build.SourcesDirectory)'
-  CfsNuGetFeedUrl: 'https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/Github_Pipelines_PublicPackages/nuget/v3/index.json'
   ${{ if eq(parameters.publishType, 'Public') }}:
     appRegistrationTenantId: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
     authenticodeSignId: '2d5c4ab9-0b7e-4f60-bb92-70322df77b94'

--- a/.azdo/publish.yaml
+++ b/.azdo/publish.yaml
@@ -41,8 +41,7 @@ parameters:
 variables:
   buildConfiguration: 'Release'
   folderPath: '$(Build.SourcesDirectory)'
-  # Temporary test value. Replace with the CFS feed URL before merging.
-  CfsNuGetFeedUrl: 'https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json'
+  CfsNuGetFeedUrl: 'https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/Github_Pipelines_PublicPackages/nuget/v3/index.json'
   ${{ if eq(parameters.publishType, 'Public') }}:
     appRegistrationTenantId: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
     authenticodeSignId: '2d5c4ab9-0b7e-4f60-bb92-70322df77b94'

--- a/.azdo/publish.yaml
+++ b/.azdo/publish.yaml
@@ -159,8 +159,8 @@ extends:
         displayName: 'Push Packages to nuget.org'
         dependsOn: Build_Test_Sign_Pack
         jobs:
-        - job: PushPackages
-          displayName: 'Push Packages to nuget.org'
+        - deployment: PushPackages
+          displayName: 'Manual Approval Required to Push Packages'
           templateContext:
             type: releaseJob
             isProduction: true
@@ -168,15 +168,20 @@ extends:
             - input: pipelineArtifact
               artifactName: Packages
               targetPath: '$(Pipeline.Workspace)/Packages'
-          steps:
-          - checkout: none
-          - task: 1ES.PublishNuget@1
-            displayName: 'Push Packages to nuget.org'
-            inputs:
-              useDotNetTask: false
-              packagesToPush: '$(Pipeline.Workspace)/Packages/*.nupkg'
-              packageParentPath: '$(Pipeline.Workspace)/Packages'
-              nuGetFeedType: external
-              publishFeedCredentials: 'Microsoft.Teams.*'
-              publishPackageMetadata: true
-              retryCountOnTaskFailure: 2
+          environment:
+            name: 'teams-net-publish'
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                - checkout: none
+                - task: 1ES.PublishNuget@1
+                  displayName: 'Push Packages to nuget.org'
+                  inputs:
+                    useDotNetTask: false
+                    packagesToPush: '$(Pipeline.Workspace)/Packages/*.nupkg'
+                    packageParentPath: '$(Pipeline.Workspace)/Packages'
+                    nuGetFeedType: external
+                    publishFeedCredentials: 'Microsoft.Teams.*'
+                    publishPackageMetadata: true
+                    retryCountOnTaskFailure: 2

--- a/.azdo/publish.yaml
+++ b/.azdo/publish.yaml
@@ -159,24 +159,24 @@ extends:
         displayName: 'Push Packages to nuget.org'
         dependsOn: Build_Test_Sign_Pack
         jobs:
-        - deployment: PushPackages
-          displayName: 'Manual Approval Required to Push Packages'
-          environment:
-            name: 'teams-net-publish'
-          strategy:
-            runOnce:
-              deploy:
-                steps:
-                - download: current
-                  artifact: Packages
-
-                - task: 1ES.PublishNuget@1
-                  displayName: 'Push Packages to nuget.org'
-                  inputs:
-                    useDotNetTask: false
-                    packagesToPush: '$(Pipeline.Workspace)/Packages/*.nupkg'
-                    packageParentPath: '$(Pipeline.Workspace)/Packages'
-                    nuGetFeedType: external
-                    publishFeedCredentials: 'Microsoft.Teams.*'
-                    publishPackageMetadata: true
-                    retryCountOnTaskFailure: 2
+        - job: PushPackages
+          displayName: 'Push Packages to nuget.org'
+          templateContext:
+            type: releaseJob
+            isProduction: true
+            inputs:
+            - input: pipelineArtifact
+              artifactName: Packages
+              targetPath: '$(Pipeline.Workspace)/Packages'
+          steps:
+          - checkout: none
+          - task: 1ES.PublishNuget@1
+            displayName: 'Push Packages to nuget.org'
+            inputs:
+              useDotNetTask: false
+              packagesToPush: '$(Pipeline.Workspace)/Packages/*.nupkg'
+              packageParentPath: '$(Pipeline.Workspace)/Packages'
+              nuGetFeedType: external
+              publishFeedCredentials: 'Microsoft.Teams.*'
+              publishPackageMetadata: true
+              retryCountOnTaskFailure: 2

--- a/.azdo/templates/build-test-pack.yaml
+++ b/.azdo/templates/build-test-pack.yaml
@@ -32,6 +32,10 @@ parameters:
   - name: buildConfiguration
     type: string
     default: 'Release'
+  - name: configureNuGet
+    type: boolean
+    default: true
+    # publish.yaml configures CFS once at the job level and disables this copy.
 
 steps:
   - task: UseDotNet@2
@@ -46,7 +50,10 @@ steps:
       packageType: 'sdk'
       version: '10.0.x'
 
-  - script: dotnet restore
+  - ${{ if eq(parameters.configureNuGet, true) }}:
+    - template: configure-cfs-nuget.yaml
+
+  - script: dotnet restore --configfile $(nugetConfigPath)
     displayName: 'Restore'
     workingDirectory: '$(Build.SourcesDirectory)/${{ parameters.sourceRoot }}'
 

--- a/.azdo/templates/configure-cfs-nuget.yaml
+++ b/.azdo/templates/configure-cfs-nuget.yaml
@@ -1,4 +1,3 @@
-# Requires $(CfsNuGetFeedUrl), supplied by each pipeline's Azure DevOps variable group.
 steps:
   - pwsh: |
       $path = Join-Path "$(Agent.TempDirectory)" "NuGet.CFS.config"
@@ -7,7 +6,7 @@ steps:
       <configuration>
         <packageSources>
           <clear />
-          <add key="CFS" value="$(CfsNuGetFeedUrl)" />
+          <add key="PublicPackages" value="https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/Github_Pipelines_PublicPackages/nuget/v3/index.json" />
         </packageSources>
       </configuration>
       "@

--- a/.azdo/templates/configure-cfs-nuget.yaml
+++ b/.azdo/templates/configure-cfs-nuget.yaml
@@ -1,0 +1,21 @@
+# Requires $(CfsNuGetFeedUrl), supplied by each pipeline's Azure DevOps variable group.
+steps:
+  - pwsh: |
+      $path = Join-Path "$(Agent.TempDirectory)" "NuGet.CFS.config"
+      $nugetConfig = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <clear />
+          <add key="CFS" value="$(CfsNuGetFeedUrl)" />
+        </packageSources>
+      </configuration>
+      "@
+
+      $nugetConfig | Out-File -FilePath $path -Encoding utf8
+      Write-Host "##vso[task.setvariable variable=nugetConfigPath]$path"
+      dotnet nuget list source --configfile $path
+    displayName: 'Configure CFS NuGet source'
+
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate with NuGet feeds'


### PR DESCRIPTION
## What’s changing

Azure DevOps restores now go through a shared, pipeline-generated CFS NuGet config—no repo-level config to surprise OSS contributors. 🎉 The public NuGet push also uses the 1ES release-job model required for change management.

## Why it matters

SFI network isolation will cut these pipelines off from nuget.org when they move to an isolated 1ES pool. Without this change, restore will have a rather predictable bad day.

## Interesting bits

- The config lives in `$(Agent.TempDirectory)` because this is a public repo; local builds and GitHub Actions keep their existing public-feed behavior.
- The two publish-job config/auth blocks are now one shared template, and every restore explicitly uses its exported path.
- The shared template points directly at the project’s CFS-backed `Github_Pipelines_PublicPackages` feed.
- The nuget.org deployment remains gated by the `teams-net-publish` approval environment and is now also marked as a production `releaseJob`; its pipeline artifact is declared as a template input.

## Reviewer tips

Please focus on template expansion in both CI build stages and both publish branches, plus the release-job artifact path. The 1ES pool migration is intentionally deferred. Also note that `UseDotNet@2` still downloads .NET 8/10 SDKs from the public CDN, and .NET 10 package availability in CFS needs a real pipeline run.

## Testing

The pipeline passed with the shared config using TeamsSDKPreviews. The CFS-backed `Github_Pipelines_PublicPackages` URL still needs a pipeline run to confirm package availability.