### PR TITLE
Rename IncomingFile.WebUrl to ContentUrl

### DIFF
--- a/src/Microsoft.Teams.Apps/Files/FilesAccessor.cs
+++ b/src/Microsoft.Teams.Apps/Files/FilesAccessor.cs
@@ -106,8 +106,8 @@ public sealed class FilesAccessor
             UniqueId = content?.UniqueId,
             // `fileType` is the platform-supplied extension (e.g. `pdf`); left null when the wire omits it, matching how peer SDKs surface it.
             Extension = content?.FileType,
-            // Maps the wire's `contentUrl` (a browsable link to the file in OneDrive/SharePoint) to `WebUrl`; not fetchable like `downloadUrl`.
-            WebUrl = attachment.ContentUrl,
+            // Browsable link to the file in OneDrive/SharePoint; not fetchable like `downloadUrl`.
+            ContentUrl = attachment.ContentUrl,
             Raw = attachment,
             DownloadUrl = downloadUrl,
         };

--- a/src/Microsoft.Teams.Apps/Files/IncomingFile.cs
+++ b/src/Microsoft.Teams.Apps/Files/IncomingFile.cs
@@ -53,7 +53,7 @@ public sealed class IncomingFile
 
     /// <summary>
     /// Browsable URL to the file in OneDrive/SharePoint, as sent on the attachment's <c>contentUrl</c>.
-    /// Not fetchable for bytes despite the name; those come from the download URL.
+    /// Not fetchable for bytes despite the name; those come from <see cref="DownloadAsync"/> or <see cref="StreamAsync"/>.
     /// </summary>
     public Uri? ContentUrl { get; init; }
 

--- a/src/Microsoft.Teams.Apps/Files/IncomingFile.cs
+++ b/src/Microsoft.Teams.Apps/Files/IncomingFile.cs
@@ -51,8 +51,11 @@ public sealed class IncomingFile
     /// <summary>Where the SDK found the file. Only <see cref="FileSource.BotActivity"/> is produced today.</summary>
     public FileSource Source { get; }
 
-    /// <summary>Web URL to the file in OneDrive/SharePoint when known.</summary>
-    public Uri? WebUrl { get; init; }
+    /// <summary>
+    /// Browsable URL to the file in OneDrive/SharePoint, as sent on the attachment's <c>contentUrl</c>.
+    /// Not fetchable for bytes despite the name; those come from the download URL.
+    /// </summary>
+    public Uri? ContentUrl { get; init; }
 
     /// <summary>The raw underlying attachment/graph object for escape-hatch access.</summary>
     public object? Raw { get; init; }

--- a/test/Microsoft.Teams.Apps.UnitTests/Files/FilesAccessorTests.cs
+++ b/test/Microsoft.Teams.Apps.UnitTests/Files/FilesAccessorTests.cs
@@ -75,7 +75,7 @@ public class FilesAccessorTests
         Assert.Equal("pdf", file.Extension);
         Assert.Equal(ConversationType.Personal, file.Scope);
         Assert.Equal(FileSource.BotActivity, file.Source);
-        Assert.Equal(new Uri("https://contoso.sharepoint.com/report.pdf"), file.WebUrl);
+        Assert.Equal(new Uri("https://contoso.sharepoint.com/report.pdf"), file.ContentUrl);
         Assert.Same(activity.Attachments![0], file.Raw);
     }
 

--- a/test/Microsoft.Teams.Apps.UnitTests/Files/FilesAccessorWireShapeTests.cs
+++ b/test/Microsoft.Teams.Apps.UnitTests/Files/FilesAccessorWireShapeTests.cs
@@ -33,7 +33,7 @@ public class FilesAccessorWireShapeTests
     private const string ExpectedUniqueId = "00000000-0000-4000-8000-00000000f11e";
 
     // Percent-encoded spaces, exactly as Teams sends them in the browsable OneDrive path.
-    private const string ExpectedWebUrl =
+    private const string ExpectedContentUrl =
         "https://example.sharepoint.com/personal/synthetic_user_example_com/Documents/Microsoft%20Teams%20Chat%20Files/quarterly%20report.pdf";
 
     private const string ExpectedDownloadUrl =
@@ -52,7 +52,7 @@ public class FilesAccessorWireShapeTests
       "attachments": [
         {
           "contentType": "application/vnd.microsoft.teams.file.download.info",
-          "contentUrl": "{{ExpectedWebUrl}}",
+          "contentUrl": "{{ExpectedContentUrl}}",
           "name": "{{ExpectedName}}",
           "content": {
             "downloadUrl": "{{ExpectedDownloadUrl}}",
@@ -88,7 +88,7 @@ public class FilesAccessorWireShapeTests
         Assert.Equal(ExpectedName, file.Name);
         Assert.Equal("pdf", file.Extension);
         Assert.Equal(ExpectedUniqueId, file.UniqueId);
-        Assert.Equal(new Uri(ExpectedWebUrl), file.WebUrl);
+        Assert.Equal(new Uri(ExpectedContentUrl), file.ContentUrl);
         Assert.Equal(new Uri(ExpectedDownloadUrl), file.DownloadUrl);
         Assert.Equal(ConversationType.Personal, file.Scope);
         Assert.Equal(FileSource.BotActivity, file.Source);
@@ -96,8 +96,8 @@ public class FilesAccessorWireShapeTests
         // `TeamsAttachment.ContentUrl` is a `Uri`, so the wire value is normalized before anything reads it. Teams
         // percent-encodes the spaces in the OneDrive path; pin that they survive the round-trip, since a URL that
         // silently decoded them would no longer address the item.
-        Assert.Contains("Microsoft%20Teams%20Chat%20Files", file.WebUrl!.AbsoluteUri, StringComparison.Ordinal);
-        Assert.DoesNotContain(' ', file.WebUrl.AbsoluteUri);
+        Assert.Contains("Microsoft%20Teams%20Chat%20Files", file.ContentUrl!.AbsoluteUri, StringComparison.Ordinal);
+        Assert.DoesNotContain(' ', file.ContentUrl.AbsoluteUri);
     }
 
     [Fact]


### PR DESCRIPTION
Renames the public `IncomingFile.WebUrl` property to `ContentUrl`.

## This is not a breaking change

**The property has never been published**, despite this repo having shipped a stable `2.1.0`. Verified rather than assumed:

- I downloaded `Microsoft.Teams.Apps` **2.1.0** (the current stable) from NuGet and inspected it. It contains **zero occurrences of `IncomingFile`** and **zero occurrences of `WebUrl`**, in both the assembly and its generated XML doc surface.
- The files feature landed after that package was cut, so nothing consuming a released build can reference this property.

So there are no consumers to break. This is also the last cheap moment: once the files feature ships, the name is locked.

## Why

The value arrives on the wire as the attachment's `ContentUrl`, and `Attachment.ContentUrl` **already exposes it publicly** in this same SDK. That left the same value reachable under two different public names depending on which door you came through:

```csharp
activity.Attachments[0].ContentUrl   // public
ctx.Files[0].WebUrl                  // public, same value, different name
```

Upstream doesn't call it a "web URL" either. APX sources it from `fileInfo.ObjectUrl` and writes it into the Bot Framework attachment's `ContentUrl` slot, so `WebUrl` was a name this SDK invented at the boundary. The mapping comment in `FilesAccessor.cs` was the only thing holding the two vocabularies together, and it's now unnecessary: the value is a straight pass-through.

## The one real objection, and how it's handled

`ContentUrl` sits next to the download URL, and it is the one that does **not** return content. That's a genuine footgun, but it already exists on `Attachment.ContentUrl` regardless of what we do here, and it's a docs problem rather than a design problem. Two public names for one value is the design problem. So the doc comment now states the trap directly:

> Browsable URL to the file in OneDrive/SharePoint, as sent on the attachment's `contentUrl`. Not fetchable for bytes despite the name.

## Scope note

`Microsoft.Teams.Cards` has an unrelated `WebUrl` (Adaptive Card Loop metadata). It is deliberately untouched; the rename is scoped to the Files namespace. The build succeeding is itself proof of completeness, since any stale reference would fail to compile.

## Cross-SDK

Companion to microsoft/teams.ts#773 and microsoft/teams.py#580. The feature is unreleased in all three, so all three can move together. Published docs in `teams-sdk` are updated separately.

## Validation

Build clean (0 errors). 528 unit tests pass on net10.0, including all 32 Files tests.
