### PR TITLE
Fix targeted activity integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -495,3 +495,4 @@ $RECYCLE.BIN/
 
 # Integration test run settings (contain secrets)
 core/test/IntegrationTests/.runsettings/
+test/IntegrationTests/.runsettings/

--- a/.gitignore
+++ b/.gitignore
@@ -495,4 +495,3 @@ $RECYCLE.BIN/
 
 # Integration test run settings (contain secrets)
 core/test/IntegrationTests/.runsettings/
-test/IntegrationTests/.runsettings/

--- a/test/IntegrationTests/ApiClientTests.cs
+++ b/test/IntegrationTests/ApiClientTests.cs
@@ -39,7 +39,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     private static MessageActivityInput CreateMessageActivity(string text, ChannelAccount recipient)
     {
         MessageActivityInput activity = CreateMessageActivity(text);
-        return activity;
+        return activity.WithRecipient(new TeamsChannelAccount { Id = recipient.Id }, isTargeted: true);
     }
 
     #region Activities

--- a/test/IntegrationTests/ApiClientTests.cs
+++ b/test/IntegrationTests/ApiClientTests.cs
@@ -39,7 +39,7 @@ public class ApiClientTests : IClassFixture<IntegrationTestFixture>
     private static MessageActivityInput CreateMessageActivity(string text, ChannelAccount recipient)
     {
         MessageActivityInput activity = CreateMessageActivity(text);
-        return activity.WithRecipient(new TeamsChannelAccount { Id = recipient.Id }, isTargeted: true);
+        return activity.WithRecipient(TeamsChannelAccount.FromChannelAccount(recipient)!, isTargeted: true);
     }
 
     #region Activities

--- a/test/IntegrationTests/README.md
+++ b/test/IntegrationTests/README.md
@@ -9,8 +9,9 @@ This project runs integration tests against Teams Server using bot and agentic i
   - Bot app registration (client ID + secret)
   - Agentic app registration (client ID + secret) — optional
   - A team with at least one channel
-  - A scheduled meeting
-  - At least 2 test users in the conversation
+  - At least 3 non-bot users in the test conversation (`GroupChat_ThreeMembers` needs three)
+  - A regular scheduled meeting (not a channel meeting) with the bot app installed *in the meeting*
+  - An OAuth connection on the Azure Bot resource named to match `TEST_CONNECTION_NAME`
 
 ## RunSettings
 
@@ -44,6 +45,7 @@ Place your `.runsettings` files in the `.runsettings/` directory (gitignored).
   <TEST_USER_ID>29:...</TEST_USER_ID>
   <TEST_TEAMID>19:...@thread.tacv2</TEST_TEAMID>
   <TEST_CHANNELID>19:...@thread.tacv2</TEST_CHANNELID>
+  <!-- base64 of "0#<19:meeting_...@thread.v2>#0" -->
   <TEST_MEETINGID>MCM...</TEST_MEETINGID>
   <TEST_TENANTID>YOUR_TENANT_ID</TEST_TENANTID>
 
@@ -52,6 +54,8 @@ Place your `.runsettings` files in the `.runsettings/` directory (gitignored).
   <TEST_AGENTIC_USERID></TEST_AGENTIC_USERID>
 
   <!-- Optional -->
+  <!-- TEST_USER_ID_2 is read by the fixture but consumed by no test today; safe to omit.
+       Multi-member tests read the live conversation roster instead. -->
   <TEST_USER_ID_2>29:...</TEST_USER_ID_2>
   <TEST_CONNECTION_NAME>aadv2</TEST_CONNECTION_NAME>
 </EnvironmentVariables>
@@ -80,6 +84,14 @@ dotnet test IntegrationTests/IntegrationTests.csproj \
   --logger "trx;LogFileName=botid-prod.trx"
 ```
 
+### Throttling
+
+The tenant enforces a call quota that a single full run already approaches. Running the full suite twice in quick succession produces a large batch of `TooManyRequests` / `"API calls quota exceeded"` failures that look exactly like real breakage. One observed back-to-back run reported 36 failures, 35 of which were quota errors rather than genuine problems.
+
+- Leave roughly 10 minutes between full runs.
+- When triaging any unexpected failure, grep the output for `TooManyRequests` before investigating anything else.
+- While iterating on one area, use `--filter` to run just that category instead of the full suite.
+
 ### Trait Categories
 
 | Category | Tests | Description |
@@ -90,11 +102,26 @@ dotnet test IntegrationTests/IntegrationTests.csproj \
 | `Reactions` | 1 | Add and delete reactions |
 | `Teams` | 6 | Get team details, channels |
 | `Meetings` | 3 | Get participant, meeting details |
-| `Bots` | 2 | Sign-in URL and resource |
-| `Users` | 3 | Token get, status, sign-out |
+| `Users` | 5 | Sign-in URL and resource, token get, status, sign-out |
 | `Client` | 1 | ForServiceUrl scoped client |
 | `Diagnostic` | 13 | Conversation creation matrix |
 | `ErrorHandling` | 3 | Error cases (compat layer) |
+
+> These account for 68 of the suite's 72 tests; the remaining 4 carry no `Category` trait. A filter naming a category that does not exist prints `No test matches the given testcase filter` and **exits 0**, so a typo looks exactly like a clean pass.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Many unrelated tests fail with `TooManyRequests` / `"API calls quota exceeded"` | Tenant quota exhausted by consecutive runs | Wait ~10 minutes and re-run. These are not real failures. |
+| Every test fails during fixture initialization with an `AADSTS` error | Tenant expired or credentials wrong | Re-provision the tenant and regenerate the runsettings |
+| Fixture throws `... environment variable not set` | A required variable is missing; `TEST_MEETINGID` and `TEST_TENANTID` are required even for unrelated categories | Populate the runsettings fully |
+| `GroupChat_*` fail on `Assert.NotNull` before any API call | Conversation has fewer than 3 non-bot members | Add users to the channel |
+| Meetings tests return `404 ConversationNotFound` | `TEST_MEETINGID` is wrong, stale, or a placeholder | Re-encode from the current meeting thread ID |
+| Meetings tests return `403 BotNotInConversationRoster` | App is not installed in the meeting | Install it in the meeting, then message the bot in the meeting chat |
+| `Meetings_GetByIdAsync` returns `403 NotEnoughPermissions` | Manifest lacks RSC `OnlineMeeting.ReadBasic.Chat` | Add the RSC permission, bump the manifest version, reinstall in the meeting |
+| `Users_GetSignInResourceAsync` returns `400 Could not find Connection Setting` | OAuth connection missing on the Azure Bot resource | Create a connection named to match `TEST_CONNECTION_NAME` |
+| A filtered run reports "No test matches" and exits 0 | Category name does not exist | Check the [Trait Categories](#trait-categories) table |
 
 ## Architecture
 
@@ -104,6 +131,7 @@ dotnet test IntegrationTests/IntegrationTests.csproj \
 
 ## Known Limitations
 
+- **Expected skips**: 5 tests are skipped by design via `Skip.If` guards (paged members and reactions on canary). Skips are not failures. A correctly provisioned tenant should report 72 total with 5 skipped and 0 failed.
 - **Agentic identity**: Targeted activities, paged members, and reactions return 500/404 with agentic identity. These are service-side limitations pending investigation.
 - **Group chat creation**: Bot-only identity cannot create group chats with `IsGroup=true` + multiple members via the conversations API.
 - **User token tests**: `SignIn` and `Users` token tests are skipped when agentic identity is configured (not supported).

--- a/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
+++ b/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Net;
+using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Teams.Core.Schema;
 using Moq;
@@ -183,6 +184,42 @@ public class ConversationClientTests
         Assert.NotNull(capturedRequest);
         Assert.Contains("isTargetedActivity=true", capturedRequest.RequestUri?.ToString());
         Assert.Equal(HttpMethod.Put, capturedRequest.Method);
+    }
+
+    [Fact]
+    public async Task UpdateActivityAsync_WithIsTargeted_DoesNotSendRecipient()
+    {
+        string? capturedBody = null;
+        Mock<HttpMessageHandler> mockHttpMessageHandler = new();
+        mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, ct) =>
+                capturedBody = req.Content?.ReadAsStringAsync(ct).GetAwaiter().GetResult())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{\"id\":\"activity123\"}")
+            });
+
+        HttpClient httpClient = new(mockHttpMessageHandler.Object);
+        ConversationClient conversationClient = new(httpClient, NullLogger<ConversationClient>.Instance);
+
+        await conversationClient.UpdateActivityAsync(
+            "conv123",
+            "activity123",
+            CoreActivityInput.CreateBuilder().WithType(ActivityType.Message).Build(),
+            new Uri("https://test.service.url/"),
+            isTargeted: true);
+
+        Assert.NotNull(capturedBody);
+        using JsonDocument document = JsonDocument.Parse(capturedBody);
+        Assert.False(
+            document.RootElement.TryGetProperty("recipient", out _),
+            "Targeted update payloads must omit 'recipient'; the service rejects it on update.");
     }
 
     [Fact]

--- a/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
+++ b/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
@@ -197,12 +197,14 @@ public class ConversationClientTests
                 "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, ct) =>
-                capturedBody = req.Content?.ReadAsStringAsync(ct).GetAwaiter().GetResult())
-            .ReturnsAsync(new HttpResponseMessage
+            .Returns(async (HttpRequestMessage req, CancellationToken ct) =>
             {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("{\"id\":\"activity123\"}")
+                capturedBody = req.Content is null ? null : await req.Content.ReadAsStringAsync(ct);
+                return new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{\"id\":\"activity123\"}")
+                };
             });
 
         HttpClient httpClient = new(mockHttpMessageHandler.Object);


### PR DESCRIPTION
## What changed

**Fix `CreateMessageActivity(text, recipient)` silently dropping its recipient.** The helper in `ApiClientTests.cs` accepted a `ChannelAccount` and then returned the activity without ever applying it, so targeted activities went out with no recipient. The service rejects those with `400 BadArgument: Recipient of Targeted Message cannot be null`, which failed `Activities_CreateTargetedAsync`, `Activities_UpdateTargetedAsync`, and `Activities_DeleteTargetedAsync`. The helper now calls `WithRecipient(..., isTargeted: true)`.

**Add a regression test for targeted update payloads.** `UpdateActivityAsync_WithIsTargeted_DoesNotSendRecipient` asserts that the serialized body omits `recipient`. C# already behaves correctly here, but only by caller convention: `ConversationClient` serializes the activity verbatim and does no stripping, so nothing was guarding the behavior. This closes a parity gap with the equivalent TypeScript coverage.

## Testing

Integration suite run against a live canary tenant: the three targeted activity tests now pass, with no change to any other test outcome. The new unit test passes and was mutation-checked by injecting a recipient, which fails it as expected.

No product code changed.