### PR TITLE
 Don't require selectedChannel when deserializing channel data

### DIFF
--- a/src/Microsoft.Teams.Apps/Schema/TeamsChannelData.cs
+++ b/src/Microsoft.Teams.Apps/Schema/TeamsChannelData.cs
@@ -37,7 +37,7 @@ public class TeamsChannelDataSettings
     /// <summary>
     /// Selected channel information.
     /// </summary>
-    [JsonPropertyName("selectedChannel")] public required TeamsChannel SelectedChannel { get; set; }
+    [JsonPropertyName("selectedChannel")] public TeamsChannel? SelectedChannel { get; set; }
 
     /// <summary>
     /// Gets or sets the collection of additional properties not explicitly defined by the type.

--- a/test/Microsoft.Teams.Apps.UnitTests/TeamsChannelDataDeserializationTests.cs
+++ b/test/Microsoft.Teams.Apps.UnitTests/TeamsChannelDataDeserializationTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+using Microsoft.Teams.Apps.Schema;
+
+namespace Microsoft.Teams.Apps.UnitTests;
+
+/// <summary>
+/// The Teams service can send nested channel data objects as empty objects. These are inbound-only
+/// models, so a missing field must not fail deserialization of the whole payload.
+/// See https://github.com/microsoft/teams.py/issues/563 for the equivalent break in the Python SDK.
+/// </summary>
+public class TeamsChannelDataDeserializationTests
+{
+    [Theory]
+    [InlineData("{\"app\":{}}")]
+    [InlineData("{\"channel\":{}}")]
+    [InlineData("{\"team\":{}}")]
+    [InlineData("{\"tenant\":{}}")]
+    [InlineData("{\"settings\":{}}")]
+    public void Deserialize_EmptyNestedObject_DoesNotThrow(string json)
+    {
+        TeamsChannelData? channelData = JsonSerializer.Deserialize<TeamsChannelData>(json);
+
+        Assert.NotNull(channelData);
+    }
+
+    [Fact]
+    public void Deserialize_EmptySettings_LeavesSelectedChannelNull()
+    {
+        TeamsChannelData? channelData = JsonSerializer.Deserialize<TeamsChannelData>("{\"settings\":{}}");
+
+        Assert.NotNull(channelData);
+        Assert.NotNull(channelData.Settings);
+        Assert.Null(channelData.Settings.SelectedChannel);
+    }
+
+    [Fact]
+    public void Deserialize_PopulatedChannelData_PreservesValues()
+    {
+        const string json = """
+        {
+            "app": { "id": "app-id", "version": "1.2.3" },
+            "channel": { "id": "channel-id" },
+            "team": { "id": "team-id" },
+            "tenant": { "id": "tenant-id" },
+            "settings": { "selectedChannel": { "id": "selected-channel-id" } }
+        }
+        """;
+
+        TeamsChannelData? channelData = JsonSerializer.Deserialize<TeamsChannelData>(json);
+
+        Assert.NotNull(channelData);
+        Assert.Equal("app-id", channelData.App?.Id);
+        Assert.Equal("1.2.3", channelData.App?.Version);
+        Assert.Equal("channel-id", channelData.Channel?.Id);
+        Assert.Equal("team-id", channelData.Team?.Id);
+        Assert.Equal("tenant-id", channelData.Tenant?.Id);
+        Assert.Equal("selected-channel-id", channelData.Settings?.SelectedChannel?.Id);
+    }
+}


### PR DESCRIPTION
`TeamsChannelDataSettings.SelectedChannel` was declared `required`, and `System.Text.Json` enforces `required` members (.NET 7+). A `channelData.settings` of `{}` therefore threw:
```
JsonException: JSON deserialization for type 'Settings' was missing required properties including: 'selectedChannel'.
```
Found while investigating teams.py#563, where the Teams service sent `channelData.app  as  {}` . .NET was otherwise unaffected; every other channel-data property is already nullable, but `SelectedChannel` was the one strict field and would fail the same way.

This is latent rather than actively reported: `settings` appears less often than `app`. Fixing it now avoids the same class of outage.

## Change
 `public required TeamsChannel SelectedChannel`  >  `public TeamsChannel? SelectedChannel`

Inbound models shouldn't enforce required fields on service-provided data. No consumers of `SelectedChannel` exist in  `src/`, `test/`, or `Samples/` .

## Tests
New `TeamsChannelDataDeserializationTests.cs` empty `app` / `channel` / `team` / `tenant` / `settings`  all deserialize,  `SelectedChannel`  is null for empty settings, and populated values round-trip.

## Validation
- Build: 0 warnings, 0 errors
- 522 tests pass (net10.0)
- No net new format issues
