### PR TITLE
add release/v2.0 to publicReleaseRefSpec

### DIFF
--- a/version.json
+++ b/version.json
@@ -4,7 +4,8 @@
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$",
-    "^refs/heads/releases/v\\d+(?:\\.\\d+)?$"
+    "^refs/heads/releases/v\\d+(?:\\.\\d+)?$",
+    "^refs/heads/release/v\\d+(?:\\.\\d+)?$"
   ],
   "cloudBuild": {
     "buildNumber": {


### PR DESCRIPTION
## Summary

Add the `release/v2.0` branch pattern to `publicReleaseRefSpec` in root `version.json` so that builds from the maintained v2 branch are treated as **public (stable) releases** by Nerdbank.GitVersioning.

Previously the spec only matched `main`, `v<N>`, and `releases/v<N>` — none of which cover the actual maintained branch `release/v2.0` (singular `release/`). Without this, builds triggered directly from `release/v2.0` would not be recognized as public releases.

```diff
   "^refs/heads/releases/v\\d+(?:\\.\\d+)?$",
+  "^refs/heads/release/v\\d+(?:\\.\\d+)?$"
```

Base: `release/v2.0`

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>