### PR TITLE
Fix SR21 NuGet isolation

### DIFF
--- a/.azdo/ci.yaml
+++ b/.azdo/ci.yaml
@@ -22,7 +22,6 @@ pr:
 
 pool:
   vmImage: 'ubuntu-22.04'
-  # TODO(SR21): Move to the network-isolated 1ES pool after CFS restore is green.
 
 variables:
   buildConfiguration: 'Release'

--- a/.azdo/publish.yaml
+++ b/.azdo/publish.yaml
@@ -86,8 +86,7 @@ extends:
                   pack: true
                   packPattern: 'Libraries/**/*.csproj'
                   publishArtifact: false
-                  configureNuGet: false
-                  useNuGetConfig: true
+                  useCfsNuGet: true
             - ${{ if eq(parameters.packageSet, 'Core') }}:
               - template: .azdo/templates/build-test-pack.yaml@self
                 parameters:
@@ -95,8 +94,7 @@ extends:
                   pack: true
                   packPattern: 'core/src/**/*.csproj'
                   publishArtifact: false
-                  configureNuGet: false
-                  useNuGetConfig: true
+                  useCfsNuGet: true
 
             - task: 1ES.PublishNuget@1
               displayName: 'Push NuGet Packages to Internal Feed'
@@ -133,16 +131,14 @@ extends:
                   sourceRoot: '.'
                   pack: false
                   publishArtifact: false
-                  configureNuGet: false
-                  useNuGetConfig: true
+                  useCfsNuGet: true
             - ${{ if eq(parameters.packageSet, 'Core') }}:
               - template: .azdo/templates/build-test-pack.yaml@self
                 parameters:
                   sourceRoot: 'core'
                   pack: false
                   publishArtifact: false
-                  configureNuGet: false
-                  useNuGetConfig: true
+                  useCfsNuGet: true
 
             - ${{ if eq(parameters.packageSet, 'Legacy') }}:
               - template: .azdo/templates/sign-and-pack.yaml@self

--- a/.azdo/publish.yaml
+++ b/.azdo/publish.yaml
@@ -87,6 +87,7 @@ extends:
                   packPattern: 'Libraries/**/*.csproj'
                   publishArtifact: false
                   configureNuGet: false
+                  useNuGetConfig: true
             - ${{ if eq(parameters.packageSet, 'Core') }}:
               - template: .azdo/templates/build-test-pack.yaml@self
                 parameters:
@@ -95,6 +96,7 @@ extends:
                   packPattern: 'core/src/**/*.csproj'
                   publishArtifact: false
                   configureNuGet: false
+                  useNuGetConfig: true
 
             - task: 1ES.PublishNuget@1
               displayName: 'Push NuGet Packages to Internal Feed'
@@ -132,6 +134,7 @@ extends:
                   pack: false
                   publishArtifact: false
                   configureNuGet: false
+                  useNuGetConfig: true
             - ${{ if eq(parameters.packageSet, 'Core') }}:
               - template: .azdo/templates/build-test-pack.yaml@self
                 parameters:
@@ -139,6 +142,7 @@ extends:
                   pack: false
                   publishArtifact: false
                   configureNuGet: false
+                  useNuGetConfig: true
 
             - ${{ if eq(parameters.packageSet, 'Legacy') }}:
               - template: .azdo/templates/sign-and-pack.yaml@self

--- a/.azdo/publish.yaml
+++ b/.azdo/publish.yaml
@@ -49,6 +49,9 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
+    settings:
+      networkIsolationPolicy: CFSClean
+
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
       image: ubuntu-22.04

--- a/.azdo/templates/build-test-pack.yaml
+++ b/.azdo/templates/build-test-pack.yaml
@@ -32,13 +32,10 @@ parameters:
   - name: buildConfiguration
     type: string
     default: 'Release'
-  - name: configureNuGet
+  - name: useCfsNuGet
     type: boolean
     default: false
-    # publish.yaml configures CFS once at the job level.
-  - name: useNuGetConfig
-    type: boolean
-    default: false
+    # publish.yaml configures and authenticates CFS once at the job level.
 
 steps:
   - task: UseDotNet@2
@@ -53,15 +50,12 @@ steps:
       packageType: 'sdk'
       version: '10.0.x'
 
-  - ${{ if eq(parameters.configureNuGet, true) }}:
-    - template: configure-cfs-nuget.yaml
-
-  - ${{ if eq(parameters.useNuGetConfig, true) }}:
+  - ${{ if eq(parameters.useCfsNuGet, true) }}:
     - script: dotnet restore --configfile $(nugetConfigPath)
       displayName: 'Restore'
       workingDirectory: '$(Build.SourcesDirectory)/${{ parameters.sourceRoot }}'
 
-  - ${{ if eq(parameters.useNuGetConfig, false) }}:
+  - ${{ if eq(parameters.useCfsNuGet, false) }}:
     - script: dotnet restore
       displayName: 'Restore'
       workingDirectory: '$(Build.SourcesDirectory)/${{ parameters.sourceRoot }}'

--- a/.azdo/templates/build-test-pack.yaml
+++ b/.azdo/templates/build-test-pack.yaml
@@ -34,8 +34,8 @@ parameters:
     default: 'Release'
   - name: configureNuGet
     type: boolean
-    default: true
-    # publish.yaml configures CFS once at the job level and disables this copy.
+    default: false
+    # publish.yaml configures CFS once at the job level.
 
 steps:
   - task: UseDotNet@2
@@ -53,9 +53,15 @@ steps:
   - ${{ if eq(parameters.configureNuGet, true) }}:
     - template: configure-cfs-nuget.yaml
 
-  - script: dotnet restore --configfile $(nugetConfigPath)
-    displayName: 'Restore'
-    workingDirectory: '$(Build.SourcesDirectory)/${{ parameters.sourceRoot }}'
+  - ${{ if eq(parameters.configureNuGet, true) }}:
+    - script: dotnet restore --configfile $(nugetConfigPath)
+      displayName: 'Restore'
+      workingDirectory: '$(Build.SourcesDirectory)/${{ parameters.sourceRoot }}'
+
+  - ${{ if eq(parameters.configureNuGet, false) }}:
+    - script: dotnet restore
+      displayName: 'Restore'
+      workingDirectory: '$(Build.SourcesDirectory)/${{ parameters.sourceRoot }}'
 
   - script: dotnet build --no-restore --configuration ${{ parameters.buildConfiguration }}
     displayName: 'Build'

--- a/.azdo/templates/build-test-pack.yaml
+++ b/.azdo/templates/build-test-pack.yaml
@@ -36,6 +36,9 @@ parameters:
     type: boolean
     default: false
     # publish.yaml configures CFS once at the job level.
+  - name: useNuGetConfig
+    type: boolean
+    default: false
 
 steps:
   - task: UseDotNet@2
@@ -53,12 +56,12 @@ steps:
   - ${{ if eq(parameters.configureNuGet, true) }}:
     - template: configure-cfs-nuget.yaml
 
-  - ${{ if eq(parameters.configureNuGet, true) }}:
+  - ${{ if eq(parameters.useNuGetConfig, true) }}:
     - script: dotnet restore --configfile $(nugetConfigPath)
       displayName: 'Restore'
       workingDirectory: '$(Build.SourcesDirectory)/${{ parameters.sourceRoot }}'
 
-  - ${{ if eq(parameters.configureNuGet, false) }}:
+  - ${{ if eq(parameters.useNuGetConfig, false) }}:
     - script: dotnet restore
       displayName: 'Restore'
       workingDirectory: '$(Build.SourcesDirectory)/${{ parameters.sourceRoot }}'

--- a/.azdo/templates/configure-cfs-nuget.yaml
+++ b/.azdo/templates/configure-cfs-nuget.yaml
@@ -6,7 +6,7 @@ steps:
       <configuration>
         <packageSources>
           <clear />
-          <add key="PublicPackages" value="https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/Github_Pipelines_PublicPackages/nuget/v3/index.json" />
+          <add key="TeamsSDKPreviews" value="https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json" />
         </packageSources>
       </configuration>
       "@


### PR DESCRIPTION
## Summary

- enforce the `CFSClean` network-isolation policy on the flagged Teams.NET publish pipeline
- restore through the existing `TeamsSDKPreviews` Azure Artifacts feed instead of the nonexistent `Github_Pipelines_PublicPackages` feed
- keep `ci.yaml` on its original plain `dotnet restore` path and remove the unrelated isolation TODO

## Context

Pipeline 50 recorded a direct `api.nuget.org` connection during restore. `TeamsSDKPreviews` is the existing authenticated Azure Artifacts feed with NuGet.org configured as an upstream; enforcing `CFSClean` blocks direct public-feed outreach while allowing restore through the feed. The endpoint introduced by #637 returned `TF1600011` because that feed does not exist.

## Validation

- reviewed the expanded restore path for both CI and publish callers
- `git diff --check` passes

A pipeline 50 Internal run should confirm restore succeeds and `Stop Network Isolation` reports no `CFSClean` violation.