### PR TITLE
set version to 2.0.10

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.10-preview.{height}",
+  "version": "2.0.10",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$",


### PR DESCRIPTION
## Summary

Prepare the stable **2.0.10** release of the Legacy (v2) package set.

- Set root `version.json` to `2.0.10` (removes the `-preview.{height}` suffix) so builds from `release/v2.0` produce stable packages.

## Release checklist (per RELEASE.md)

- [x] Branch `prep-release/2.0.10` created from `release/v2.0`
- [x] `version.json` set to stable `2.0.10`
- [ ] Approve & merge this PR into `release/v2.0`
- [ ] Trigger `Teams.NET-ESRP` pipeline from `release/v2.0` with `publishType=Public`
- [ ] Approve push to nuget.org
- [ ] Bump `version.json` on `release/v2.0` for the next cycle (`2.0.11-preview.{height}`)
- [ ] Tag & draft GitHub release `v2.0.10` after packages land on nuget.org

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>