### PR TITLE
Route threaded replies through reply endpoint

### DIFF
--- a/samples/InteractingWithMessagesBot/Program.cs
+++ b/samples/InteractingWithMessagesBot/Program.cs
@@ -24,7 +24,7 @@ teamsApp.OnMessage("(?i)^help$", async (context, cancellationToken) =>
             **Interacting with Messages**
 
             **Quoting:**
-            - `quote reply` - auto-quote your message
+            - `quote reply` - explicitly quote your message
             - `quote message` - quote a previously sent message
             - `quote add` - compose a quote with the message builder
             - `quote batch` - combine multiple quotes

--- a/samples/InteractingWithMessagesBot/Program.cs
+++ b/samples/InteractingWithMessagesBot/Program.cs
@@ -24,17 +24,16 @@ teamsApp.OnMessage("(?i)^help$", async (context, cancellationToken) =>
             **Interacting with Messages**
 
             **Quoting:**
-            - `quote reply` - explicitly quote your message
+            - `quote reply` - quote your incoming message
             - `quote message` - quote a previously sent message
-            - `quote add` - compose a quote with the message builder
             - `quote batch` - combine multiple quotes
-            - `quote manual` - combine a quote and text manually
 
             **Threading:**
-            - `thread reply` - send a reactive threaded reply
-            - `thread send` - send to the same thread without quoting
+            - `default send` - send to the same thread without quoting
             - `thread proactive` - send a proactive threaded reply
-            - `thread manual` - construct a threaded conversation ID manually
+            - `thread proactive quote` - explicitly place and quote a threaded reply
+            - `thread proactive targeted` - send a proactive targeted threaded reply
+            - `thread proactive targeted quote` - send a proactive targeted threaded reply with a quote
 
             **Reactions:**
             - `reaction add <type>` - add a reaction to your message
@@ -57,7 +56,7 @@ teamsApp.OnMessage("(?s)^.*$", async (context, cancellationToken) =>
     string text = context.Activity.TextWithoutMentions ?? "";
     if (Regex.IsMatch(
         text,
-        @"(?i)^(help|quote (reply|message|add|batch|manual)|thread (send|reply|proactive|manual)|reaction (add \S+|remove \S+|proactive))$"))
+        @"(?i)^(help|quote (reply|message|batch)|default send|thread proactive( quote| targeted( quote)?)?|reaction (add \S+|remove \S+|proactive))$"))
     {
         return;
     }

--- a/samples/InteractingWithMessagesBot/QuotingHandlers.cs
+++ b/samples/InteractingWithMessagesBot/QuotingHandlers.cs
@@ -12,7 +12,10 @@ internal static class QuotingHandlers
     {
         teamsApp.OnMessage("(?i)^quote reply$", async (context, cancellationToken) =>
         {
-            await context.ReplyAsync("Thanks for your message! This reply auto-quotes it.", cancellationToken);
+            await context.SendAsync(
+                new MessageActivityInput()
+                    .AddQuote(context.Activity.Id!, "Thanks for your message!"),
+                cancellationToken);
         });
 
         teamsApp.OnMessage("(?i)^quote message$", async (context, cancellationToken) =>
@@ -22,9 +25,9 @@ internal static class QuotingHandlers
                 cancellationToken);
             if (sent?.Id != null)
             {
-                await context.QuoteAsync(
-                    sent.Id,
-                    "Just to confirm - does the new time work for everyone?",
+                await context.SendAsync(
+                    new MessageActivityInput()
+                        .AddQuote(sent.Id, "Just to confirm - does the new time work for everyone?"),
                     cancellationToken);
             }
         });

--- a/samples/InteractingWithMessagesBot/QuotingHandlers.cs
+++ b/samples/InteractingWithMessagesBot/QuotingHandlers.cs
@@ -32,19 +32,6 @@ internal static class QuotingHandlers
             }
         });
 
-        teamsApp.OnMessage("(?i)^quote add$", async (context, cancellationToken) =>
-        {
-            SendActivityResponse? sent = await context.SendAsync(
-                "Please review the latest PR before end of day.",
-                cancellationToken);
-            if (sent?.Id != null)
-            {
-                await context.SendAsync(
-                    new MessageActivityInput().AddQuote(sent.Id, "Done! Left my comments on the PR."),
-                    cancellationToken);
-            }
-        });
-
         teamsApp.OnMessage("(?i)^quote batch$", async (context, cancellationToken) =>
         {
             SendActivityResponse? sentA = await context.SendAsync(
@@ -64,21 +51,6 @@ internal static class QuotingHandlers
                     .AddQuote(sentB.Id, "Looks great, approved!")
                     .AddQuote(sentC.Id);
                 await context.SendAsync(message, cancellationToken);
-            }
-        });
-
-        teamsApp.OnMessage("(?i)^quote manual$", async (context, cancellationToken) =>
-        {
-            SendActivityResponse? sent = await context.SendAsync(
-                "Deployment to staging is complete.",
-                cancellationToken);
-            if (sent?.Id != null)
-            {
-                await context.SendAsync(
-                    new MessageActivityInput()
-                        .AddQuote(sent.Id)
-                        .AddText(" Verified - all smoke tests passing."),
-                    cancellationToken);
             }
         });
     }

--- a/samples/InteractingWithMessagesBot/README.md
+++ b/samples/InteractingWithMessagesBot/README.md
@@ -24,7 +24,7 @@ in a separate handler class.
 | Command | Behavior |
 |---------|----------|
 | `default send` | `context.SendAsync()` uses the default placement for the current scope without quoting |
-| `thread proactive` | `teamsApp.ReplyAsync()` sends a proactive threaded reply |
+| `thread proactive` | `GetProactiveThreadReference()` resolves placement and `teamsApp.ReplyAsync()` sends a proactive threaded reply |
 | `thread proactive quote` | `teamsApp.ReplyAsync()` explicitly places a reply and `AddQuote()` quotes the inbound message |
 | `thread proactive targeted` | `teamsApp.ReplyAsync()` sends a proactive targeted reply through the explicit reply endpoint |
 | `thread proactive targeted quote` | `teamsApp.ReplyAsync()` sends a proactive targeted reply with an explicit quote |

--- a/samples/InteractingWithMessagesBot/README.md
+++ b/samples/InteractingWithMessagesBot/README.md
@@ -4,7 +4,7 @@ Demonstrates quoting, threading, and reactions in one bot while keeping each con
 in a separate handler class.
 
 - `QuotingHandlers.cs` - quoted-message metadata and quote composition
-- `ThreadingHandlers.cs` - reactive, proactive, and manually constructed threads
+- `ThreadingHandlers.cs` - default and explicit thread placement
 - `ReactionHandlers.cs` - reactions on inbound messages and a proactive reaction flow
 - `Program.cs` - app setup, handler registration, and help
 
@@ -14,21 +14,20 @@ in a separate handler class.
 
 | Command | Behavior |
 |---------|----------|
-| `quote reply` | `MessageActivityInput.AddQuote()` explicitly quotes the inbound message |
+| `quote reply` | `MessageActivityInput.AddQuote()` quotes the inbound message |
 | `quote message` | `MessageActivityInput.AddQuote()` quotes a previously sent message by ID |
-| `quote add` | `AddQuote()` composes a quote with a response |
 | `quote batch` | Combines multiple quotes with mixed responses |
-| `quote manual` | Combines `AddQuote()` and `AddText()` manually |
 | *(quote a message)* | Displays the quoted-message metadata |
 
 ### Threading
 
 | Command | Behavior |
 |---------|----------|
-| `thread reply` | `teamsApp.ReplyAsync()` sends a reactive threaded reply |
-| `thread send` | `context.SendAsync()` sends to the same thread without quoting |
+| `default send` | `context.SendAsync()` uses the default placement for the current scope without quoting |
 | `thread proactive` | `teamsApp.ReplyAsync()` sends a proactive threaded reply |
-| `thread manual` | `context.Api.Conversations.ReplyToActivityAsync()` uses the reply endpoint directly |
+| `thread proactive quote` | `teamsApp.ReplyAsync()` explicitly places a reply and `AddQuote()` quotes the inbound message |
+| `thread proactive targeted` | `teamsApp.ReplyAsync()` sends a proactive targeted reply through the explicit reply endpoint |
+| `thread proactive targeted quote` | `teamsApp.ReplyAsync()` sends a proactive targeted reply with an explicit quote |
 
 ### Reactions
 

--- a/samples/InteractingWithMessagesBot/README.md
+++ b/samples/InteractingWithMessagesBot/README.md
@@ -14,8 +14,8 @@ in a separate handler class.
 
 | Command | Behavior |
 |---------|----------|
-| `quote reply` | `context.ReplyAsync()` auto-quotes the inbound message |
-| `quote message` | `context.QuoteAsync()` quotes a previously sent message by ID |
+| `quote reply` | `MessageActivityInput.AddQuote()` explicitly quotes the inbound message |
+| `quote message` | `MessageActivityInput.AddQuote()` quotes a previously sent message by ID |
 | `quote add` | `AddQuote()` composes a quote with a response |
 | `quote batch` | Combines multiple quotes with mixed responses |
 | `quote manual` | Combines `AddQuote()` and `AddText()` manually |
@@ -28,7 +28,7 @@ in a separate handler class.
 | `thread reply` | `teamsApp.ReplyAsync()` sends a reactive threaded reply |
 | `thread send` | `context.SendAsync()` sends to the same thread without quoting |
 | `thread proactive` | `teamsApp.ReplyAsync()` sends a proactive threaded reply |
-| `thread manual` | `ToThreadedConversationId()` and `teamsApp.SendAsync()` provide manual control |
+| `thread manual` | `context.Api.Conversations.ReplyToActivityAsync()` uses the reply endpoint directly |
 
 ### Reactions
 

--- a/samples/InteractingWithMessagesBot/ThreadingHandlers.cs
+++ b/samples/InteractingWithMessagesBot/ThreadingHandlers.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Schema;
-using Microsoft.Teams.Core;
 using Microsoft.Teams.Core.Schema;
 
 internal static class ThreadingHandlers
@@ -38,11 +37,11 @@ internal static class ThreadingHandlers
         teamsApp.OnMessage("(?i)^thread manual$", async (context, cancellationToken) =>
         {
             (string conversationId, string threadRootId) = GetThreadReference(context.Activity);
-            await context.Api.Conversations.ReplyToActivityAsync(
+            await teamsApp.ReplyAsync(
                 conversationId,
                 threadRootId,
                 new MessageActivityInput().WithText(
-                    "This was sent using the explicit reply endpoint for manual control."),
+                    "This was sent using teamsApp.ReplyAsync() for explicit thread placement."),
                 cancellationToken: cancellationToken);
         });
     }

--- a/samples/InteractingWithMessagesBot/ThreadingHandlers.cs
+++ b/samples/InteractingWithMessagesBot/ThreadingHandlers.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Core;
 using Microsoft.Teams.Core.Schema;
 
@@ -37,22 +38,25 @@ internal static class ThreadingHandlers
         teamsApp.OnMessage("(?i)^thread manual$", async (context, cancellationToken) =>
         {
             (string conversationId, string threadRootId) = GetThreadReference(context.Activity);
-            string threadId = ConversationExtensions.ToThreadedConversationId(conversationId, threadRootId);
-            await teamsApp.SendAsync(
-                threadId,
-                "This was sent using ToThreadedConversationId() + teamsApp.SendAsync() for manual control.",
+            await context.Api.Conversations.ReplyToActivityAsync(
+                conversationId,
+                threadRootId,
+                new MessageActivityInput().WithText(
+                    "This was sent using the explicit reply endpoint for manual control."),
                 cancellationToken: cancellationToken);
         });
     }
 
-    private static (string ConversationId, string ThreadRootId) GetThreadReference(CoreActivity activity)
+    private static (string ConversationId, string ThreadRootId) GetThreadReference(TeamsActivity activity)
     {
         ArgumentNullException.ThrowIfNull(activity.Conversation);
         ArgumentException.ThrowIfNullOrEmpty(activity.Id);
 
-        string conversationId = activity.Conversation.Id;
-        string[] threadParts = conversationId.Split(";messageid=");
-        string threadRootId = threadParts.Length > 1 ? threadParts[1] : activity.Id;
+        string inboundConversationId = activity.Conversation.Id;
+        string conversationId = activity.Conversation.ThreadId();
+        string[] threadParts = inboundConversationId.Split(";messageid=");
+        string threadRootId = activity.ChannelData?.Thread?.Id
+            ?? (threadParts.Length > 1 ? threadParts[1] : activity.Id);
         return (conversationId, threadRootId);
     }
 }

--- a/samples/InteractingWithMessagesBot/ThreadingHandlers.cs
+++ b/samples/InteractingWithMessagesBot/ThreadingHandlers.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Schema;
-using Microsoft.Teams.Core.Schema;
 
 internal static class ThreadingHandlers
 {
@@ -16,7 +15,7 @@ internal static class ThreadingHandlers
 
         teamsApp.OnMessage("(?i)^thread proactive$", async (context, cancellationToken) =>
         {
-            (string conversationId, string threadRootId) = GetThreadReference(context.Activity);
+            (string conversationId, string threadRootId) = context.Activity.GetProactiveThreadReference();
             await teamsApp.ReplyAsync(
                 conversationId,
                 threadRootId,
@@ -26,7 +25,7 @@ internal static class ThreadingHandlers
 
         teamsApp.OnMessage("(?i)^thread proactive quote$", async (context, cancellationToken) =>
         {
-            (string conversationId, string threadRootId) = GetThreadReference(context.Activity);
+            (string conversationId, string threadRootId) = context.Activity.GetProactiveThreadReference();
             await teamsApp.ReplyAsync(
                 conversationId,
                 threadRootId,
@@ -39,7 +38,7 @@ internal static class ThreadingHandlers
         teamsApp.OnMessage("(?i)^thread proactive targeted$", async (context, cancellationToken) =>
         {
             ArgumentNullException.ThrowIfNull(context.Activity.From);
-            (string conversationId, string threadRootId) = GetThreadReference(context.Activity);
+            (string conversationId, string threadRootId) = context.Activity.GetProactiveThreadReference();
             await teamsApp.ReplyAsync(
                 conversationId,
                 threadRootId,
@@ -52,7 +51,7 @@ internal static class ThreadingHandlers
         teamsApp.OnMessage("(?i)^thread proactive targeted quote$", async (context, cancellationToken) =>
         {
             ArgumentNullException.ThrowIfNull(context.Activity.From);
-            (string conversationId, string threadRootId) = GetThreadReference(context.Activity);
+            (string conversationId, string threadRootId) = context.Activity.GetProactiveThreadReference();
             await teamsApp.ReplyAsync(
                 conversationId,
                 threadRootId,
@@ -61,18 +60,5 @@ internal static class ThreadingHandlers
                     .WithRecipient(context.Activity.From, isTargeted: true),
                 cancellationToken: cancellationToken);
         });
-    }
-
-    private static (string ConversationId, string ThreadRootId) GetThreadReference(TeamsActivity activity)
-    {
-        ArgumentNullException.ThrowIfNull(activity.Conversation);
-        ArgumentException.ThrowIfNullOrEmpty(activity.Id);
-
-        string inboundConversationId = activity.Conversation.Id;
-        string conversationId = activity.Conversation.ThreadId();
-        string[] threadParts = inboundConversationId.Split(";messageid=");
-        string threadRootId = activity.ChannelData?.Thread?.Id
-            ?? (threadParts.Length > 1 ? threadParts[1] : activity.Id);
-        return (conversationId, threadRootId);
     }
 }

--- a/samples/InteractingWithMessagesBot/ThreadingHandlers.cs
+++ b/samples/InteractingWithMessagesBot/ThreadingHandlers.cs
@@ -9,19 +9,9 @@ internal static class ThreadingHandlers
 {
     internal static void Register(TeamsBotApplication teamsApp)
     {
-        teamsApp.OnMessage("(?i)^thread send$", async (context, cancellationToken) =>
+        teamsApp.OnMessage("(?i)^default send$", async (context, cancellationToken) =>
         {
             await context.SendAsync("This is sent to the same thread, without quoting.", cancellationToken);
-        });
-
-        teamsApp.OnMessage("(?i)^thread reply$", async (context, cancellationToken) =>
-        {
-            (string conversationId, string threadRootId) = GetThreadReference(context.Activity);
-            await teamsApp.ReplyAsync(
-                conversationId,
-                threadRootId,
-                "This is a threaded reply to your message.",
-                cancellationToken: cancellationToken);
         });
 
         teamsApp.OnMessage("(?i)^thread proactive$", async (context, cancellationToken) =>
@@ -34,14 +24,41 @@ internal static class ThreadingHandlers
                 cancellationToken: cancellationToken);
         });
 
-        teamsApp.OnMessage("(?i)^thread manual$", async (context, cancellationToken) =>
+        teamsApp.OnMessage("(?i)^thread proactive quote$", async (context, cancellationToken) =>
         {
             (string conversationId, string threadRootId) = GetThreadReference(context.Activity);
             await teamsApp.ReplyAsync(
                 conversationId,
                 threadRootId,
-                new MessageActivityInput().WithText(
-                    "This was sent using teamsApp.ReplyAsync() for explicit thread placement."),
+                new MessageActivityInput().AddQuote(
+                    context.Activity.Id!,
+                    "This is explicitly placed in the thread and quotes your message."),
+                cancellationToken: cancellationToken);
+        });
+
+        teamsApp.OnMessage("(?i)^thread proactive targeted$", async (context, cancellationToken) =>
+        {
+            ArgumentNullException.ThrowIfNull(context.Activity.From);
+            (string conversationId, string threadRootId) = GetThreadReference(context.Activity);
+            await teamsApp.ReplyAsync(
+                conversationId,
+                threadRootId,
+                new MessageActivityInput()
+                    .WithText("This proactive targeted message uses the explicit reply endpoint.")
+                    .WithRecipient(context.Activity.From, isTargeted: true),
+                cancellationToken: cancellationToken);
+        });
+
+        teamsApp.OnMessage("(?i)^thread proactive targeted quote$", async (context, cancellationToken) =>
+        {
+            ArgumentNullException.ThrowIfNull(context.Activity.From);
+            (string conversationId, string threadRootId) = GetThreadReference(context.Activity);
+            await teamsApp.ReplyAsync(
+                conversationId,
+                threadRootId,
+                new MessageActivityInput()
+                    .AddQuote(context.Activity.Id!, "This proactive targeted reply quotes your message.")
+                    .WithRecipient(context.Activity.From, isTargeted: true),
                 cancellationToken: cancellationToken);
         });
     }

--- a/samples/M365ExtensionsBot/MyTeamsBot.cs
+++ b/samples/M365ExtensionsBot/MyTeamsBot.cs
@@ -47,7 +47,9 @@ public class MyTeamsBot : TeamsBotApplication
 
         this.OnMessage("quote", async (context, ct) =>
         {
-            await context.ReplyAsync("Quoting your message!", ct);
+            await context.SendAsync(
+                new MessageActivityInput().AddQuote(context.Activity.Id!, "Quoting your message!"),
+                ct);
         });
 
         this.OnMessage("targeted", async (context, ct) =>

--- a/samples/TargetedMessages/Program.cs
+++ b/samples/TargetedMessages/Program.cs
@@ -22,15 +22,14 @@ teamsApp.OnMessage("(?i)^test send$", async (context, cancellationToken) =>
     await context.SendAsync(reply, cancellationToken);
 });
 
-// Targeted reply to the inbound message: same wire format as send, but goes through
-// Context.Reply which prepends a quoted reference to the inbound message.
+// Targeted message that explicitly quotes the inbound message.
 teamsApp.OnMessage("(?i)^test reply$", async (context, cancellationToken) =>
 {
     MessageActivityInput reply = new MessageActivityInput()
-        .WithText("🔒 Targeted reply visible only to you.")
+        .AddQuote(context.Activity.Id!, "🔒 Targeted reply visible only to you.")
         .WithRecipient(context.Activity.From!, isTargeted: true)
         ;
-    await context.ReplyAsync(reply, cancellationToken);
+    await context.SendAsync(reply, cancellationToken);
 });
 
 // Send → Update a targeted message after 3 seconds.

--- a/src/Microsoft.Teams.Apps/Clients/ActivityClient.cs
+++ b/src/Microsoft.Teams.Apps/Clients/ActivityClient.cs
@@ -83,8 +83,7 @@ public class ActivityClient
     public Task<SendActivityResponse?> ReplyAsync(string conversationId, string id, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        activity.ReplyToId = id;
-        return SendCoreAsync(conversationId, activity, isTargeted: false, additionalHeaders, cancellationToken);
+        return _client.ReplyToActivityAsync(conversationId, id, activity, _serviceUrl, isTargeted: false, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -95,8 +94,7 @@ public class ActivityClient
     {
         ArgumentNullException.ThrowIfNull(activity);
         CoreActivityInput input = CoreActivityInput.FromActivity(activity);
-        input.ReplyToId = id;
-        return SendCoreAsync(conversationId, input, isTargeted: false, additionalHeaders, cancellationToken);
+        return _client.ReplyToActivityAsync(conversationId, id, input, _serviceUrl, isTargeted: false, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/src/Microsoft.Teams.Apps/Clients/ActivityClient.cs
+++ b/src/Microsoft.Teams.Apps/Clients/ActivityClient.cs
@@ -116,6 +116,15 @@ public class ActivityClient
     }
 
     /// <summary>
+    /// Reply to an existing activity with a targeted activity visible only to the specified recipient.
+    /// </summary>
+    public Task<SendActivityResponse?> ReplyTargetedAsync(string conversationId, string id, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        return _client.ReplyToActivityAsync(conversationId, id, activity, _serviceUrl, isTargeted: true, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
     /// Update an existing targeted activity in a conversation.
     /// </summary>
     public Task<UpdateActivityResponse> UpdateTargetedAsync(string conversationId, string id, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)

--- a/src/Microsoft.Teams.Apps/Clients/ConversationApiClient.cs
+++ b/src/Microsoft.Teams.Apps/Clients/ConversationApiClient.cs
@@ -109,6 +109,15 @@ public class ConversationApiClient
     }
 
     /// <summary>
+    /// Reply to an existing activity with a targeted activity visible only to the specified recipient.
+    /// </summary>
+    public Task<SendActivityResponse?> ReplyToTargetedActivityAsync(string conversationId, string id, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        return _client.ReplyToActivityAsync(conversationId, id, activity, _serviceUrl, isTargeted: true, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
     /// Update an existing targeted activity in a conversation.
     /// </summary>
     public Task<UpdateActivityResponse> UpdateTargetedActivityAsync(string conversationId, string id, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)

--- a/src/Microsoft.Teams.Apps/Clients/ConversationApiClient.cs
+++ b/src/Microsoft.Teams.Apps/Clients/ConversationApiClient.cs
@@ -87,8 +87,7 @@ public class ConversationApiClient
     public Task<SendActivityResponse?> ReplyToActivityAsync(string conversationId, string id, TeamsActivityInput activity, Dictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        activity.ReplyToId = id;
-        return _client.SendActivityAsync(conversationId, activity, _serviceUrl, isTargeted: false, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
+        return _client.ReplyToActivityAsync(conversationId, id, activity, _serviceUrl, isTargeted: false, requestContext: AgenticContext, customHeaders: additionalHeaders, cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/src/Microsoft.Teams.Apps/Context.cs
+++ b/src/Microsoft.Teams.Apps/Context.cs
@@ -169,7 +169,7 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// Teams renders the quoted message as a preview bubble above the response text.
     /// </summary>
     /// <param name="messageId">The ID of the message to quote.</param>
-    /// <param name="activity">The activity to send. For <see cref="MessageActivity"/>, a quote placeholder for messageId is prepended to its text. Other activity types are sent as-is without quoting.</param>
+    /// <param name="activity">The activity to send. A quote placeholder for messageId is prepended to its text.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>The response from sending the activity.</returns>
     [Obsolete("Add the quote to the MessageActivityInput with AddQuote before passing it to SendAsync.")]

--- a/src/Microsoft.Teams.Apps/Context.cs
+++ b/src/Microsoft.Teams.Apps/Context.cs
@@ -294,13 +294,15 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
             TargetedMessageInfoEntityExtensions.AddToActivity(activity, Activity.Id);
         }
 
+        if (TryGetThreadRoot(conversationId, out string baseConversationId, out string threadRootId))
+        {
+            return isTargeted
+                ? Api.Conversations.ReplyToTargetedActivityAsync(baseConversationId, threadRootId, activity, cancellationToken: cancellationToken)
+                : Api.Conversations.ReplyToActivityAsync(baseConversationId, threadRootId, activity, cancellationToken: cancellationToken);
+        }
+
         if (!isTargeted)
         {
-            if (TryGetThreadRoot(conversationId, out string baseConversationId, out string threadRootId))
-            {
-                return Api.Conversations.ReplyToActivityAsync(baseConversationId, threadRootId, activity, cancellationToken: cancellationToken);
-            }
-
             return Api.Conversations.CreateActivityAsync(conversationId, activity, cancellationToken: cancellationToken);
         }
 

--- a/src/Microsoft.Teams.Apps/Context.cs
+++ b/src/Microsoft.Teams.Apps/Context.cs
@@ -108,30 +108,31 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     // ==================== Convenience Send/Reply/Typing ====================
 
     /// <summary>
-    /// Sends a text message as a threaded reply to the current activity. When the inbound activity
-    /// has an id, the response auto-quotes it (rendered as a quote bubble above the response in Teams);
-    /// otherwise sends without quoting.
+    /// Sends a text message that quotes the current activity when it has an ID.
     /// </summary>
     /// <param name="text">The text to send.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
+    [Obsolete("Use SendAsync. To quote a message, add the quote to a MessageActivityInput with AddQuote and pass it to SendAsync.")]
     public Task<SendActivityResponse?> ReplyAsync(string text, CancellationToken cancellationToken = default)
-        => ReplyAsync(new MessageActivityInput().WithText(text), cancellationToken);
+        => SendQuotedReplyAsync(new MessageActivityInput().WithText(text), cancellationToken);
 
     /// <summary>
-    /// Sends an activity to the conversation. When the inbound activity has an id, the response
-    /// auto-quotes it (rendered as a quote bubble above the response in Teams). Otherwise sends
-    /// without quoting. To send without quoting unconditionally, use <see cref="SendAsync(MessageActivityInput, CancellationToken)"/>.
+    /// Sends an activity that quotes the current activity when it has an ID.
     /// </summary>
     /// <param name="activity">The activity to send.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The response from the send operation.</returns>
+    [Obsolete("Use SendAsync. To quote a message, add the quote to the MessageActivityInput with AddQuote before passing it to SendAsync.")]
     public Task<SendActivityResponse?> ReplyAsync(MessageActivityInput activity, CancellationToken cancellationToken = default)
+        => SendQuotedReplyAsync(activity, cancellationToken);
+
+    private Task<SendActivityResponse?> SendQuotedReplyAsync(MessageActivityInput activity, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(activity);
         if (!string.IsNullOrWhiteSpace(Activity.Id))
         {
-            return QuoteAsync(Activity.Id, activity, cancellationToken);
+            activity.PrependQuote(Activity.Id);
         }
 
         return SendAsync(activity, cancellationToken);
@@ -159,8 +160,9 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="text">The response text, appended to the quoted message placeholder.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>The response from sending the activity.</returns>
+    [Obsolete("Add the quote to a MessageActivityInput with AddQuote and pass it to SendAsync.")]
     public Task<SendActivityResponse?> QuoteAsync(string messageId, string text, CancellationToken cancellationToken = default)
-        => QuoteAsync(messageId, new MessageActivityInput().WithText(text), cancellationToken);
+        => SendQuotedAsync(messageId, new MessageActivityInput().WithText(text), cancellationToken);
 
     /// <summary>
     /// Send a message to the conversation with a quoted message reference prepended to the text.
@@ -170,14 +172,15 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     /// <param name="activity">The activity to send. For <see cref="MessageActivity"/>, a quote placeholder for messageId is prepended to its text. Other activity types are sent as-is without quoting.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>The response from sending the activity.</returns>
+    [Obsolete("Add the quote to the MessageActivityInput with AddQuote before passing it to SendAsync.")]
     public Task<SendActivityResponse?> QuoteAsync(string messageId, MessageActivityInput activity, CancellationToken cancellationToken = default)
+        => SendQuotedAsync(messageId, activity, cancellationToken);
+
+    private Task<SendActivityResponse?> SendQuotedAsync(string messageId, MessageActivityInput activity, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(activity);
         ArgumentException.ThrowIfNullOrWhiteSpace(messageId);
-        if (activity is MessageActivityInput message)
-        {
-            message.PrependQuote(messageId);
-        }
+        activity.PrependQuote(messageId);
         return SendAsync(activity, cancellationToken);
     }
 
@@ -199,23 +202,25 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
     }
 
     /// <inheritdoc cref="ReplyAsync(string, CancellationToken)"/>
-    [Obsolete("Use ReplyAsync instead.")]
+    [Obsolete("Use SendAsync. To quote a message, add the quote to a MessageActivityInput with AddQuote and pass it to SendAsync.")]
     public Task<SendActivityResponse?> Reply(string text, CancellationToken cancellationToken = default)
-        => ReplyAsync(text, cancellationToken);
+        => SendQuotedReplyAsync(new MessageActivityInput().WithText(text), cancellationToken);
 
     /// <inheritdoc cref="ReplyAsync(MessageActivityInput, CancellationToken)"/>
-    [Obsolete("Use ReplyAsync with a TeamsActivityInput built via new MessageActivityInput() instead.")]
+    [Obsolete("Use SendAsync. To quote a message, add the quote to a MessageActivityInput with AddQuote and pass it to SendAsync.")]
     public Task<SendActivityResponse?> Reply(MessageActivity activity, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
         string conversationId = Activity.Conversation?.Id
             ?? throw new InvalidOperationException("Activity.Conversation.Id is required to send an activity.");
-#pragma warning disable CS0618 // routing an inbound activity through the obsolete client overload
         if (!string.IsNullOrWhiteSpace(Activity.Id))
         {
-            return Api.Conversations.Activities.ReplyAsync(conversationId, Activity.Id!, activity, cancellationToken: cancellationToken);
+#pragma warning disable CS0618 // preserving the obsolete auto-quote behavior
+            activity.PrependQuote(Activity.Id);
+#pragma warning restore CS0618
         }
 
+#pragma warning disable CS0618 // routing an inbound activity through the obsolete client overload
         return Api.Conversations.Activities.CreateAsync(conversationId, activity, cancellationToken: cancellationToken);
 #pragma warning restore CS0618
     }
@@ -231,19 +236,20 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
         => TeamsStreamingWriter.CreateFromContext(this);
 
     /// <inheritdoc cref="QuoteAsync(string, string, CancellationToken)"/>
-    [Obsolete("Use QuoteAsync instead.")]
+    [Obsolete("Add the quote to a MessageActivityInput with AddQuote and pass it to SendAsync.")]
     public Task<SendActivityResponse?> Quote(string messageId, string text, CancellationToken cancellationToken = default)
-        => QuoteAsync(messageId, text, cancellationToken);
+        => SendQuotedAsync(messageId, new MessageActivityInput().WithText(text), cancellationToken);
 
     /// <inheritdoc cref="QuoteAsync(string, MessageActivityInput, CancellationToken)"/>
-    [Obsolete("Use QuoteAsync with a TeamsActivityInput built via new MessageActivityInput() instead.")]
+    [Obsolete("Add the quote to a MessageActivityInput with AddQuote and pass it to SendAsync.")]
     public Task<SendActivityResponse?> Quote(string messageId, MessageActivity activity, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
         string conversationId = Activity.Conversation?.Id
             ?? throw new InvalidOperationException("Activity.Conversation.Id is required to send an activity.");
-#pragma warning disable CS0618 // routing an inbound activity through the obsolete client overload
-        return Api.Conversations.Activities.ReplyAsync(conversationId, messageId, activity, cancellationToken: cancellationToken);
+#pragma warning disable CS0618 // preserving the obsolete quote behavior and outbound activity overload
+        activity.PrependQuote(messageId);
+        return Api.Conversations.Activities.CreateAsync(conversationId, activity, cancellationToken: cancellationToken);
 #pragma warning restore CS0618
     }
 
@@ -290,10 +296,45 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
 
         if (!isTargeted)
         {
+            if (TryGetThreadRoot(conversationId, out string baseConversationId, out string threadRootId))
+            {
+                return Api.Conversations.ReplyToActivityAsync(baseConversationId, threadRootId, activity, cancellationToken: cancellationToken);
+            }
+
             return Api.Conversations.CreateActivityAsync(conversationId, activity, cancellationToken: cancellationToken);
         }
 
         return Api.Conversations.CreateTargetedActivityAsync(conversationId, activity, cancellationToken: cancellationToken);
+    }
+
+    private bool TryGetThreadRoot(string conversationId, out string baseConversationId, out string threadRootId)
+    {
+        const string legacyThreadMarker = ";messageid=";
+        int markerIndex = conversationId.IndexOf(legacyThreadMarker, StringComparison.OrdinalIgnoreCase);
+        baseConversationId = markerIndex >= 0 ? conversationId[..markerIndex] : conversationId;
+
+        string? channelDataThreadId = Activity.ChannelData?.Thread?.Id;
+        if (!string.IsNullOrWhiteSpace(channelDataThreadId))
+        {
+            threadRootId = channelDataThreadId;
+            return true;
+        }
+
+        if (markerIndex >= 0)
+        {
+            threadRootId = conversationId[(markerIndex + legacyThreadMarker.Length)..];
+            return !string.IsNullOrWhiteSpace(threadRootId);
+        }
+
+        bool isChannel = Activity.Conversation?.ConversationType?.Equals(ConversationTypes.Channel) ?? false;
+        if (isChannel && !string.IsNullOrWhiteSpace(Activity.Id))
+        {
+            threadRootId = Activity.Id;
+            return true;
+        }
+
+        threadRootId = string.Empty;
+        return false;
     }
 
     // ==================== OAuth Sign-In ====================

--- a/src/Microsoft.Teams.Apps/Context.cs
+++ b/src/Microsoft.Teams.Apps/Context.cs
@@ -8,6 +8,7 @@ using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Apps.Schema.Entities;
 using Microsoft.Teams.Apps.State;
 using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Schema;
 
 namespace Microsoft.Teams.Apps;
 
@@ -294,8 +295,10 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
             TargetedMessageInfoEntityExtensions.AddToActivity(activity, Activity.Id);
         }
 
-        if (TryGetThreadRoot(conversationId, out string baseConversationId, out string threadRootId))
+        string? threadRootId = Activity.GetDefaultThreadId();
+        if (threadRootId is not null)
         {
+            string baseConversationId = Activity.Conversation!.ThreadId();
             return isTargeted
                 ? Api.Conversations.ReplyToTargetedActivityAsync(baseConversationId, threadRootId, activity, cancellationToken: cancellationToken)
                 : Api.Conversations.ReplyToActivityAsync(baseConversationId, threadRootId, activity, cancellationToken: cancellationToken);
@@ -307,36 +310,6 @@ public class Context<TActivity>(TeamsBotApplication botApplication, TActivity ac
         }
 
         return Api.Conversations.CreateTargetedActivityAsync(conversationId, activity, cancellationToken: cancellationToken);
-    }
-
-    private bool TryGetThreadRoot(string conversationId, out string baseConversationId, out string threadRootId)
-    {
-        const string legacyThreadMarker = ";messageid=";
-        int markerIndex = conversationId.IndexOf(legacyThreadMarker, StringComparison.OrdinalIgnoreCase);
-        baseConversationId = markerIndex >= 0 ? conversationId[..markerIndex] : conversationId;
-
-        string? channelDataThreadId = Activity.ChannelData?.Thread?.Id;
-        if (!string.IsNullOrWhiteSpace(channelDataThreadId))
-        {
-            threadRootId = channelDataThreadId;
-            return true;
-        }
-
-        if (markerIndex >= 0)
-        {
-            threadRootId = conversationId[(markerIndex + legacyThreadMarker.Length)..];
-            return !string.IsNullOrWhiteSpace(threadRootId);
-        }
-
-        bool isChannel = Activity.Conversation?.ConversationType?.Equals(ConversationTypes.Channel) ?? false;
-        if (isChannel && !string.IsNullOrWhiteSpace(Activity.Id))
-        {
-            threadRootId = Activity.Id;
-            return true;
-        }
-
-        threadRootId = string.Empty;
-        return false;
     }
 
     // ==================== OAuth Sign-In ====================

--- a/src/Microsoft.Teams.Apps/Schema/TeamsActivityExtensions.cs
+++ b/src/Microsoft.Teams.Apps/Schema/TeamsActivityExtensions.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Teams.Core.Schema;
+
+namespace Microsoft.Teams.Apps.Schema;
+
+/// <summary>
+/// Threading helpers for Teams activities.
+/// </summary>
+public static class TeamsActivityExtensions
+{
+    private const string LegacyThreadMarker = ";messageid=";
+
+    /// <summary>
+    /// Gets the base conversation ID and thread root ID needed to send a proactive threaded reply.
+    /// </summary>
+    /// <remarks>
+    /// The thread root is resolved from typed channel data first, then from a legacy
+    /// <c>;messageid=</c> conversation ID suffix, and finally from the inbound activity ID.
+    /// </remarks>
+    /// <param name="activity">The inbound Teams activity.</param>
+    /// <returns>The base conversation ID and thread root ID.</returns>
+    public static (string ConversationId, string ThreadRootId) GetProactiveThreadReference(this TeamsActivity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        ArgumentNullException.ThrowIfNull(activity.Conversation);
+
+        string? threadRootId = GetExplicitThreadId(activity);
+        if (string.IsNullOrWhiteSpace(threadRootId))
+        {
+            ArgumentException.ThrowIfNullOrEmpty(activity.Id);
+            threadRootId = activity.Id;
+        }
+
+        return (activity.Conversation.ThreadId(), threadRootId);
+    }
+
+    /// <summary>
+    /// Gets the thread root ID used by default for a reactive reply.
+    /// </summary>
+    /// <remarks>
+    /// The thread root is resolved from typed channel data first, then from a legacy
+    /// <c>;messageid=</c> conversation ID suffix. For a channel root activity, the inbound
+    /// activity ID is used. Group-chat and personal root activities return <see langword="null"/>.
+    /// </remarks>
+    /// <param name="activity">The inbound Teams activity.</param>
+    /// <returns>The default thread root ID, or <see langword="null"/> for an unthreaded activity.</returns>
+    public static string? GetDefaultThreadId(this TeamsActivity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+
+        string? threadRootId = GetExplicitThreadId(activity);
+        if (!string.IsNullOrWhiteSpace(threadRootId))
+        {
+            return threadRootId;
+        }
+
+        bool isChannel = activity.Conversation?.ConversationType?.Equals(ConversationTypes.Channel) ?? false;
+        return isChannel && !string.IsNullOrWhiteSpace(activity.Id) ? activity.Id : null;
+    }
+
+    private static string? GetExplicitThreadId(TeamsActivity activity)
+    {
+        if (!string.IsNullOrWhiteSpace(activity.ChannelData?.Thread?.Id))
+        {
+            return activity.ChannelData.Thread.Id;
+        }
+
+        string? conversationId = activity.Conversation?.Id;
+        if (string.IsNullOrEmpty(conversationId))
+        {
+            return null;
+        }
+
+        int markerIndex = conversationId.IndexOf(LegacyThreadMarker, StringComparison.OrdinalIgnoreCase);
+        if (markerIndex < 0)
+        {
+            return null;
+        }
+
+        string threadRootId = conversationId[(markerIndex + LegacyThreadMarker.Length)..];
+        return string.IsNullOrWhiteSpace(threadRootId) ? null : threadRootId;
+    }
+}

--- a/src/Microsoft.Teams.Apps/Schema/TeamsChannelData.cs
+++ b/src/Microsoft.Teams.Apps/Schema/TeamsChannelData.cs
@@ -65,6 +65,28 @@ public class AppInfo
 }
 
 /// <summary>
+/// Identifies the root of the thread containing an inbound activity.
+/// </summary>
+public sealed class TeamsChannelDataThread
+{
+    /// <summary>
+    /// Creates thread information for deserialization.
+    /// </summary>
+    /// <param name="id">The root activity ID.</param>
+    [JsonConstructor]
+    public TeamsChannelDataThread(string? id)
+    {
+        Id = id;
+    }
+
+    /// <summary>
+    /// Gets the root activity ID.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; }
+}
+
+/// <summary>
 /// Represents Teams-specific channel data.
 /// </summary>
 public class TeamsChannelData : ChannelData
@@ -90,6 +112,13 @@ public class TeamsChannelData : ChannelData
     /// Teams Team Id.
     /// </summary>
     [JsonPropertyName("teamsTeamId")] public string? TeamsTeamId { get; set; }
+
+    /// <summary>
+    /// Gets information about the thread containing this inbound activity.
+    /// </summary>
+    [JsonPropertyName("thread")]
+    [JsonInclude]
+    public TeamsChannelDataThread? Thread { get; internal set; }
 
     /// <summary>
     /// Gets or sets the channel information associated with this entity.

--- a/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
+++ b/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
@@ -243,6 +243,18 @@ public class TeamsBotApplication : BotApplication
         Uri resolvedUrl = serviceUrl ?? _lastServiceUrl
             ?? throw new InvalidOperationException("No service URL available. Either pass a serviceUrl parameter or ensure the bot has received at least one activity.");
 
+        if (TryParseLegacyThreadedConversationId(conversationId, out string baseConversationId, out string threadRootId))
+        {
+            return ConversationClient.ReplyToActivityAsync(
+                baseConversationId,
+                threadRootId,
+                activity,
+                resolvedUrl,
+                isTargeted: activity.Recipient?.IsTargeted ?? false,
+                requestContext: BotRequestContext.FromAgenticIdentity(agenticIdentity),
+                cancellationToken: cancellationToken);
+        }
+
         return SendActivityAsync(
             conversationId,
             activity,
@@ -313,6 +325,17 @@ public class TeamsBotApplication : BotApplication
         ArgumentNullException.ThrowIfNull(activity);
         Uri resolvedUrl = serviceUrl ?? _lastServiceUrl
             ?? throw new InvalidOperationException("No service URL available. Either pass a serviceUrl parameter or ensure the bot has received at least one activity.");
+        if (TryParseLegacyThreadedConversationId(conversationId, out string baseConversationId, out string threadRootId))
+        {
+            return ConversationClient.ReplyToActivityAsync(
+                baseConversationId,
+                threadRootId,
+                CoreActivityInput.FromActivity(activity),
+                resolvedUrl,
+                requestContext: BotRequestContext.FromAgenticIdentity(agenticIdentity),
+                cancellationToken: cancellationToken);
+        }
+
         return SendActivityAsync(conversationId, CoreActivityInput.FromActivity(activity), resolvedUrl, agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
     }
 
@@ -345,6 +368,26 @@ public class TeamsBotApplication : BotApplication
         {
             throw new ArgumentException($"Invalid messageId \"{messageId}\": must be a non-zero numeric value", nameof(messageId));
         }
+    }
+
+    private static bool TryParseLegacyThreadedConversationId(string conversationId, out string baseConversationId, out string threadRootId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+
+        const string marker = ";messageid=";
+        int markerIndex = conversationId.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (markerIndex < 0)
+        {
+            baseConversationId = conversationId;
+            threadRootId = string.Empty;
+            return false;
+        }
+
+        baseConversationId = conversationId[..markerIndex];
+        threadRootId = conversationId[(markerIndex + marker.Length)..];
+        ArgumentException.ThrowIfNullOrWhiteSpace(baseConversationId);
+        ValidateThreadRootId(threadRootId);
+        return true;
     }
 
     /// <summary>

--- a/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
+++ b/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
@@ -10,6 +10,7 @@ using Microsoft.Teams.Apps.Routing;
 using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Apps.State;
 using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Http;
 using Microsoft.Teams.Core.Schema;
 
 namespace Microsoft.Teams.Apps;
@@ -211,7 +212,7 @@ public class TeamsBotApplication : BotApplication
     /// <summary>
     /// Sends a text message proactively to a conversation.
     /// </summary>
-    /// <param name="conversationId">The conversation ID to send to. For channel threads, include <c>;messageid=</c>.</param>
+    /// <param name="conversationId">The base conversation ID to send to.</param>
     /// <param name="text">The text to send.</param>
     /// <param name="serviceUrl">The service URL. If null, uses the last-seen service URL from an incoming activity.</param>
     /// <param name="agenticIdentity">The agentic identity for user-delegated token acquisition. Extract from the inbound activity's <see cref="CoreActivity.Recipient"/> via <see cref="ChannelAccount.GetAgenticIdentity"/>.</param>
@@ -229,7 +230,7 @@ public class TeamsBotApplication : BotApplication
     /// Sends an activity proactively to a conversation. When the activity carries a recipient marked as
     /// targeted (<see cref="ChannelAccount.IsTargeted"/>), it is sent as a targeted message visible only to that recipient.
     /// </summary>
-    /// <param name="conversationId">The conversation ID to send to. For channel threads, include <c>;messageid=</c>.</param>
+    /// <param name="conversationId">The base conversation ID to send to.</param>
     /// <param name="activity">The activity to send.</param>
     /// <param name="serviceUrl">The service URL. If null, uses the last-seen service URL from an incoming activity.</param>
     /// <param name="agenticIdentity">The agentic identity for user-delegated token acquisition. Extract from the inbound activity's <see cref="CoreActivity.Recipient"/> via <see cref="ChannelAccount.GetAgenticIdentity"/>.</param>
@@ -253,7 +254,6 @@ public class TeamsBotApplication : BotApplication
 
     /// <summary>
     /// Sends a text message proactively as a threaded reply.
-    /// Constructs a threaded conversation ID from the conversation ID and message ID.
     /// </summary>
     /// <param name="conversationId">The conversation ID.</param>
     /// <param name="messageId">The thread root message ID.</param>
@@ -264,13 +264,17 @@ public class TeamsBotApplication : BotApplication
     /// <returns>The response from the send operation.</returns>
     public Task<SendActivityResponse?> ReplyAsync(string conversationId, string messageId, string text, Uri? serviceUrl = null, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
     {
-        string threadedConversationId = ConversationExtensions.ToThreadedConversationId(conversationId, messageId);
-        return SendAsync(threadedConversationId, text, serviceUrl, agenticIdentity, cancellationToken);
+        return ReplyAsync(
+            conversationId,
+            messageId,
+            new MessageActivityInput().WithText(text),
+            serviceUrl,
+            agenticIdentity,
+            cancellationToken);
     }
 
     /// <summary>
     /// Sends an activity proactively as a threaded reply.
-    /// Constructs a threaded conversation ID from the conversation ID and message ID.
     /// </summary>
     /// <param name="conversationId">The conversation ID.</param>
     /// <param name="messageId">The thread root message ID.</param>
@@ -281,8 +285,20 @@ public class TeamsBotApplication : BotApplication
     /// <returns>The response from the send operation.</returns>
     public Task<SendActivityResponse?> ReplyAsync(string conversationId, string messageId, TeamsActivityInput activity, Uri? serviceUrl = null, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
     {
-        string threadedConversationId = ConversationExtensions.ToThreadedConversationId(conversationId, messageId);
-        return SendAsync(threadedConversationId, activity, serviceUrl, agenticIdentity, cancellationToken);
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+        ValidateThreadRootId(messageId);
+        ArgumentNullException.ThrowIfNull(activity);
+
+        Uri resolvedUrl = serviceUrl ?? _lastServiceUrl
+            ?? throw new InvalidOperationException("No service URL available. Either pass a serviceUrl parameter or ensure the bot has received at least one activity.");
+        string baseConversationId = conversationId.Split(';')[0];
+        return ConversationClient.ReplyToActivityAsync(
+            baseConversationId,
+            messageId,
+            activity,
+            resolvedUrl,
+            requestContext: BotRequestContext.FromAgenticIdentity(agenticIdentity),
+            cancellationToken: cancellationToken);
     }
 
     /// <inheritdoc cref="SendAsync(string, string, Uri?, AgenticIdentity?, CancellationToken)"/>
@@ -310,10 +326,25 @@ public class TeamsBotApplication : BotApplication
     public Task<SendActivityResponse?> Reply(string conversationId, string messageId, TeamsActivity activity, AgenticIdentity? agenticIdentity = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(activity);
-        string threadedConversationId = ConversationExtensions.ToThreadedConversationId(conversationId, messageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+        ValidateThreadRootId(messageId);
         Uri resolvedUrl = _lastServiceUrl
             ?? throw new InvalidOperationException("No service URL available. Either pass a serviceUrl parameter or ensure the bot has received at least one activity.");
-        return SendActivityAsync(threadedConversationId, CoreActivityInput.FromActivity(activity), resolvedUrl, agenticIdentity: agenticIdentity, cancellationToken: cancellationToken);
+        return ConversationClient.ReplyToActivityAsync(
+            conversationId.Split(';')[0],
+            messageId,
+            CoreActivityInput.FromActivity(activity),
+            resolvedUrl,
+            requestContext: BotRequestContext.FromAgenticIdentity(agenticIdentity),
+            cancellationToken: cancellationToken);
+    }
+
+    private static void ValidateThreadRootId(string messageId)
+    {
+        if (string.IsNullOrEmpty(messageId) || !ulong.TryParse(messageId, out ulong parsed) || parsed == 0)
+        {
+            throw new ArgumentException($"Invalid messageId \"{messageId}\": must be a non-zero numeric value", nameof(messageId));
+        }
     }
 
     /// <summary>

--- a/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
+++ b/src/Microsoft.Teams.Apps/TeamsBotApplication.cs
@@ -286,7 +286,8 @@ public class TeamsBotApplication : BotApplication
     }
 
     /// <summary>
-    /// Sends an activity proactively as a threaded reply.
+    /// Sends an activity proactively as a threaded reply. When the activity carries a targeted recipient,
+    /// the reply is visible only to that recipient.
     /// </summary>
     /// <param name="conversationId">The conversation ID.</param>
     /// <param name="messageId">The thread root message ID.</param>
@@ -309,6 +310,7 @@ public class TeamsBotApplication : BotApplication
             messageId,
             activity,
             resolvedUrl,
+            isTargeted: activity.Recipient?.IsTargeted ?? false,
             requestContext: BotRequestContext.FromAgenticIdentity(agenticIdentity),
             cancellationToken: cancellationToken);
     }
@@ -358,6 +360,7 @@ public class TeamsBotApplication : BotApplication
             messageId,
             CoreActivityInput.FromActivity(activity),
             resolvedUrl,
+            isTargeted: activity.Recipient?.IsTargeted ?? false,
             requestContext: BotRequestContext.FromAgenticIdentity(agenticIdentity),
             cancellationToken: cancellationToken);
     }

--- a/src/Microsoft.Teams.Core/ConversationClient.cs
+++ b/src/Microsoft.Teams.Core/ConversationClient.cs
@@ -122,7 +122,6 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
                     body,
                     CreateRequestOptions(requestContext, "replying to activity", customHeaders),
                     cancellationToken).ConfigureAwait(false);
-                span?.SetTag(Telemetry.Tags.ActivityId, response?.Id);
                 return response;
             }).ConfigureAwait(false);
     }

--- a/src/Microsoft.Teams.Core/ConversationClient.cs
+++ b/src/Microsoft.Teams.Core/ConversationClient.cs
@@ -83,6 +83,51 @@ public class ConversationClient(HttpClient httpClient, ILogger<ConversationClien
     }
 
     /// <summary>
+    /// Sends an activity as a reply beneath an existing root activity.
+    /// </summary>
+    /// <param name="conversationId">The ID of the conversation. Cannot be null or whitespace.</param>
+    /// <param name="activityId">The ID of the root activity to reply beneath. Cannot be null or whitespace.</param>
+    /// <param name="activity">The activity to send. Cannot be null.</param>
+    /// <param name="serviceUrl">The service URL for the conversation. Cannot be null.</param>
+    /// <param name="isTargeted">When true, the activity is sent as a targeted message.</param>
+    /// <param name="requestContext">Optional per-request properties used as a fallback for authentication context.</param>
+    /// <param name="customHeaders">Optional custom headers to include in the request.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the send operation.</param>
+    /// <returns>The response containing the ID of the sent activity, or <see langword="null"/>.</returns>
+    public virtual async Task<SendActivityResponse?> ReplyToActivityAsync(string conversationId, string activityId, CoreActivityInput activity, Uri serviceUrl, bool isTargeted = false, BotRequestContext? requestContext = null, CustomHeaders? customHeaders = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(activityId);
+        ArgumentNullException.ThrowIfNull(activity);
+        ArgumentNullException.ThrowIfNull(serviceUrl);
+
+        string url = $"{serviceUrl.ToString().TrimEnd('/')}/v3/conversations/{Uri.EscapeDataString(conversationId)}/activities/{Uri.EscapeDataString(activityId)}";
+        if (isTargeted)
+        {
+            url += "?isTargetedActivity=true";
+        }
+
+        string body = activity.ToJson();
+        return await ExecuteConversationClientAsync(
+            serviceUrl,
+            Telemetry.ClientOperations.SendActivity,
+            async span =>
+            {
+                span?.SetTag(Telemetry.Tags.ConversationId, conversationId);
+                span?.SetTag(Telemetry.Tags.ActivityId, activityId);
+                span?.SetTag(Telemetry.Tags.ActivityType, activity.Type);
+                SendActivityResponse? response = await _botHttpClient.SendAsync<SendActivityResponse>(
+                    HttpMethod.Post,
+                    url,
+                    body,
+                    CreateRequestOptions(requestContext, "replying to activity", customHeaders),
+                    cancellationToken).ConfigureAwait(false);
+                span?.SetTag(Telemetry.Tags.ActivityId, response?.Id);
+                return response;
+            }).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Updates an existing activity in a conversation.
     /// </summary>
     /// <param name="conversationId">The ID of the conversation. Cannot be null or whitespace.</param>

--- a/src/Microsoft.Teams.Core/Schema/ConversationExtensions.cs
+++ b/src/Microsoft.Teams.Core/Schema/ConversationExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Teams.Core.Schema;
 public static class ConversationExtensions
 {
     /// <summary>
-    /// The thread root portion of the conversation ID, with any <c>;messageid=</c> suffix stripped.
+    /// The base conversation ID, with any legacy <c>;messageid=</c> suffix stripped.
     /// </summary>
     public static string ThreadId(this Conversation conversation)
     {
@@ -26,6 +26,7 @@ public static class ConversationExtensions
     /// <param name="conversationId">the conversation to thread into (e.g. <c>19:abc@thread.skype</c>)</param>
     /// <param name="messageId">the thread root message ID (must be a non-zero numeric string)</param>
     /// <returns>the threaded conversation ID (e.g. <c>19:abc@thread.skype;messageid=123</c>)</returns>
+    [Obsolete("Thread placement is endpoint-based. Use the base conversation ID with ReplyToActivityAsync instead.")]
     public static string ToThreadedConversationId(string conversationId, string messageId)
     {
         if (string.IsNullOrEmpty(conversationId))

--- a/test/Microsoft.Teams.Apps.UnitTests/ConversationApiClientTests.cs
+++ b/test/Microsoft.Teams.Apps.UnitTests/ConversationApiClientTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Teams.Apps.Clients;
+using Microsoft.Teams.Apps.Schema;
+using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Http;
+using Microsoft.Teams.Core.Schema;
+using Moq;
+
+namespace Microsoft.Teams.Apps.UnitTests;
+
+public class ConversationApiClientTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ReplyMethods_SetExpectedTargetedFlag(bool isTargeted)
+    {
+        Mock<ConversationClient> conversationClient = new(
+            new HttpClient(),
+            NullLogger<ConversationClient>.Instance);
+        bool? capturedIsTargeted = null;
+        conversationClient
+            .Setup(c => c.ReplyToActivityAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CoreActivityInput>(),
+                It.IsAny<Uri>(),
+                It.IsAny<bool>(),
+                It.IsAny<BotRequestContext?>(),
+                It.IsAny<Dictionary<string, string>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, CoreActivityInput, Uri, bool, BotRequestContext?, Dictionary<string, string>?, CancellationToken>(
+                (_, _, _, _, targeted, _, _, _) => capturedIsTargeted = targeted)
+            .ReturnsAsync(new SendActivityResponse { Id = "reply-id" });
+
+        ConversationApiClient client = new(
+            new Uri("https://test.service.url/"),
+            conversationClient.Object);
+        MessageActivityInput activity = new MessageActivityInput().WithText("hello");
+
+        if (isTargeted)
+        {
+            await client.ReplyToTargetedActivityAsync("conversation-id", "root-id", activity);
+        }
+        else
+        {
+            await client.ReplyToActivityAsync("conversation-id", "root-id", activity);
+        }
+
+        Assert.Equal(isTargeted, capturedIsTargeted);
+    }
+}

--- a/test/Microsoft.Teams.Apps.UnitTests/PromptPreviewTests.cs
+++ b/test/Microsoft.Teams.Apps.UnitTests/PromptPreviewTests.cs
@@ -173,6 +173,29 @@ public class PromptPreviewTests
     }
 
     [Fact]
+    public async Task SendActivityAsync_TargetedWithChannelDataThread_UsesTargetedReplyEndpoint()
+    {
+        TestHarness harness = CreateHarness();
+        string? capturedRootId = null;
+        bool? capturedIsTargeted = null;
+        SetupReplyCapture(
+            harness,
+            (_, rootId) => capturedRootId = rootId,
+            isTargeted => capturedIsTargeted = isTargeted);
+        MessageActivity inbound = BuildInbound(targetedInbound: false, inboundId: "reply-id", convType: ConversationTypes.GroupChat);
+        inbound.ChannelData = JsonSerializer.Deserialize<TeamsChannelData>("{\"thread\":{\"id\":\"1772129782775\"}}");
+        Context<MessageActivity> ctx = new(harness.App, inbound);
+
+        await ctx.SendAsync(
+            new MessageActivityInput()
+                .WithText("targeted reply")
+                .WithRecipient(inbound.From!, isTargeted: true));
+
+        Assert.Equal("1772129782775", capturedRootId);
+        Assert.True(capturedIsTargeted);
+    }
+
+    [Fact]
     public async Task SendActivityAsync_WithLegacyThreadedConversationId_UsesBaseIdAndReplyEndpoint()
     {
         TestHarness harness = CreateHarness();
@@ -240,7 +263,10 @@ public class PromptPreviewTests
         return slot;
     }
 
-    private static void SetupReplyCapture(TestHarness harness, Action<string, string> capture)
+    private static void SetupReplyCapture(
+        TestHarness harness,
+        Action<string, string> capture,
+        Action<bool>? captureIsTargeted = null)
     {
         harness.MockConversationClient
             .Setup(c => c.ReplyToActivityAsync(
@@ -253,7 +279,11 @@ public class PromptPreviewTests
                 It.IsAny<Dictionary<string, string>?>(),
                 It.IsAny<CancellationToken>()))
             .Callback<string, string, CoreActivityInput, Uri, bool, BotRequestContext?, Dictionary<string, string>?, CancellationToken>(
-                (conversationId, rootId, _, _, _, _, _, _) => capture(conversationId, rootId))
+                (conversationId, rootId, _, _, isTargeted, _, _, _) =>
+                {
+                    capture(conversationId, rootId);
+                    captureIsTargeted?.Invoke(isTargeted);
+                })
             .ReturnsAsync(new SendActivityResponse { Id = "sent-id" });
     }
 

--- a/test/Microsoft.Teams.Apps.UnitTests/PromptPreviewTests.cs
+++ b/test/Microsoft.Teams.Apps.UnitTests/PromptPreviewTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -136,6 +137,62 @@ public class PromptPreviewTests
         Assert.NotNull(captured.Value);
     }
 
+    [Fact]
+    public async Task SendActivityAsync_InChannel_RoutesToReplyEndpoint()
+    {
+        TestHarness harness = CreateHarness();
+        string? capturedConversationId = null;
+        string? capturedRootId = null;
+        SetupReplyCapture(harness, (conversationId, rootId) =>
+        {
+            capturedConversationId = conversationId;
+            capturedRootId = rootId;
+        });
+        MessageActivity inbound = BuildInbound(targetedInbound: false, inboundId: "1772129782775", convType: ConversationTypes.Channel);
+        Context<MessageActivity> ctx = new(harness.App, inbound);
+
+        await ctx.SendAsync("hello");
+
+        Assert.Equal("conv-1", capturedConversationId);
+        Assert.Equal("1772129782775", capturedRootId);
+    }
+
+    [Fact]
+    public async Task SendActivityAsync_WithChannelDataThread_RoutesToReplyEndpoint()
+    {
+        TestHarness harness = CreateHarness();
+        string? capturedRootId = null;
+        SetupReplyCapture(harness, (_, rootId) => capturedRootId = rootId);
+        MessageActivity inbound = BuildInbound(targetedInbound: false, inboundId: "reply-id", convType: ConversationTypes.GroupChat);
+        inbound.ChannelData = JsonSerializer.Deserialize<TeamsChannelData>("{\"thread\":{\"id\":\"1772129782775\"}}");
+        Context<MessageActivity> ctx = new(harness.App, inbound);
+
+        await ctx.SendAsync("hello");
+
+        Assert.Equal("1772129782775", capturedRootId);
+    }
+
+    [Fact]
+    public async Task SendActivityAsync_WithLegacyThreadedConversationId_UsesBaseIdAndReplyEndpoint()
+    {
+        TestHarness harness = CreateHarness();
+        string? capturedConversationId = null;
+        string? capturedRootId = null;
+        SetupReplyCapture(harness, (conversationId, rootId) =>
+        {
+            capturedConversationId = conversationId;
+            capturedRootId = rootId;
+        });
+        MessageActivity inbound = BuildInbound(targetedInbound: false, inboundId: "reply-id", convType: ConversationTypes.GroupChat);
+        inbound.Conversation!.Id = "conv-1;messageid=1772129782775";
+        Context<MessageActivity> ctx = new(harness.App, inbound);
+
+        await ctx.SendAsync("hello");
+
+        Assert.Equal("conv-1", capturedConversationId);
+        Assert.Equal("1772129782775", capturedRootId);
+    }
+
     // ==================== Helpers ====================
 
     private sealed class CaptureSlot
@@ -181,6 +238,23 @@ public class PromptPreviewTests
                 (_, activity, _, _, _, _, _) => slot.Value = activity)
             .ReturnsAsync(new SendActivityResponse { Id = "sent-id" });
         return slot;
+    }
+
+    private static void SetupReplyCapture(TestHarness harness, Action<string, string> capture)
+    {
+        harness.MockConversationClient
+            .Setup(c => c.ReplyToActivityAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CoreActivityInput>(),
+                It.IsAny<Uri>(),
+                It.IsAny<bool>(),
+                It.IsAny<BotRequestContext?>(),
+                It.IsAny<Dictionary<string, string>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, CoreActivityInput, Uri, bool, BotRequestContext?, Dictionary<string, string>?, CancellationToken>(
+                (conversationId, rootId, _, _, _, _, _, _) => capture(conversationId, rootId))
+            .ReturnsAsync(new SendActivityResponse { Id = "sent-id" });
     }
 
     private sealed class TestHarness

--- a/test/Microsoft.Teams.Apps.UnitTests/TeamsActivityExtensionsTests.cs
+++ b/test/Microsoft.Teams.Apps.UnitTests/TeamsActivityExtensionsTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Microsoft.Teams.Apps.Schema;
+
+namespace Microsoft.Teams.Apps.UnitTests;
+
+public class TeamsActivityExtensionsTests
+{
+    [Fact]
+    public void GetProactiveThreadReference_PrefersTypedThreadId()
+    {
+        MessageActivity activity = BuildActivity(
+            "base-conversation;messageid=legacy-root",
+            "inbound-id",
+            ConversationTypes.GroupChat,
+            "typed-root");
+
+        (string conversationId, string threadRootId) = activity.GetProactiveThreadReference();
+
+        Assert.Equal("base-conversation", conversationId);
+        Assert.Equal("typed-root", threadRootId);
+    }
+
+    [Fact]
+    public void GetProactiveThreadReference_UsesLegacyThreadId()
+    {
+        MessageActivity activity = BuildActivity(
+            "base-conversation;messageid=legacy-root",
+            "inbound-id",
+            ConversationTypes.GroupChat);
+
+        (string conversationId, string threadRootId) = activity.GetProactiveThreadReference();
+
+        Assert.Equal("base-conversation", conversationId);
+        Assert.Equal("legacy-root", threadRootId);
+    }
+
+    [Fact]
+    public void GetProactiveThreadReference_FallsBackToInboundActivityId()
+    {
+        MessageActivity activity = BuildActivity(
+            "base-conversation",
+            "inbound-id",
+            ConversationTypes.GroupChat);
+
+        (string conversationId, string threadRootId) = activity.GetProactiveThreadReference();
+
+        Assert.Equal("base-conversation", conversationId);
+        Assert.Equal("inbound-id", threadRootId);
+    }
+
+    [Fact]
+    public void GetProactiveThreadReference_ThrowsWhenFallbackActivityIdIsMissing()
+    {
+        MessageActivity activity = BuildActivity(
+            "base-conversation",
+            null,
+            ConversationTypes.GroupChat);
+
+        Assert.Throws<ArgumentNullException>(() => activity.GetProactiveThreadReference());
+    }
+
+    [Fact]
+    public void GetDefaultThreadId_PrefersTypedThreadId()
+    {
+        MessageActivity activity = BuildActivity(
+            "base-conversation;messageid=legacy-root",
+            "inbound-id",
+            ConversationTypes.Channel,
+            "typed-root");
+
+        Assert.Equal("typed-root", activity.GetDefaultThreadId());
+    }
+
+    [Fact]
+    public void GetDefaultThreadId_UsesLegacyThreadId()
+    {
+        MessageActivity activity = BuildActivity(
+            "base-conversation;messageid=legacy-root",
+            "inbound-id",
+            ConversationTypes.GroupChat);
+
+        Assert.Equal("legacy-root", activity.GetDefaultThreadId());
+    }
+
+    [Fact]
+    public void GetDefaultThreadId_UsesInboundActivityIdForChannelRoot()
+    {
+        MessageActivity activity = BuildActivity(
+            "base-conversation",
+            "inbound-id",
+            ConversationTypes.Channel);
+
+        Assert.Equal("inbound-id", activity.GetDefaultThreadId());
+    }
+
+    [Theory]
+    [InlineData("groupChat")]
+    [InlineData("personal")]
+    public void GetDefaultThreadId_ReturnsNullForUnthreadedChatRoot(string conversationType)
+    {
+        MessageActivity activity = BuildActivity(
+            "base-conversation",
+            "inbound-id",
+            new ConversationType(conversationType));
+
+        Assert.Null(activity.GetDefaultThreadId());
+    }
+
+    [Obsolete]
+    private static MessageActivity BuildActivity(
+        string conversationId,
+        string? activityId,
+        ConversationType conversationType,
+        string? threadId = null)
+    {
+        MessageActivity activity = new("test")
+        {
+            Id = activityId,
+            Conversation = new TeamsConversation
+            {
+                Id = conversationId,
+                ConversationType = conversationType,
+            },
+        };
+
+        if (threadId is not null)
+        {
+            activity.ChannelData = JsonSerializer.Deserialize<TeamsChannelData>(
+                $"{{\"thread\":{{\"id\":\"{threadId}\"}}}}");
+        }
+
+        return activity;
+    }
+}

--- a/test/Microsoft.Teams.Apps.UnitTests/TeamsBotApplicationTests.cs
+++ b/test/Microsoft.Teams.Apps.UnitTests/TeamsBotApplicationTests.cs
@@ -76,6 +76,49 @@ public class TeamsBotApplicationTests
     }
 
     [Fact]
+    public async Task Send_Proactive_WithLegacyThreadedId_UsesReplyEndpoint()
+    {
+        (TeamsBotApplication app, Mock<ConversationClient> conversationClient) = CreateAppWithConversationClient();
+        string? capturedConversationId = null;
+        string? capturedRootId = null;
+        conversationClient
+            .Setup(c => c.ReplyToActivityAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CoreActivityInput>(),
+                It.IsAny<Uri>(),
+                It.IsAny<bool>(),
+                It.IsAny<BotRequestContext?>(),
+                It.IsAny<Dictionary<string, string>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, CoreActivityInput, Uri, bool, BotRequestContext?, Dictionary<string, string>?, CancellationToken>(
+                (conversationId, rootId, _, _, _, _, _, _) =>
+                {
+                    capturedConversationId = conversationId;
+                    capturedRootId = rootId;
+                })
+            .ReturnsAsync(new SendActivityResponse { Id = "reply-id" });
+
+        await app.SendAsync(
+            "19:abc@thread.skype;messageid=1680000000000",
+            new MessageActivityInput().WithText("hello"),
+            new Uri("https://test.service.url/"));
+
+        Assert.Equal("19:abc@thread.skype", capturedConversationId);
+        Assert.Equal("1680000000000", capturedRootId);
+        conversationClient.Verify(
+            c => c.SendActivityAsync(
+                It.IsAny<string>(),
+                It.IsAny<CoreActivityInput>(),
+                It.IsAny<Uri>(),
+                It.IsAny<bool>(),
+                It.IsAny<BotRequestContext?>(),
+                It.IsAny<Dictionary<string, string>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public void HasMatchingRoute_ReturnsTrueForRegisteredInvokeHandler()
     {
         TeamsBotApplication app = CreateApp();

--- a/test/Microsoft.Teams.Apps.UnitTests/TeamsBotApplicationTests.cs
+++ b/test/Microsoft.Teams.Apps.UnitTests/TeamsBotApplicationTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Teams.Apps.Clients;
+using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Core;
 using Microsoft.Teams.Core.Http;
 using Microsoft.Teams.Core.Schema;
@@ -73,6 +74,36 @@ public class TeamsBotApplicationTests
 
         Assert.Equal("19:abc@thread.skype", capturedConversationId);
         Assert.Equal("1680000000000", capturedRootId);
+    }
+
+    [Fact]
+    public async Task Reply_Proactive_WithTargetedRecipient_UsesTargetedReplyEndpoint()
+    {
+        (TeamsBotApplication app, Mock<ConversationClient> conversationClient) = CreateAppWithConversationClient();
+        bool? capturedIsTargeted = null;
+        conversationClient
+            .Setup(c => c.ReplyToActivityAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CoreActivityInput>(),
+                It.IsAny<Uri>(),
+                It.IsAny<bool>(),
+                It.IsAny<BotRequestContext?>(),
+                It.IsAny<Dictionary<string, string>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, CoreActivityInput, Uri, bool, BotRequestContext?, Dictionary<string, string>?, CancellationToken>(
+                (_, _, _, _, isTargeted, _, _, _) => capturedIsTargeted = isTargeted)
+            .ReturnsAsync(new SendActivityResponse { Id = "reply-id" });
+
+        await app.ReplyAsync(
+            "19:abc@thread.skype",
+            "1680000000000",
+            new MessageActivityInput()
+                .WithText("hello")
+                .WithRecipient(new TeamsChannelAccount { Id = "user-1" }, isTargeted: true),
+            new Uri("https://test.service.url/"));
+
+        Assert.True(capturedIsTargeted);
     }
 
     [Fact]

--- a/test/Microsoft.Teams.Apps.UnitTests/TeamsBotApplicationTests.cs
+++ b/test/Microsoft.Teams.Apps.UnitTests/TeamsBotApplicationTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Teams.Apps.Clients;
 using Microsoft.Teams.Core;
+using Microsoft.Teams.Core.Http;
 using Microsoft.Teams.Core.Schema;
 using Moq;
 
@@ -41,6 +42,40 @@ public class TeamsBotApplicationTests
     }
 
     [Fact]
+    public async Task Reply_Proactive_UsesReplyEndpointWithoutThreadedConversationId()
+    {
+        (TeamsBotApplication app, Mock<ConversationClient> conversationClient) = CreateAppWithConversationClient();
+        string? capturedConversationId = null;
+        string? capturedRootId = null;
+        conversationClient
+            .Setup(c => c.ReplyToActivityAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CoreActivityInput>(),
+                It.IsAny<Uri>(),
+                It.IsAny<bool>(),
+                It.IsAny<BotRequestContext?>(),
+                It.IsAny<Dictionary<string, string>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, CoreActivityInput, Uri, bool, BotRequestContext?, Dictionary<string, string>?, CancellationToken>(
+                (conversationId, rootId, _, _, _, _, _, _) =>
+                {
+                    capturedConversationId = conversationId;
+                    capturedRootId = rootId;
+                })
+            .ReturnsAsync(new SendActivityResponse { Id = "reply-id" });
+
+        await app.ReplyAsync(
+            "19:abc@thread.skype;messageid=old",
+            "1680000000000",
+            "hello",
+            new Uri("https://test.service.url/"));
+
+        Assert.Equal("19:abc@thread.skype", capturedConversationId);
+        Assert.Equal("1680000000000", capturedRootId);
+    }
+
+    [Fact]
     public void HasMatchingRoute_ReturnsTrueForRegisteredInvokeHandler()
     {
         TeamsBotApplication app = CreateApp();
@@ -51,6 +86,9 @@ public class TeamsBotApplicationTests
     }
 
     private static TeamsBotApplication CreateApp()
+        => CreateAppWithConversationClient().App;
+
+    private static (TeamsBotApplication App, Mock<ConversationClient> ConversationClient) CreateAppWithConversationClient()
     {
         Mock<UserTokenClient> mockUserTokenClient = new(
             new HttpClient(),
@@ -66,10 +104,12 @@ public class TeamsBotApplicationTests
             mockConversationClient.Object,
             mockUserTokenClient.Object);
 
-        return new TeamsBotApplication(
+        TeamsBotApplication app = new(
             apiClient,
             new HttpContextAccessor(),
             NullLogger<TeamsBotApplication>.Instance,
             new TeamsBotApplicationOptions { AppId = "test-app-id" });
+
+        return (app, mockConversationClient);
     }
 }

--- a/test/Microsoft.Teams.Apps.UnitTests/TeamsChannelDataDeserializationTests.cs
+++ b/test/Microsoft.Teams.Apps.UnitTests/TeamsChannelDataDeserializationTests.cs
@@ -14,6 +14,15 @@ namespace Microsoft.Teams.Apps.UnitTests;
 /// </summary>
 public class TeamsChannelDataDeserializationTests
 {
+    [Fact]
+    public void Deserialize_ThreadRoot()
+    {
+        TeamsChannelData? channelData = JsonSerializer.Deserialize<TeamsChannelData>(
+            "{\"thread\":{\"id\":\"1772129782775\"}}");
+
+        Assert.Equal("1772129782775", channelData?.Thread?.Id);
+    }
+
     [Theory]
     [InlineData("{\"app\":{}}")]
     [InlineData("{\"channel\":{}}")]

--- a/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
+++ b/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
@@ -166,6 +166,38 @@ public class ConversationClientTests
     }
 
     [Fact]
+    public async Task ReplyToActivityAsync_WithIsTargeted_AppendsQueryString()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        Mock<HttpMessageHandler> mockHttpMessageHandler = new();
+        mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{\"id\":\"reply123\"}")
+            });
+
+        ConversationClient conversationClient = new(new HttpClient(mockHttpMessageHandler.Object));
+
+        await conversationClient.ReplyToActivityAsync(
+            "conv123",
+            "root456",
+            CoreActivityInput.CreateBuilder().WithType(ActivityType.Message).Build(),
+            new Uri("https://test.service.url/"),
+            isTargeted: true);
+
+        Assert.Equal(
+            "https://test.service.url/v3/conversations/conv123/activities/root456?isTargetedActivity=true",
+            capturedRequest?.RequestUri?.ToString());
+    }
+
+    [Fact]
     public async Task ReplyToActivityAsync_RejectsEmptyRootId()
     {
         ConversationClient conversationClient = new(new HttpClient());

--- a/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
+++ b/test/Microsoft.Teams.Core.UnitTests/ConversationClientTests.cs
@@ -132,6 +132,53 @@ public class ConversationClientTests
     }
 
     [Fact]
+    public async Task ReplyToActivityAsync_ConstructsReplyEndpoint()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        Mock<HttpMessageHandler> mockHttpMessageHandler = new();
+        mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{\"id\":\"reply123\"}")
+            });
+
+        ConversationClient conversationClient = new(new HttpClient(mockHttpMessageHandler.Object));
+
+        SendActivityResponse? result = await conversationClient.ReplyToActivityAsync(
+            "conv/123",
+            "root/456",
+            CoreActivityInput.CreateBuilder().WithType(ActivityType.Message).Build(),
+            new Uri("https://test.service.url/"));
+
+        Assert.Equal("reply123", result?.Id);
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(
+            "https://test.service.url/v3/conversations/conv%2F123/activities/root%2F456",
+            capturedRequest.RequestUri?.ToString());
+        Assert.Equal(HttpMethod.Post, capturedRequest.Method);
+    }
+
+    [Fact]
+    public async Task ReplyToActivityAsync_RejectsEmptyRootId()
+    {
+        ConversationClient conversationClient = new(new HttpClient());
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            conversationClient.ReplyToActivityAsync(
+                "conv123",
+                "",
+                CoreActivityInput.CreateBuilder().WithType(ActivityType.Message).Build(),
+                new Uri("https://test.service.url/")));
+    }
+
+    [Fact]
     public async Task SendActivityAsync_WithIsTargeted_AppendsQueryString()
     {
         HttpRequestMessage? capturedRequest = null;


### PR DESCRIPTION
## Summary

- add endpoint-based activity replies at `POST /v3/conversations/{conversationId}/activities/{rootId}`
- route proactive and context-derived channel/group thread replies without constructing `;messageid=` conversation IDs
- translate legacy suffixed IDs passed to `app.SendAsync()` into reply-endpoint calls
- expose inbound `channelData.thread.id` and retain legacy suffix parsing as a compatibility fallback
- separate quoting from placement by standardizing on `MessageActivityInput.AddQuote()` and deprecating legacy context quote/reply conveniences without removing them
- add explicit `ReplyToTargetedActivityAsync()` / `ReplyTargetedAsync()` APIs alongside regular reply APIs
- route targeted threaded replies through `POST /activities/{rootId}?isTargetedActivity=true`
- expand the messaging sample to cover default placement, explicit threading, quoting, targeted replies, and targeted quoted replies

## Validation

- `Microsoft.Teams.Core.UnitTests`: endpoint and targeted-query coverage passed on net8.0 and net10.0
- `Microsoft.Teams.Apps.UnitTests`: focused conversation API, application reply, and reactive routing coverage passed on net8.0 and net10.0
- `InteractingWithMessagesBot`: validated end to end in Teams across default and explicit threading, quoting, targeted replies, and targeted quoted replies