### PR TITLE
Add setCachePolicy card action type

### DIFF
--- a/src/Microsoft.Teams.Apps/Schema/SuggestedAction.cs
+++ b/src/Microsoft.Teams.Apps/Schema/SuggestedAction.cs
@@ -113,6 +113,11 @@ public class ActionType(string value) : StringEnum(value)
     public static readonly ActionType SignIn = new("signin");
     /// <summary>Gets the <c>call</c> action type.</summary>
     public static readonly ActionType Call = new("call");
+    /// <summary>
+    /// Gets the <c>setCachePolicy</c> action type used to control caching for a link-unfurling response.
+    /// Set the action value to <c>{"type":"no-cache"}</c> to prevent Teams from caching the response.
+    /// </summary>
+    public static readonly ActionType SetCachePolicy = new("setCachePolicy");
     /// <summary>Gets the experimental <c>Action.Submit</c> action type.</summary>
     public static readonly ActionType Submit = new("Action.Submit");
 
@@ -149,6 +154,12 @@ public static class ActionTypes
 
     /// <summary>Gets the <c>call</c> action type.</summary>
     public static ActionType Call => ActionType.Call;
+
+    /// <summary>
+    /// Gets the <c>setCachePolicy</c> action type used to control caching for a link-unfurling response.
+    /// Set the action value to <c>{"type":"no-cache"}</c> to prevent Teams from caching the response.
+    /// </summary>
+    public static ActionType SetCachePolicy => ActionType.SetCachePolicy;
 
     /// <summary>Gets the experimental <c>Action.Submit</c> action type.</summary>
     [System.Diagnostics.CodeAnalysis.Experimental("ExperimentalTeamsSuggestedAction")]

--- a/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionsTests.cs
+++ b/test/Microsoft.Teams.Apps.UnitTests/SuggestedActionsTests.cs
@@ -22,6 +22,7 @@ public class SuggestedActionsTests
         Assert.Equal("downloadFile", ActionTypes.DownloadFile);
         Assert.Equal("signin", ActionTypes.SignIn);
         Assert.Equal("call", ActionTypes.Call);
+        Assert.Equal("setCachePolicy", ActionTypes.SetCachePolicy);
         Assert.Equal("Action.Submit", ActionTypes.Submit);
     }
 
@@ -249,5 +250,26 @@ public class SuggestedActionsTests
         Assert.Equal("Open", roundTripped.SuggestedActions.Actions[0].Title);
         Assert.Equal("imBack", roundTripped.SuggestedActions.Actions[1].Type!.ToString());
         Assert.Equal("Say Hi", roundTripped.SuggestedActions.Actions[1].Title);
+    }
+
+    [Fact]
+    public void MessageActivity_SetCachePolicySuggestedAction_RoundTripsNoCacheValue()
+    {
+        MessageActivity activity = new("Link unfurl")
+        {
+            SuggestedActions = new SuggestedActions()
+                .AddAction(new SuggestedAction(
+                    ActionTypes.SetCachePolicy,
+                    "Disable caching",
+                    new { type = "no-cache" }))
+        };
+
+        string json = activity.ToJson();
+        CoreActivity coreActivity = CoreActivity.FromJsonString(json);
+        MessageActivity roundTripped = MessageActivity.FromActivity(coreActivity);
+
+        SuggestedAction action = Assert.Single(roundTripped.SuggestedActions!.Actions);
+        Assert.Equal("setCachePolicy", action.Type!.ToString());
+        Assert.Equal("no-cache", action.Value!["type"]!.GetValue<string>());
     }
 }


### PR DESCRIPTION
## Summary

- add the Teams `setCachePolicy` card/suggested-action type to the .NET action model
- document the `{"type":"no-cache"}` value used to disable caching for link-unfurling responses
- preserve the existing action types, including the newer experimental `Action.Submit` type

Cross-SDK context: microsoft/teams.ts#574
Related issue: microsoft/teams.ts#154

## Tests

- `dotnet format Microsoft.Teams.slnx --include src/Microsoft.Teams.Apps/Schema/SuggestedAction.cs test/Microsoft.Teams.Apps.UnitTests/SuggestedActionsTests.cs --verify-no-changes`
- `dotnet test test/Microsoft.Teams.Apps.UnitTests/Microsoft.Teams.Apps.UnitTests.csproj --framework net8.0 --filter FullyQualifiedName~SuggestedActionsTests --no-restore` (15 passed)