### PR TITLE
fix(api): support installation upgrade activity

### DIFF
--- a/src/Microsoft.Teams.Apps/Handlers/InstallUpdateHandlers.Activity.cs
+++ b/src/Microsoft.Teams.Apps/Handlers/InstallUpdateHandlers.Activity.cs
@@ -59,6 +59,8 @@ public class InstallUpdateAction(string value) : StringEnum(value)
     public static readonly InstallUpdateAction Add = new("add");
     /// <summary>Remove action.</summary>
     public static readonly InstallUpdateAction Remove = new("remove");
+    /// <summary>Upgrade action.</summary>
+    public static readonly InstallUpdateAction Upgrade = new("upgrade");
 }
 
 /// <summary>
@@ -75,4 +77,9 @@ public static class InstallUpdateActions
     /// Remove action constant.
     /// </summary>
     public static InstallUpdateAction Remove => InstallUpdateAction.Remove;
+
+    /// <summary>
+    /// Upgrade action constant.
+    /// </summary>
+    public static InstallUpdateAction Upgrade => InstallUpdateAction.Upgrade;
 }

--- a/test/Microsoft.Teams.Apps.UnitTests/ActivitiesTests.cs
+++ b/test/Microsoft.Teams.Apps.UnitTests/ActivitiesTests.cs
@@ -76,18 +76,59 @@ public class ActivitiesTests
         //Assert.Equal("Converted Topic", activity.TopicName);
     }
 
-    [Fact]
-    public void InstallUpdate_FromActivityConvertsCorrectly()
+    [Theory]
+    [InlineData("add")]
+    [InlineData("remove")]
+    public void InstallUpdate_FromActivityConvertsKnownActionsCorrectly(string action)
     {
         CoreActivity coreActivity = new()
         {
             Type = TeamsActivityTypes.InstallationUpdate
         };
-        coreActivity.Properties["action"] = "remove";
+        coreActivity.Properties["action"] = action;
 
         InstallUpdateActivity activity = InstallUpdateActivity.FromActivity(coreActivity);
         Assert.NotNull(activity);
         Assert.Equal(TeamsActivityTypes.InstallationUpdate, activity.Type);
-        Assert.Equal(InstallUpdateActions.Remove, activity.Action);
+        Assert.Equal(action, activity.Action?.Value);
+    }
+
+    [Fact]
+    public void InstallUpdate_FromJsonConvertsUpgradeActionCorrectly()
+    {
+        const string json = """
+            {
+              "action": "upgrade",
+              "channelId": "msteams",
+              "conversation": {
+                "conversationType": "personal",
+                "id": "xxx",
+                "tenantId": "xxx"
+              },
+              "entities": [
+                {
+                  "locale": "en-US",
+                  "type": "clientInfo"
+                }
+              ],
+              "from": {
+                "aadObjectId": "xxx",
+                "id": "xxx"
+              },
+              "id": "xxx",
+              "recipient": {
+                "id": "xxx",
+                "name": "xxx"
+              },
+              "serviceUrl": "https://smba.trafficmanager.net/emea/xxx/",
+              "timestamp": "2026-08-26T13:38:36.356Z",
+              "type": "installationUpdate"
+            }
+            """;
+
+        TeamsActivity activity = TeamsActivity.FromActivity(CoreActivity.FromJsonString(json));
+
+        InstallUpdateActivity installUpdateActivity = Assert.IsType<InstallUpdateActivity>(activity);
+        Assert.Equal(InstallUpdateActions.Upgrade, installUpdateActivity.Action);
     }
 }


### PR DESCRIPTION
## Summary

- add InstallUpdateAction for `upgrade`


Parity fix based on microsoft/teams.py#583.