### PR TITLE
feat: add Anthropic support to ExtAIBot

### DIFF
--- a/samples/ExtAIBot/ExtAIBot.csproj
+++ b/samples/ExtAIBot/ExtAIBot.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Anthropic" Version="12.40.0" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.2" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.5.2" />

--- a/samples/ExtAIBot/Program.cs
+++ b/samples/ExtAIBot/Program.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System.ClientModel;
+using Anthropic;
+using Anthropic.Core;
 using Azure.AI.OpenAI;
 using ExtAIBot;
 using Microsoft.Extensions.AI;
@@ -15,13 +17,17 @@ builder.Services.AddTeamsBotApplication<ExtAIBotApp>();
 builder.Services.AddSingleton<IChatClient>(sp =>
 {
     IConfiguration config = sp.GetRequiredService<IConfiguration>();
-    string endpoint = config["AzureOpenAI:Endpoint"] ?? throw new InvalidOperationException("AzureOpenAI:Endpoint is required.");
-    string apiKey = config["AzureOpenAI:ApiKey"] ?? throw new InvalidOperationException("AzureOpenAI:ApiKey is required.");
-    string deployment = config["AzureOpenAI:Deployment"] ?? throw new InvalidOperationException("AzureOpenAI:Deployment is required.");
+    string provider = config["AI_PROVIDER"] ?? "azure-openai";
+    IChatClient client = provider switch
+    {
+        "anthropic" => CreateAnthropicClient(config),
+        "azure-openai" => CreateAzureOpenAIClient(config),
+        _ => throw new InvalidOperationException(
+            $"Unsupported AI_PROVIDER '{provider}'. Use 'azure-openai' or 'anthropic'."
+        ),
+    };
 
-    return new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey))
-        .GetChatClient(deployment)
-        .AsIChatClient()
+    return client
         .AsBuilder()
         .UseFunctionInvocation()
         .Build();
@@ -35,3 +41,21 @@ builder.Services.AddSingleton<Agent>();
 WebApplication webApp = builder.Build();
 webApp.UseTeamsBotApplication<ExtAIBotApp>();
 webApp.Run();
+
+static IChatClient CreateAnthropicClient(IConfiguration config)
+{
+    string apiKey = config["ANTHROPIC_API_KEY"] ?? throw new InvalidOperationException("ANTHROPIC_API_KEY is required.");
+    string model = config["ANTHROPIC_MODEL"] ?? throw new InvalidOperationException("ANTHROPIC_MODEL is required.");
+    return new AnthropicClient(new ClientOptions { ApiKey = apiKey }).AsIChatClient(model);
+}
+
+static IChatClient CreateAzureOpenAIClient(IConfiguration config)
+{
+    string endpoint = config["AzureOpenAI:Endpoint"] ?? throw new InvalidOperationException("AzureOpenAI:Endpoint is required.");
+    string apiKey = config["AzureOpenAI:ApiKey"] ?? throw new InvalidOperationException("AzureOpenAI:ApiKey is required.");
+    string deployment = config["AzureOpenAI:Deployment"] ?? throw new InvalidOperationException("AzureOpenAI:Deployment is required.");
+
+    return new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey))
+        .GetChatClient(deployment)
+        .AsIChatClient();
+}

--- a/samples/ExtAIBot/README.md
+++ b/samples/ExtAIBot/README.md
@@ -1,6 +1,6 @@
 # ExtAIBot — Microsoft.Extensions.AI sample
 
-A Teams bot powered by [Microsoft.Extensions.AI](https://learn.microsoft.com/dotnet/ai/ai-extensions) and Azure OpenAI. Demonstrates streaming responses, per-conversation memory, a local clarification tool, remote MCP server tools, inline citations, follow-up suggestions, and custom feedback.
+A Teams bot powered by [Microsoft.Extensions.AI](https://learn.microsoft.com/dotnet/ai/ai-extensions) and either Azure OpenAI or Anthropic Claude. Demonstrates streaming responses, per-conversation memory, a local clarification tool, remote MCP server tools, inline citations, follow-up suggestions, and custom feedback.
 
 ## What it shows
 
@@ -15,11 +15,17 @@ A Teams bot powered by [Microsoft.Extensions.AI](https://learn.microsoft.com/dot
 ## Prerequisites
 
 - Bot registered and installed in Teams.
-- Azure Open AI configured
+- Azure OpenAI configured
+  - `AI_PROVIDER=azure-openai`
   - `AzureOpenAI__Endpoint`
   - `AzureOpenAI__ApiKey`
   - `AzureOpenAI__Deployment`
 
+Or Anthropic configured:
+
+- `AI_PROVIDER=anthropic`
+- `ANTHROPIC_API_KEY`
+- `ANTHROPIC_MODEL`
 
 The bot initializes the MS Learn MCP tool set at startup before accepting messages. If the MCP server is unreachable the app will fail to start.
 
@@ -56,7 +62,8 @@ ChatOptions options = new()
 };
 ```
 
-`UseFunctionInvocation()` then handles all tool calls — local or remote — transparently during streaming.
+`UseFunctionInvocation()` then handles all tool calls — local or remote — transparently during streaming with either provider.
+
 ## Running the Sample
 
 ~~~bash


### PR DESCRIPTION
## Summary
- select Azure OpenAI or Anthropic Claude through `AI_PROVIDER`
- adapt the official Anthropic SDK to the existing `IChatClient` boundary
- preserve function invocation, MCP tools, streaming, citations, cards, memory, feedback, and follow-up prompts
- document both provider configurations

## Validation
- `dotnet build samples/ExtAIBot/ExtAIBot.csproj`
- sample startup with Anthropic configuration and Microsoft Learn MCP
- live Claude + MCP streaming request
- structured follow-up response parsing

## Related PRs
- TypeScript: https://github.com/microsoft/teams.ts/pull/726
- Python: https://github.com/microsoft/teams.py/pull/559
- Documentation: https://github.com/microsoft/teams-sdk/pull/2957
